### PR TITLE
Dir and theme helper

### DIFF
--- a/example-app/src/index.js
+++ b/example-app/src/index.js
@@ -5,6 +5,14 @@ import './index.css';
 
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
+import setDirAndThemeAttributes from 'ui/utils/setDirAndThemeAttributes';
+
+const dummyUserSettings = {
+    keyUiLocale: 'en_US',
+    keyCurrentStyle: 'light_blue/light_blue.css',
+};
+
+setDirAndThemeAttributes(dummyUserSettings);
 
 ReactDOM.render(<App />, document.getElementById('root'));
 registerServiceWorker();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export { default as isRtl } from './isRtl';
 export { default as bemClassNames } from './bemClassNames';
 export { default as wrapTextNodesInSpans } from './wrapTextNodesInSpans';
+export { default as setDirAndThemeAttributes } from './setDirAndThemeAttributes';

--- a/src/utils/setDirAndThemeAttributes.js
+++ b/src/utils/setDirAndThemeAttributes.js
@@ -1,0 +1,45 @@
+/**
+ * This function will set the dir attribute on the HTML tag and add a theme class to the body tag if required.
+ * Since it takes userSettings as an option and returns them too, it fits nicely into a chained promise sequence used to bootstrap a DHIS2 React app:
+ * @example
+ * ...
+ * .then(getUserSettings)
+ * .then(setDirAndThemeAttributes)
+ * .then(configI18n)
+ * ...
+ * @example
+ * @param {Object} userSettings - The userSettings available in on the d2 object (d2.currentUser.userSettings.settings) or returned from the from the `getUserSettings` function exposed by d2
+ */
+export default function(userSettings) {
+    // Will produce "en" from "en_EN" as well as "en"
+    const uiLanguage = userSettings.keyUiLocale.split('_')[0];
+    const dir = RTL_LANGUAGES.has(uiLanguage) ? 'rtl' : 'ltr';
+    // Currently formatted like this: "light_blue/light_blue.css
+    // Since we only want to put a class on the body, we need the first part
+    const theme = userSettings.keyCurrentStyle.split('/')[0];
+
+    document.documentElement.setAttribute('dir', dir);
+
+    // Don't set a class for the default theme
+    if (theme !== 'light_blue') {
+        document.body.classList.add(theme);
+    }
+
+    return userSettings;
+}
+
+// https://meta.wikimedia.org/wiki/Template:List_of_language_names_ordered_by_code
+const RTL_LANGUAGES = new Set([
+    'ar',
+    'arc',
+    'dv',
+    'fa',
+    'ha',
+    'he',
+    'khw',
+    'ks',
+    'ku',
+    'ps',
+    'ur',
+    'yi',
+]);


### PR DESCRIPTION
This is more of a proof of concept than anything else, based on our discussion we had yesterday regarding the `isRtl()` utility function which is currently broken. What I propose is the following:
- This function would run BEFORE the app is rendered into the DOM to ensure that the HTML attribute and body class are have been set. (see `example-app/src/index.js`)
- It would fit nicely into a "bootstrap-sequence" as we have in most DHIS2 apps. (See example in the JSDoc comment in `src/utils/setDirAndThemeAttributes.js`)
- This fixes the `isRtl` function. And this removes the need for any context / lifecycle methods / element ref in our React components.

What I don't like:
1. The fact that we are using a lookup for RTL languages. However, I discussed this with Adeel and he had some compelling reasons for doing it this way nonetheless. (I was thinking about letting the server set the dir but not all apps want this (yet) )
2. What I am doing to add a class to the body is ugly and quite likely not what we want. We talked about having 1 single CSS with all the themes in, but in the settings we are pointed towards a CSS file (unfortunately not an exact path). This part should probably change.

Perhaps what we could do for the Beta of d2ui-core, is to split up the theme part and the text direction part into two separate helpers. And then only introduce the direction helper, because I don't think we will be using themes any time soon, and the way this is implemented exactly is still up for discussion....