### PR TITLE
Tabs compute scrollbar height

### DIFF
--- a/src/Tabs/TabIndicator.js
+++ b/src/Tabs/TabIndicator.js
@@ -30,7 +30,7 @@ class TabIndicator extends Component {
 
         const translateX = `translateX(${activeTabNode.offsetLeft}px)`;
         const scaleX = `scaleX(${activeTabNode.offsetWidth})`;
-        return { transform: `${translateX} ${scaleX}` };
+        return { transform: `${translateX} translateY(2px) ${scaleX}` };
     }
 
     render() {

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -5,8 +5,9 @@ import Tab from './Tab';
 import Icon from '../Icon';
 import TabIndicator from './TabIndicator';
 import { animatedScrollTo, bemClassNames, throttle } from '../utils';
+import computeHorizontalScrollbarHeight from './computeHorizontalScrollbarHeight';
 
-const bem = bemClassNames('d2ui-tabs');
+export const bem = bemClassNames('d2ui-tabs');
 
 class Tabs extends Component {
     constructor(props) {
@@ -22,6 +23,7 @@ class Tabs extends Component {
             scrolledToEnd: true,
             showTabIndicator: false,
         };
+        this.horizontalScrollbarHeight = computeHorizontalScrollbarHeight();
         this.handleSideScroll = throttle(this.toggleScrollButtonVisibility.bind(this));
     }
 
@@ -211,6 +213,9 @@ class Tabs extends Component {
     render() {
         const { scrolledToStart, scrolledToEnd } = this.state;
         const { position, contained } = this.props;
+        const scrollBoxStyle = {
+            marginBottom: -this.horizontalScrollbarHeight,
+        };
         let tabBar = this.renderTabBar();
 
         if (!contained) {
@@ -223,7 +228,11 @@ class Tabs extends Component {
                         <Icon name="keyboard_arrow_left" />
                     </button>
                     <div className={bem.e('scroll-box-clipper')}>
-                        <div className={bem.e('scroll-box')} ref={this.setScrollBoxRef}>
+                        <div
+                            className={bem.e('scroll-box')}
+                            ref={this.setScrollBoxRef}
+                            style={scrollBoxStyle}
+                        >
                             <div
                                 className={bem.e('scroll-area')}
                                 ref={this.setScrollAreaRef}

--- a/src/Tabs/computeHorizontalScrollbarHeight.js
+++ b/src/Tabs/computeHorizontalScrollbarHeight.js
@@ -1,0 +1,18 @@
+import { bem } from './Tabs';
+
+let horizontalScrollbarHeight;
+
+export default function() {
+    if (horizontalScrollbarHeight) {
+        return horizontalScrollbarHeight;
+    }
+
+    const el = document.createElement('div');
+    el.classList.add(bem.e('test-horizontal-scrollbar-height'));
+    document.body.appendChild(el);
+    // cache the result
+    horizontalScrollbarHeight = el.offsetHeight - el.clientHeight;
+    document.body.removeChild(el);
+
+    return horizontalScrollbarHeight;
+}

--- a/src/Tabs/tabindicator.css
+++ b/src/Tabs/tabindicator.css
@@ -3,7 +3,7 @@
     position: absolute;
     bottom: 0;
     left: 0;
-    height: 2px;
+    height: 4px;
     /* 
     * By choosing 1px here, we can use scaleX to animate the width  
     * of the tabIndicator. I.e. 40px width = scaleX(40)
@@ -11,7 +11,7 @@
     width: 1px;
     background-color: #1976d2;
     transform-origin: left bottom;
-    transform: translateX(0) scaleX(100);
+    transform: translateX(0) translateY(2px) scaleX(100);
     transition: none;
     visibility: hidden;
 

--- a/src/Tabs/tabs.css
+++ b/src/Tabs/tabs.css
@@ -59,14 +59,27 @@
         overflow-y: hidden;
     }
 
+    &__test-horizontal-scrollbar-height {
+        position: absolute;
+        top: -9999px;
+        width: 100px;
+        height: 100px;
+        overflow-x: scroll;
+    }
+
     &__scroll-box {
         flex-grow: 1;
         overflow-x: scroll;
         -webkit-overflow-scrolling: touch;
         display: -ms-flexbox;
         display: flex;
-        /* Hide the scrollbar by moving it below the clipper */
-        margin-bottom: -15px;
+    }
+
+    &__test-horizontal-scrollbar-height,
+    &__scroll-box {
+        &::-webkit-scrollbar {
+            display: none;
+        }
     }
 
     &__scroll-area {

--- a/src/Tabs/tabs.css
+++ b/src/Tabs/tabs.css
@@ -92,6 +92,7 @@
 
     &__tab-container {
         position: relative;
+        overflow-y: hidden;
 
         &--contained {
             display: flex;
@@ -113,6 +114,15 @@
 
         &--cluster-right {
             justify-content: flex-end;
+        }
+    }
+}
+/* FIREFOX HACK */
+@-moz-document url-prefix() {
+    .d2ui-tabs {
+        &__scroll-area &__tab-container {
+            /* Forces all the tabs to be on one line */
+            width: -moz-max-content;
         }
     }
 }


### PR DESCRIPTION
This includes a couple of fixes:
- **All browsers**: Compute horizontal scrollbar height instead of assuming this is 15px in all browser/OS combos, which is not true.
- **Edge**: tab-indicator lifts up 2px whilst moving, showing whitespace below. Now moved the indicator 2 px down and increased height by 2px. This looks a lot better in Edge, and the same in all other browsers
- **FF52**: tabs would take up several lines instead of being forced into one. Found out that the `width: -moz-max-content;` fixes this.