### PR TITLE
refactor(DropdownButton)

### DIFF
--- a/example-app/src/App.js
+++ b/example-app/src/App.js
@@ -59,6 +59,7 @@ class App extends Component {
                         helpText="Toggle text direction"
                     />
                 </Paper>
+                <ButtonDemo />
                 <TabsDemo />
                 <DialogDemo />
                 <TypographyDemo />
@@ -66,7 +67,6 @@ class App extends Component {
                 <InputDemo />
                 <MenuDemo />
                 <LogoDemo />
-                <ButtonDemo />
             </UI>
         )
     }

--- a/example-app/src/ButtonDemo.js
+++ b/example-app/src/ButtonDemo.js
@@ -14,17 +14,12 @@ import {
 } from 'ui/core/Button'
 
 import Icon from 'ui/core/Icon'
-import { MenuItem } from 'ui/core/Menu'
 
-const menuItemSelectTest = (event, value, option) => {
+function onMenuItemSelect(event, value, option) {
     console.log('Menu item click', event.target, value, option)
 }
 
-const menuProps = {
-    selectHandler: menuItemSelectTest,
-}
-
-const dropdownOptions = [
+const items = [
     {
         value: 1,
         label: 'One ',
@@ -50,42 +45,6 @@ const dropdownOptions = [
     { value: 5, label: 'Five', icon: 'alarm' },
 ]
 
-const subSubMenuItems = [
-    <MenuItem key="jajaja" value={1}>
-        Sub item 1
-    </MenuItem>,
-    <MenuItem key="neee" value={2}>
-        Sub item 2
-    </MenuItem>,
-    <MenuItem key="misschien" value={3}>
-        Sub item 3
-    </MenuItem>,
-]
-
-const subMenuItems = [
-    <MenuItem key="jajaja" value={1}>
-        Sub item 1
-    </MenuItem>,
-    <MenuItem key="neee" value={2} menuItems={subSubMenuItems}>
-        Sub item 2
-    </MenuItem>,
-    <MenuItem key="misschien" value={3}>
-        Sub item 3
-    </MenuItem>,
-]
-
-const menuItems = [
-    <MenuItem key="jajaja" value={1} menuItems={subMenuItems}>
-        Main item 1
-    </MenuItem>,
-    <MenuItem key="neee" value={2}>
-        Main item 2
-    </MenuItem>,
-    <MenuItem key="misschien" value={3}>
-        Main item 3
-    </MenuItem>,
-]
-
 function onButtonClick(msg) {
     console.log(msg, 'button clicked')
 }
@@ -94,7 +53,7 @@ const HSpace = () => <span style={{ width: 20, display: 'inline-block' }} />
 
 function Buttons() {
     return (
-        <div style={{ marginBottom: 20 }}>
+        <div style={{ margin: '0 20px 0 0' }}>
             <PrimaryButton onClick={() => onButtonClick('primary')}>
                 Primary
             </PrimaryButton>
@@ -160,30 +119,23 @@ function onDropdownClick(msg) {
 
 function Dropdowns() {
     return (
-        <div style={{ marginBottom: 20 }}>
+        <div style={{ margin: '20px 20px 20px 0', paddingBottom: 20 }}>
             <DropdownButton
-                buttonProps={{
-                    kind: 'primary',
-                    onClick: () => onDropdownClick('first'),
-                }}
-                menuProps={menuProps}
-                options={dropdownOptions}
-            >
-                <Icon name="add" />
-                Dropdown button
-            </DropdownButton>
+                list={items}
+                icon={<Icon name="add" />}
+                label="Dropdown Button"
+                onSelect={onMenuItemSelect}
+                onClick={() => onDropdownClick('primary dropdown')}
+            />
             <HSpace />
             <DropdownButton
-                buttonProps={{
-                    kind: 'raised',
-                    onClick: () => onDropdownClick('second'),
-                }}
-                menuProps={{ children: menuItems }}
-                options={dropdownOptions}
-            >
-                <Icon name="add" />
-                Second Dropdown
-            </DropdownButton>
+                kind="raised"
+                list={items}
+                icon={<Icon name="add" />}
+                label="Second Dropdown"
+                onSelect={onMenuItemSelect}
+                onClick={() => onDropdownClick('raised dropdown')}
+            />
         </div>
     )
 }
@@ -191,10 +143,12 @@ function Dropdowns() {
 export default function ProgressDemo() {
     return (
         <Paper>
-            <h6>Button components</h6>
-            <br />
-            <Buttons />
-            <Dropdowns />
+            <div style={{ margin: 20 }}>
+                <h6>Button components</h6>
+                <br />
+                <Buttons />
+                <Dropdowns />
+            </div>
         </Paper>
     )
 }

--- a/example-app/src/HeaderBarDemo.js
+++ b/example-app/src/HeaderBarDemo.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import HeaderBar from 'ui/widgets/HeaderBar/HeaderBar.Component'
-import HeaderBarContainer from 'ui/widgets/HeaderBar/HeaderBar.Container'
+// import HeaderBarContainer from 'ui/widgets/HeaderBar/HeaderBar.Container'
 
 const props = {
     title: 'Demo - Sierra Leone',

--- a/src/core/Button/DropdownButton.js
+++ b/src/core/Button/DropdownButton.js
@@ -11,33 +11,33 @@ class DropdownButton extends Component {
     getAnchorRef = () => this.anchorRef
 
     render() {
-        const { options, buttonProps, menuProps } = this.props
-
-        const mergedMenuProps = {
-            ...menuProps,
-            options,
-        }
-
         return (
             <div ref={c => (this.anchorRef = c)} className={s('dropdown')}>
-                <Button {...buttonProps}>{this.props.children}</Button>
+                <Button kind={this.props.kind} onClick={this.props.onClick}>
+                    {this.props.label}
+                </Button>
                 <DropdownMenu
-                    buttonKind={buttonProps.kind}
+                    kind={this.props.kind}
+                    list={this.props.list}
+                    onSelect={this.props.onSelect}
                     getAnchorRef={this.getAnchorRef}
-                    menuProps={mergedMenuProps}
                 />
             </div>
         )
     }
 }
 
+DropdownButton.defaultProps = {
+    kind: 'primary',
+}
+
 DropdownButton.propTypes = {
-    children: PropTypes.node.isRequired,
-    options: PropTypes.arrayOf(
-        PropTypes.oneOfType([PropTypes.object, PropTypes.element])
-    ).isRequired,
-    buttonProps: PropTypes.object.isRequired,
-    menuProps: PropTypes.object,
+    kind: PropTypes.string,
+    label: PropTypes.string.isRequired,
+    icon: PropTypes.element.isRequired,
+    list: PropTypes.array.isRequired,
+    onClick: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
 }
 
 export { DropdownButton }

--- a/src/core/Input/SelectField/index.js
+++ b/src/core/Input/SelectField/index.js
@@ -156,13 +156,10 @@ class SelectField extends Component {
                 </LabelField>
                 {!native && (
                     <PopoverMenu
-                        menuProps={{
-                            options: this.getOptions(),
-                            selectHandler: this.selectHandler,
-                        }}
-                        getAnchorRef={this.getInputRef}
+                        list={this.getOptions()}
+                        onSelect={this.selectHandler}
                         open={this.state.open}
-                        closePopover={this.onClose}
+                        onClose={this.onClose}
                         anchorPosition={{
                             vertical: 'top',
                             horizontal: 'center',
@@ -171,7 +168,7 @@ class SelectField extends Component {
                             vertical: 'top',
                             horizontal: 'center',
                         }}
-                        animation="slide-down"
+                        getAnchorRef={this.getInputRef}
                     />
                 )}
             </Fragment>

--- a/src/core/Menu/DropdownMenu.js
+++ b/src/core/Menu/DropdownMenu.js
@@ -21,23 +21,23 @@ class DropdownMenu extends React.Component {
         open: false,
     }
 
-    openMenu = () => this.setState({ open: true })
-    closeMenu = () => this.setState({ open: false })
+    onOpen = () => this.setState({ open: true })
+    onClose = () => this.setState({ open: false })
 
     render() {
         return (
             <React.Fragment>
-                <Button kind={this.props.buttonKind} onClick={this.openMenu}>
+                <Button kind={this.props.kind} onClick={this.onOpen}>
                     <Icon name="keyboard_arrow_down" />
                 </Button>
                 <PopoverMenu
-                    menuProps={this.props.menuProps}
-                    getAnchorRef={this.props.getAnchorRef}
-                    open={this.state.open}
-                    closePopover={this.closeMenu}
-                    animation="slide-down"
-                    anchorPosition={anchorPosition}
                     popoverPosition={popoverPosition}
+                    anchorPosition={anchorPosition}
+                    open={this.state.open}
+                    list={this.props.list}
+                    onClose={this.onClose}
+                    onSelect={this.props.onSelect}
+                    getAnchorRef={this.props.getAnchorRef}
                 />
             </React.Fragment>
         )
@@ -45,9 +45,10 @@ class DropdownMenu extends React.Component {
 }
 
 DropdownMenu.propTypes = {
-    buttonKind: PropTypes.oneOf(['primary', 'raised']).isRequired,
+    kind: PropTypes.oneOf(['primary', 'raised']).isRequired,
+    list: PropTypes.array.isRequired,
+    onSelect: PropTypes.func.isRequired,
     getAnchorRef: PropTypes.func.isRequired,
-    menuProps: PropTypes.object.isRequired,
 }
 
 export { DropdownMenu }

--- a/src/core/Menu/Menu.js
+++ b/src/core/Menu/Menu.js
@@ -7,7 +7,7 @@ import Paper from '../Paper'
 
 import s from './styles'
 
-function Menu({ options, selectHandler, closePopover, children }) {
+function Menu({ list, onSelect, onClose, children }) {
     if (children) {
         return (
             <Paper elevation={4}>
@@ -19,11 +19,12 @@ function Menu({ options, selectHandler, closePopover, children }) {
     return (
         <Paper elevation={4}>
             <ul className={s('container')}>
-                {options.map(({ onClick, ...rest }, idx) => (
+                {list.map(({ onClick, ...rest }, idx) => (
                     <MenuItem
                         key={`mi-${idx}`}
-                        onClick={onClick || selectHandler}
-                        closePopover={closePopover}
+                        onClick={onClick || onSelect}
+                        onSelect={onSelect}
+                        onClose={onClose}
                         {...rest}
                     />
                 ))}
@@ -32,10 +33,14 @@ function Menu({ options, selectHandler, closePopover, children }) {
     )
 }
 
+Menu.defaultProps = {
+    options: [],
+}
+
 Menu.propTypes = {
-    options: PropTypes.array,
-    selectHandler: PropTypes.func,
-    closePopover: PropTypes.func,
+    list: PropTypes.array,
+    onSelect: PropTypes.func,
+    onClose: PropTypes.func,
     children: PropTypes.arrayOf(PropTypes.element),
 }
 

--- a/src/core/Menu/MenuItem.js
+++ b/src/core/Menu/MenuItem.js
@@ -9,10 +9,9 @@ import s from './styles'
 
 class MenuItem extends Component {
     onClick = event => {
-        const { value, onClick, selectHandler, closePopover } = this.props
-        const handler = onClick || selectHandler
-        handler(event, value, this.props)
-        closePopover && closePopover()
+        const handler = this.props.onClick || this.props.onSelect
+        handler(event, this.props.value, this.props)
+        this.props.onClose && this.props.onClose()
     }
 
     render() {
@@ -51,7 +50,8 @@ MenuItem.propTypes = {
     // onClick is bound to a menuItem itself
     onClick: PropTypes.func,
     // selecthandler is passed down from parent, a generic handler for each item
-    selectHandler: PropTypes.func,
+    onSelect: PropTypes.func,
+    onClose: PropTypes.func,
     menuItems: PropTypes.arrayOf(
         PropTypes.oneOfType([PropTypes.element, PropTypes.object])
     ),

--- a/src/core/Menu/PopoverMenu.js
+++ b/src/core/Menu/PopoverMenu.js
@@ -6,36 +6,43 @@ import Menu from './Menu'
 import Popover from '../Popover'
 
 function PopoverMenu({
-    anchorPosition,
-    closePopover,
-    getAnchorRef,
-    menuProps,
     open,
-    popoverPosition,
+    list,
     animation,
+    popoverPosition,
+    anchorPosition,
+    onSelect,
+    onClose,
+    getAnchorRef,
 }) {
     return (
         <Popover
-            anchorPosition={anchorPosition}
-            closePopover={closePopover}
-            getAnchorRef={getAnchorRef}
             open={open}
-            popoverPosition={popoverPosition}
+            onClose={onClose}
             animation={animation}
+            getAnchorRef={getAnchorRef}
+            anchorPosition={anchorPosition}
+            popoverPosition={popoverPosition}
         >
-            <Menu closePopover={closePopover} {...menuProps} />
+            <Menu list={list} onSelect={onSelect} onClose={onClose} />
         </Popover>
     )
 }
 
+PopoverMenu.defaultProps = {
+    list: [],
+    animation: 'slide-down',
+}
+
 PopoverMenu.propTypes = {
-    anchorPosition: PropTypes.object,
-    closePopover: PropTypes.func.isRequired,
-    getAnchorRef: PropTypes.func.isRequired,
-    menuProps: PropTypes.object,
     open: PropTypes.bool.isRequired,
-    popoverPosition: PropTypes.object,
+    list: PropTypes.array.isRequired,
     animation: PropTypes.string,
+    anchorPosition: PropTypes.object,
+    popoverPosition: PropTypes.object,
+    onClose: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
+    getAnchorRef: PropTypes.func.isRequired,
 }
 
 PopoverMenu.defaultProps = {

--- a/src/core/Menu/SubMenu.js
+++ b/src/core/Menu/SubMenu.js
@@ -11,20 +11,12 @@ const anchorPosition = { vertical: 'top', horizontal: 'right' }
 const popoverPosition = { vertical: 'top', horizontal: 'left' }
 
 class SubMenu extends Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            popoverOpen: false,
-        }
+    state = {
+        open: false,
     }
 
-    openPopover = () => {
-        this.setState({ popoverOpen: true })
-    }
-
-    closePopover = () => {
-        this.setState({ popoverOpen: false })
-    }
+    onOpen = () => this.setState({ open: true })
+    onClose = () => this.setState({ open: false })
 
     getAnchorRef = () => this.anchorRef
     setAnchorRef = node => (this.anchorRef = node)
@@ -41,16 +33,18 @@ class SubMenu extends Component {
 
         return (
             <Fragment>
-                <MenuItem ref={this.setAnchorRef} onClick={this.openPopover}>
+                <MenuItem ref={this.setAnchorRef} onClick={this.onOpen}>
                     {children
                         ? children
                         : [icon && <Icon key="icon" name={icon} />, label]}
                     <Icon name={arrowIconName} />
                 </MenuItem>
                 <PopoverMenu
-                    closePopover={this.closePopover}
+                    list={menuItems}
+                    onSelect={() => null}
+                    onClose={this.onClose}
                     getAnchorRef={this.getAnchorRef}
-                    open={this.state.popoverOpen}
+                    open={this.state.open}
                     menuProps={menuProps}
                     anchorPosition={anchorPosition}
                     popoverPosition={popoverPosition}

--- a/src/core/Popover/index.js
+++ b/src/core/Popover/index.js
@@ -92,7 +92,7 @@ const attachPointPropType = PropTypes.shape({
 Popover.propTypes = {
     open: PropTypes.bool.isRequired,
     getAnchorRef: PropTypes.func.isRequired,
-    closePopover: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
     children: PropTypes.node,
     anchorPosition: attachPointPropType,
     popoverPosition: attachPointPropType,

--- a/src/widgets/HeaderBar/Apps.js
+++ b/src/widgets/HeaderBar/Apps.js
@@ -7,8 +7,6 @@ import Icon from '../../core/Icon'
 import TextField from '../../core/Input/TextField'
 import s from './styles'
 
-console.log("s('search')", s('search'))
-
 function Search({ value, onChange }) {
     return (
         <div className={s('search')}>


### PR DESCRIPTION
Refactored code to be more readable for DropdownMenu

- simplify property passing
- naming changes for events and component

#### Issues

*SubMenu.js*

Children is not used in PopoverMenu. MenuItems should just be a list of items passed in as `list={list}` prop.

Line 29-32
```js
const menuProps = isValidElement(menuItems[0])
    ? { children: menuItems }
    : { options: menuItems }
```