### PR TITLE
refactor(SelectField)

### DIFF
--- a/example-app/src/InputDemo.js
+++ b/example-app/src/InputDemo.js
@@ -15,6 +15,22 @@ const selectOptions = [
     { value: 3, label: 'Three' },
 ]
 
+const list = [
+    {
+        value: 1,
+        label: 'One ',
+        icon: 'alarm',
+    },
+    { value: 2, label: 'two', icon: 'alarm', disabled: true },
+    {
+        value: 3,
+        label: 'Three',
+        icon: 'face',
+    },
+    { value: 4, label: 'Four', icon: 'alarm' },
+    { value: 5, label: 'Five', icon: 'alarm' },
+]
+
 export default class InputDemo extends Component {
     constructor(props) {
         super(props)
@@ -45,9 +61,7 @@ export default class InputDemo extends Component {
         })
     }
 
-    updateSelect = selectValue => {
-        this.setState({ selectValue: parseInt(selectValue, 10) })
-    }
+    updateSelect = (evt, value, option) => this.setState({ selectValue: value })
 
     render() {
         return (
@@ -64,23 +78,19 @@ export default class InputDemo extends Component {
                     inline
                     required
                 />
-                <SelectField
-                    options={selectOptions}
-                    label="Choose something"
-                    onChange={this.updateSelect}
-                    value={this.state.selectValue}
-                    variant="outlined"
-                    native
-                    emptyOption="None"
-                    // leadingIcon="face"
-                    // helpText="Help with this text"
-                    // dense
-                    valid
-                    required
-                    // error
-                    // warning
-                />
-                <SelectField
+                <div style={{ width: 200 }}>
+                    <SelectField
+                        required
+                        list={list}
+                        label="Choose below"
+                        help="Help with this text"
+                        icon="face"
+                        status={!this.state.selectValue ? 'valid' : 'error'}
+                        value={this.state.selectValue}
+                        onChange={this.updateSelect}
+                    />
+                </div>
+                {/*<SelectField
                     options={selectOptions}
                     label="Choose something"
                     onChange={this.updateSelect}
@@ -93,7 +103,7 @@ export default class InputDemo extends Component {
                     valid
                     // error
                     // warning
-                />
+                />*/}
                 <br />
                 <TextField
                     label="testlabel"

--- a/src/core/Button/DropdownButton.js
+++ b/src/core/Button/DropdownButton.js
@@ -51,11 +51,7 @@ class DropdownButton extends Component {
                 </Button>
 
                 <Button kind={this.props.kind} onClick={this.onToggle}>
-                    <Icon
-                        name={
-                            open ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
-                        }
-                    />
+                    <Icon name={open ? 'arrow_drop_up' : 'arrow_drop_down'} />
                 </Button>
 
                 {open && (

--- a/src/core/Input/SelectField/styles.css
+++ b/src/core/Input/SelectField/styles.css
@@ -1,48 +1,29 @@
 /** @format */
 
 .container {
-    display: inline-flex;
-    vertical-align: top;
+    position: relative;
 }
 
-.input {
-    min-width: 14.375rem;
-    text-align: left;
+.icon {
+    margin-right: 5px;
 }
 
-/* TODO */
-/*.d2ui-text-field--with-leading-icon .input {
-    min-width: 16.375rem;
-}*/
-
-/* If a <label/> is wrapped around a <select/> it will normally cause an issue:
- * the <label/> and the <select/> will both get the :focus state and the <label/>
- * will close the dropdown options again immediately.
- * (Prehaps because the label is the parent element it will get higher priority?)
- * To combat this, we remove all pointer-events from the <label/> and then re-attach them to <select/>
- */
-/* TODO */
-/*.native label.d2ui-text-field {
-    pointer-events: none;
-}*/
-.native .material-icons {
-    pointer-events: none;
+.dropdown-icon {
+    margin-left: auto;
 }
 
-.native .input {
+.select {
     pointer-events: all;
-}
-.native .input::-ms-expand {
-    display: none;
+    user-select: none;
+    display: flex;
+    flex-direction: row;
+    cursor: pointer;
+    height: 44px;
 }
 
-/* BROWSER INCONSISTENCIES */
-/* FIREFOX */
-@-moz-document url-prefix() {
-    .input {
-        /* hide the arrow in FF */
-        -moz-appearance: none;
-        /* Hide the outline in FF */
-        color: transparent;
-    }
+.menu {
+    position: absolute;
+    z-index: 1000;
+    left: 0;
+    top: 44px;
 }

--- a/src/core/Input/shared/LabelField/styles.css
+++ b/src/core/Input/shared/LabelField/styles.css
@@ -70,7 +70,7 @@
     cursor: text;
     overflow: hidden;
     color: #494949;
-    will-change: transform color;
+    will-change: transform-color;
 }
 
 .bottom-line {
@@ -157,10 +157,9 @@ input:focus ~ .floating {
     transition: border-color 180ms cubic-bezier(0.4, 0, 0.2, 1);
     padding-top: 0.875rem;
     padding-bottom: 0.75rem;
-
-    &:hover {
-        border-color: #494949;
-    }
+}
+.outlined .input:hover {
+    border-color: #494949;
 }
 
 .input:focus ~ .notched-outline {
@@ -200,7 +199,7 @@ input:focus ~ .floating {
     padding-right: 3rem;
 }
 
-.outlined.with-leading-icon.with-value &__floating,
+.outlined.with-leading-icon.with-value .floating,
 .outlined.with-leading-icon .input:focus ~ .floating {
     transform: translateY(-140%) translateX(-2.1rem) scale(0.75);
 }

--- a/src/core/Menu/Menu.js
+++ b/src/core/Menu/Menu.js
@@ -7,17 +7,17 @@ import Paper from '../Paper'
 
 import s from './styles'
 
-function Menu({ list, onSelect, onClose, children }) {
+function Menu({ width, height, list, onSelect, onClose, children }) {
     if (children) {
         return (
-            <Paper elevation={4}>
+            <Paper elevation={4} width={width} height={height}>
                 <ul className={s('container')}>{children}</ul>
             </Paper>
         )
     }
 
     return (
-        <Paper elevation={4}>
+        <Paper elevation={4} width={width} height={height}>
             <ul className={s('container')}>
                 {list.map(({ onClick, ...rest }, idx) => (
                     <MenuItem
@@ -35,9 +35,13 @@ function Menu({ list, onSelect, onClose, children }) {
 
 Menu.defaultProps = {
     options: [],
+    width: 'inherit',
+    height: 'inherit',
 }
 
 Menu.propTypes = {
+    width: PropTypes.string,
+    height: PropTypes.string,
     list: PropTypes.array,
     onSelect: PropTypes.func,
     onClose: PropTypes.func,

--- a/src/core/Menu/styles.css
+++ b/src/core/Menu/styles.css
@@ -1,18 +1,17 @@
 /** @format */
 
 .container {
-    padding: 0.5rem 0;
+    padding: 8px 0;
 }
 .item {
     display: flex;
     justify-content: flex-start;
-    padding: 0.25rem 1rem 0 1rem;
+    padding: 4px 16px 0 16px;
     transition: background-color 150ms cubic-bezier(0.4, 0, 0.6, 1);
     cursor: pointer;
-    min-width: 9.375rem;
-    font-size: 1rem;
+    font-size: 16px;
     font-weight: 400;
-    line-height: 2.25rem;
+    line-height: 36px;
     vertical-align: baseline;
 }
 .item:hover {
@@ -22,8 +21,8 @@
 .item .material-icons {
     /* To make sure event.target of the click handler is always the list item */
     pointer-events: none;
-    line-height: 2rem;
-    margin-right: 0.75rem;
+    line-height: 32px;
+    margin-right: 12px;
 }
 
 .item .material-icons:last-child {

--- a/src/core/Paper/index.js
+++ b/src/core/Paper/index.js
@@ -4,22 +4,27 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import s from './styles'
 
-function Paper({ elevation, children }) {
+function Paper({ width, height, elevation, children }) {
+    const style = { width, height }
     return (
-        <div className={s('container', `elevation-${elevation}`)}>
+        <div style={style} className={s('container', `elevation-${elevation}`)}>
             {children}
         </div>
     )
 }
 
+Paper.defaultProps = {
+    elevation: 1,
+    width: 'inherit',
+    height: 'inherit',
+}
+
 Paper.propTypes = {
+    width: PropTypes.string,
+    height: PropTypes.string,
     elevation: PropTypes.oneOf([0, 1, 2, 3, 4, 6, 12, 24]),
     className: PropTypes.string,
     children: PropTypes.node,
-}
-
-Paper.defaultProps = {
-    elevation: 1,
 }
 
 export { Paper }


### PR DESCRIPTION
- auto-resize based on parent width
- remove references to getAnchorRef, PopoverMenu, Fragment, labelStyles,
  LabelField
- remove native select control
- added width/height to Paper to auto-resize Menu in Select dropdown
- only the necessary properties adding Placeholder, HelpText etc. will
  come as standalone components