### PR TITLE
Update deps

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,17 +14,7 @@ module.exports = {
     env: {
         production: {
             presets,
-            plugins: [
-                ...plugins,
-                [
-                    'transform-react-remove-prop-types',
-                    {
-                        removeImport: true,
-                        additionalLibraries: ['prop-types-exact'],
-                        ignoreFilenames: ['node_modules'],
-                    },
-                ],
-            ],
+            plugins,
         },
         development: {
             presets,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
         "@dhis2/code-style": "^1.2.1",
         "babel-eslint": "^7.2.3",
         "babel-loader": "^8.0.2",
-        "babel-plugin-transform-react-remove-prop-types": "^0.4.18",
         "chokidar": "^2.0.4",
         "core-js": "^2.5.7",
         "cssnano": "^4.1.3",
@@ -49,7 +48,6 @@
         "file-loader": "^2.0.0",
         "fs-extra": "^7.0.0",
         "husky": "^1.0.1",
-        "material-design-icons": "^3.0.1",
         "mini-css-extract-plugin": "^0.4.3",
         "nodemon": "^1.18.4",
         "postcss-cli": "^6.0.0",
@@ -66,13 +64,14 @@
         "webpack-bundle-analyzer": "^3.0.2"
     },
     "peerDependencies": {
-        "@babel/polyfill": "^7.0.0",
         "react": "^16.4.2",
         "react-dom": "^16.4.2"
     },
     "dependencies": {
+        "@babel/polyfill": "^7.0.0",
         "classnames": "^2.2.6",
         "prop-types": "^15.6.2",
+        "material-design-icons": "^3.0.1",
         "typeface-roboto": "^0.0.54"
     }
 }


### PR DESCRIPTION
In order for the developers to get warnings from proptypes in their App when integrating the UI framework, we cannot remove the proptypes when we create our build. Prop types has to removed when the App is bundled (using CRA the plugin `babel-plugin-transform-react-remove-prop-types` is included by default).

`material-design-icons` is resolved using `import`, so technically it needs to be a runtime dependency.

`@babel/polyfill` needs to be a runtime dependency since we rely on 7.x and CRA only bundles 6.x, so having it as a peer dependency is not perfect.