### PR TITLE
Add message hook to husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
         "@babel/preset-react": "^7.0.0",
-        "@dhis2/code-style": "^1.2.1",
+        "@dhis2/code-style": "^1.3.0",
         "babel-eslint": "^7.2.3",
         "babel-loader": "^8.0.2",
         "chokidar": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     },
     "husky": {
         "hooks": {
+            "commit-msg": "commit-style",
             "pre-commit": "npm run format"
         }
     },


### PR DESCRIPTION
I added a hook called [`commit-style`](https://github.com/dhis2/code-style/blob/master/commit-style) to the **code-style** package, so we can get conventional commits going.

This allows us to generate changelogs: https://github.com/conventional-changelog/conventional-changelog