### PR TITLE
fix(style-overrides)

### DIFF
--- a/src/core/UI/theme/blue.css
+++ b/src/core/UI/theme/blue.css
@@ -121,7 +121,3 @@
 :global .blue a:visited {
     color: #1976d2;
 }
-:global .blue a:focus,
-:global .blue a:active {
-    background-color: #eceff1;
-}


### PR DESCRIPTION
we should better identify the target use-case in destination, as this over-ride will add un-necessary background to all `<a/>` tags on focus/click