### PR TITLE
fix(headerbar style): fix z-index on apps/profile dropdown

### DIFF
--- a/src/widgets/HeaderBar/styles.css
+++ b/src/widgets/HeaderBar/styles.css
@@ -96,7 +96,7 @@
 }
 
 .apps .contents {
-    z-index: 10;
+    z-index: 10000;
     position: absolute;
     top: 20px;
     right: -6px;
@@ -200,7 +200,7 @@
 }
 
 .profile .contents {
-    z-index: 10;
+    z-index: 10000;
     position: absolute;
     top: 36px;
     right: -6px;


### PR DESCRIPTION
- On Maps app Bjorn has set 1000 z-index on the map container which hides our **profile** and **apps** dropdown
- Settings **10,000** for the z-index is probably reasonable enough to overcome any z-index issues we find during `<HeaderBar />` integrations