### PR TITLE
Avoid style collisions between components and apps

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -4,7 +4,6 @@ const stringHash = require('string-hash')
 
 module.exports = {
     plugins: {
-        'postcss-import': {},
         'postcss-preset-env': {
             browsers: [
                 '> 0.5%',
@@ -33,7 +32,6 @@ module.exports = {
                 const path = require('path')
 
                 const i = css.indexOf('.' + name)
-                const lineNumber = css.substr(0, i).split(/[\r\n]/).length
                 const component = path
                     .basename(path.dirname(filename))
                     .toLowerCase()
@@ -42,7 +40,7 @@ module.exports = {
                     .toString(36)
                     .substr(0, 5)
 
-                return `_ui_${component}_${name}_${hash}_${lineNumber}`
+                return `_ui_${component}_${name}_${hash}`
             },
         },
         'postcss-rtl': {},

--- a/src/core/Button/Button.js
+++ b/src/core/Button/Button.js
@@ -17,7 +17,7 @@ function Button({
         <button
             disabled={disabled}
             onClick={onClick}
-            className={s('button', `kind-${kind}`, `size-${size}`, {
+            className={s('base', `kind-${kind}`, `size-${size}`, {
                 'icon-only': icon && !label && !children,
                 icon,
             })}

--- a/src/core/Button/styles.css
+++ b/src/core/Button/styles.css
@@ -1,4 +1,4 @@
-.button {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
     user-select: none;
@@ -15,18 +15,24 @@
     text-decoration: none;
     text-transform: capitalize;
     transition: all 0.15s cubic-bezier(0.4, 0, 0.6, 1);
+    margin: 0 /* rtl:ignore */;
+    padding: 0 /* rtl:ignore */;
+    border: 0 /* rtl:ignore */;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
 }
 
-.button:disabled {
+.base:disabled {
     cursor: not-allowed;
 }
 
-.button:focus {
+.base:focus {
     /* Prevent default browser behavior whcih adds an outline */
     outline: none;
 }
 
-.button.icon {
+.base.icon {
     padding-left: 10px;
 }
 
@@ -193,24 +199,45 @@
 
 .dropdown {
     composes: boxmodel font from '../mixins/globals.css';
+
+    display: block;
     position: relative;
-    display: inline-flex;
     white-space: nowrap;
+    margin: 0 /* rtl:ignore */;
+    padding: 0 /* rtl:ignore */;
+    border: 0 /* rtl:ignore */;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+    margin: 0 /* rtl:ignore */;
+    padding: 0 /* rtl:ignore */;
+    border: 0 /* rtl:ignore */;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
 }
 
 .split {
     composes: boxmodel font from '../mixins/globals.css';
+
+    display: block;
     position: relative;
     display: inline-flex;
     white-space: nowrap;
+    margin: 0 /* rtl:ignore */;
+    padding: 0 /* rtl:ignore */;
+    border: 0 /* rtl:ignore */;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
 }
 
-.split .button:first-child {
+.split .base:first-child {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
 }
 
-.split .button:nth-child(2) {
+.split .base:nth-child(2) {
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
     padding: 0 9px;
@@ -218,6 +245,8 @@
 
 .menu {
     composes: boxmodel font from '../mixins/globals.css';
+
+    display: block;
     position: absolute;
     z-index: 1000;
     left: 0;
@@ -234,11 +263,11 @@
        Graceful degradation: remove the rounded corners on all buttons apart from circle.
        These are not rendered correctly in IE11, where they produce white pixels in the corners 
     */
-    .button {
+    .base {
         border-radius: 0;
     }
     /* Prevent icon position shifting during a click */
-    .button .material-icons {
+    .base .material-icons {
         position: relative;
         top: 0;
         left: 0;

--- a/src/core/Button/styles.css
+++ b/src/core/Button/styles.css
@@ -15,12 +15,6 @@
     text-decoration: none;
     text-transform: capitalize;
     transition: all 0.15s cubic-bezier(0.4, 0, 0.6, 1);
-    margin: 0 /* rtl:ignore */;
-    padding: 0 /* rtl:ignore */;
-    border: 0 /* rtl:ignore */;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
 }
 
 .base:disabled {
@@ -200,36 +194,16 @@
 .dropdown {
     composes: boxmodel font from '../mixins/globals.css';
 
-    display: block;
     position: relative;
     white-space: nowrap;
-    margin: 0 /* rtl:ignore */;
-    padding: 0 /* rtl:ignore */;
-    border: 0 /* rtl:ignore */;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
-    margin: 0 /* rtl:ignore */;
-    padding: 0 /* rtl:ignore */;
-    border: 0 /* rtl:ignore */;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
 }
 
 .split {
     composes: boxmodel font from '../mixins/globals.css';
 
-    display: block;
     position: relative;
     display: inline-flex;
     white-space: nowrap;
-    margin: 0 /* rtl:ignore */;
-    padding: 0 /* rtl:ignore */;
-    border: 0 /* rtl:ignore */;
-    font-size: 100%;
-    font: inherit;
-    vertical-align: baseline;
 }
 
 .split .base:first-child {
@@ -246,7 +220,6 @@
 .menu {
     composes: boxmodel font from '../mixins/globals.css';
 
-    display: block;
     position: absolute;
     z-index: 1000;
     left: 0;

--- a/src/core/Card/index.js
+++ b/src/core/Card/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import s from './styles'
 
 function Card({ className, children }) {
-    return <div className={s('container', className)}>{children}</div>
+    return <div className={s('base', className)}>{children}</div>
 }
 
 Card.defaultProps = {

--- a/src/core/Card/styles.css
+++ b/src/core/Card/styles.css
@@ -1,7 +1,6 @@
 .base {
     composes: boxmodel font from '../mixins/globals.css';
 
-    display: block;
     height: inherit;
     width: inherit;
     border-radius: 2px;

--- a/src/core/Card/styles.css
+++ b/src/core/Card/styles.css
@@ -1,11 +1,12 @@
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
-    position: relative;
+    display: block;
     height: inherit;
     width: inherit;
     border-radius: 2px;
     background-color: #fff;
     box-shadow: 0 0 2px 0 rgba(0, 0, 0, 0.14), 0 2px 2px 0 rgba(0, 0, 0, 0.12),
         0 1px 3px 0 rgba(0, 0, 0, 0.2);
+    position: relative;
 }

--- a/src/core/Checkbox/index.js
+++ b/src/core/Checkbox/index.js
@@ -38,9 +38,7 @@ class Checkbox extends React.Component {
         )
 
         return (
-            <label
-                className={s('container', { disabled: this.props.disabled })}
-            >
+            <label className={s('base', { disabled: this.props.disabled })}>
                 <input
                     type="checkbox"
                     onChange={this.onChange}

--- a/src/core/Checkbox/styles.css
+++ b/src/core/Checkbox/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
     pointer-events: all;
     user-select: none;
@@ -9,7 +9,7 @@
     cursor: pointer;
 }
 
-.container input[type='checkbox'] {
+.base input[type='checkbox'] {
     display: none;
 }
 
@@ -23,7 +23,7 @@
 }
 
 .disabled,
-.container .disabled {
+.base .disabled {
     cursor: not-allowed;
 }
 

--- a/src/core/Chip/index.js
+++ b/src/core/Chip/index.js
@@ -47,7 +47,7 @@ class Chip extends React.PureComponent {
 
         return (
             <div
-                className={s('container', {
+                className={s('base', {
                     selected,
                     disabled,
                     dragging,

--- a/src/core/Chip/styles.css
+++ b/src/core/Chip/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
     display: inline-flex;
@@ -13,43 +13,43 @@
     user-select: none;
 }
 
-.container:hover {
+.base:hover {
     background-color: #e0f2f1;
 }
 
-.container.selected,
-.container.selected.static:hover {
+.base.selected,
+.base.selected.static:hover {
     background-color: #00796b;
 }
 
-.container.selected:hover {
+.base.selected:hover {
     background-color: #00695c;
 }
 
-.container.selected,
-.container.selected .icon,
-.container.selected .remove-icon {
+.base.selected,
+.base.selected .icon,
+.base.selected .remove-icon {
     color: #ffffff;
 }
 
-.container.static {
+.base.static {
     pointer-events: none;
 }
 
-.container.static:hover {
+.base.static:hover {
     background-color: #eceff1;
 }
 
-.container.disabled {
+.base.disabled {
     cursor: not-allowed;
     opacity: 0.3;
 }
 
-.container.disabled .remove-icon {
+.base.disabled .remove-icon {
     pointer-events: none;
 }
 
-.container.dragging {
+.base.dragging {
     box-shadow: 0 3px 1px -2px rgba(0, 0, 0, 0.2),
         0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12);
 }

--- a/src/core/CircularProgress/index.js
+++ b/src/core/CircularProgress/index.js
@@ -19,7 +19,7 @@ function Circle() {
 
 function CircularProgress({ size, overlay }) {
     const loader = (
-        <div role="progressbar" className={s('container', size)}>
+        <div role="progressbar" className={s('base', size)}>
             <Circle />
         </div>
     )

--- a/src/core/CircularProgress/styles.css
+++ b/src/core/CircularProgress/styles.css
@@ -14,7 +14,7 @@
     align-items: center;
 }
 
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
     display: inline-block;
@@ -23,17 +23,17 @@
     animation: anim-rotate 1.4s linear infinite;
 }
 
-.container.small {
+.base.small {
     width: 24px;
     height: 24px;
 }
 
-.container.medium {
+.base.medium {
     width: 50px;
     height: 50px;
 }
 
-.container.large {
+.base.large {
     width: 80px;
     height: 80px;
 }

--- a/src/core/Icon/index.js
+++ b/src/core/Icon/index.js
@@ -6,7 +6,7 @@ import 'material-design-icons-iconfont/dist/material-design-icons.css'
 
 function Icon({ name, className, onClick }) {
     return (
-        <i onClick={onClick} className={s('container', className)}>
+        <i onClick={onClick} className={s('base', className)}>
             {name}
         </i>
     )

--- a/src/core/Icon/styles.css
+++ b/src/core/Icon/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel from '../mixins/globals.css';
 
     content: ' ';

--- a/src/core/InputField/index.js
+++ b/src/core/InputField/index.js
@@ -36,7 +36,7 @@ class InputField extends React.Component {
     render() {
         return (
             <div
-                className={s('container', {
+                className={s('base', {
                     disabled: this.props.disabled,
                     [`size-${this.props.size}`]: true,
                     [`kind-${this.props.kind}`]: true,

--- a/src/core/InputField/styles.css
+++ b/src/core/InputField/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
     position: relative;
@@ -7,7 +7,8 @@
     cursor: pointer;
     width: 100%;
 }
-.container.disabled {
+
+.base.disabled {
     cursor: not-allowed;
 }
 
@@ -18,12 +19,12 @@
     justify-content: center;
     margin-bottom: 8px;
 }
-.container.size-default,
-.container.size-default .field {
+.base.size-default,
+.base.size-default .field {
     height: 56px;
 }
-.container.size-dense,
-.container.size-dense .field {
+.base.size-dense,
+.base.size-dense .field {
     height: 44px;
 }
 
@@ -41,25 +42,25 @@
     color: #494949;
 }
 
-.container.disabled .input,
-.container.disabled .input::placeholder {
+.base.disabled .input,
+.base.disabled .input::placeholder {
     color: #9e9e9e;
 }
-.container.size-default .input {
+.base.size-default .input {
     height: 16px;
     line-height: 16px;
     font-size: 16px;
 }
-.container.size-dense .input {
+.base.size-dense .input {
     height: 13px;
     line-height: 13px;
     font-size: 13px;
     font-weight: 300;
 }
-.container.kind-filled.size-default .input {
+.base.kind-filled.size-default .input {
     margin: 20px 14px 0 14px;
 }
-.container.kind-filled.size-dense .input {
+.base.kind-filled.size-dense .input {
     margin: 18px 14px 0 14px;
     height: 13px;
 }
@@ -70,45 +71,45 @@
 }
 
 /* icon in filled bg, default size */
-.container.kind-filled.size-default .icon {
+.base.kind-filled.size-default .icon {
     margin: 12px 7px 0 14px;
 }
-.container.is-empty.kind-filled.size-default .icon {
+.base.is-empty.kind-filled.size-default .icon {
     margin-top: 0;
 }
-.container.kind-filled.size-default .icon + .input {
+.base.kind-filled.size-default .icon + .input {
     margin: 18px 14px 0 0;
 }
 
 /* icon in filled bg, dense size */
-.container.kind-filled.size-dense .icon i {
+.base.kind-filled.size-dense .icon i {
     font-size: 18px;
 }
-.container.is-empty.kind-filled.size-dense .icon {
+.base.is-empty.kind-filled.size-dense .icon {
     margin-top: 4px;
 }
-.container.kind-filled.size-dense .icon + .input::placeholder {
+.base.kind-filled.size-dense .icon + .input::placeholder {
 }
-.container.kind-filled.size-dense .icon {
+.base.kind-filled.size-dense .icon {
     margin: 22px 5px 0 14px;
 }
-.container.kind-filled.size-dense .icon + .input {
+.base.kind-filled.size-dense .icon + .input {
     margin: 16px 14px 0 0;
 }
 
 /* icon in outlined, default size */
-.container.kind-outlined.size-default .icon + .input {
+.base.kind-outlined.size-default .icon + .input {
     margin-left: 0;
 }
 
 /* icon in outlined, dense size */
-.container.kind-outlined.size-dense .icon i {
+.base.kind-outlined.size-dense .icon i {
     font-size: 18px;
 }
-.container.kind-outlined.size-dense .icon {
+.base.kind-outlined.size-dense .icon {
     margin: 6px 5px 0 14px;
 }
-.container.kind-outlined.size-dense .icon + .input {
+.base.kind-outlined.size-dense .icon + .input {
     margin-left: 0;
 }
 

--- a/src/core/LinearProgress/index.js
+++ b/src/core/LinearProgress/index.js
@@ -8,7 +8,7 @@ function LinearProgress({ amount, margin }) {
     const style = amount ? { width: `${amount}%` } : null
 
     return (
-        <div role="progressbar" className={s('container')} style={{ margin }}>
+        <div role="progressbar" className={s('base')} style={{ margin }}>
             <div style={style} className={s('progress', type)} />
         </div>
     )

--- a/src/core/LinearProgress/styles.css
+++ b/src/core/LinearProgress/styles.css
@@ -3,7 +3,7 @@
  */
 
 /* rtl:begin:ignore */
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
     position: relative;
@@ -53,16 +53,16 @@
     will-change: left, right;
 }
 
-[dir='rtl'] .container .progress.determinate {
+[dir='rtl'] .base .progress.determinate {
     left: auto;
     right: 0;
 }
 
-[dir='rtl'] .container .progress.indeterminate:before {
+[dir='rtl'] .base .progress.indeterminate:before {
     animation-name: anim-indeterminate-rtl;
 }
 
-[dir='rtl'] .container .progress.indeterminate:after {
+[dir='rtl'] .base .progress.indeterminate:after {
     animation-name: anim-indeterminate-short-rtl;
 }
 

--- a/src/core/Menu/index.js
+++ b/src/core/Menu/index.js
@@ -9,7 +9,7 @@ import s from './styles'
 export function Menu({ size, width, list, onClick }) {
     return (
         <Card>
-            <ul className={s('menu', size)}>
+            <ul className={s('base', size)}>
                 {list.map(
                     (
                         { label, value, icon, list, active, type, disabled },

--- a/src/core/Menu/styles.css
+++ b/src/core/Menu/styles.css
@@ -1,7 +1,6 @@
 .base {
     composes: boxmodel font from '../mixins/globals.css';
 
-    display: block;
     user-select: none;
     padding: 0;
     margin: 0;

--- a/src/core/Menu/styles.css
+++ b/src/core/Menu/styles.css
@@ -1,10 +1,11 @@
-.menu {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
+    display: block;
     user-select: none;
-    display: flex;
-    flex-direction: column;
-    padding: 8px 0;
+    padding: 0;
+    margin: 0;
+    position: relative;
 }
 
 .item {
@@ -14,7 +15,6 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    width: 100%;
     height: 48px;
 }
 
@@ -23,7 +23,7 @@
     background-color: #f7f7f7;
 }
 
-.menu.dense .item {
+.base.dense .item {
     height: 32px;
 }
 
@@ -31,7 +31,7 @@
     color: rgba(0, 0, 0, 0.87);
     font-size: 15px;
 }
-.menu.dense .label {
+.base.dense .label {
     font-size: 13px;
 }
 
@@ -40,10 +40,10 @@
     color: #404040;
     font-size: 24px;
 }
-.menu.dense .icon {
+.base.dense .icon {
     font-size: 20px;
 }
-.menu.dense .divider {
+.base.dense .divider {
     margin: 4px 0;
 }
 
@@ -57,7 +57,7 @@
 }
 
 /* SUB-MENU */
-.menu .chevron {
+.base .chevron {
     margin: 0 14px 0 auto;
     font-size: 18px;
 }

--- a/src/core/Radio/index.js
+++ b/src/core/Radio/index.js
@@ -24,9 +24,7 @@ class Radio extends React.Component {
         )
 
         return (
-            <label
-                className={s('container', { disabled: this.props.disabled })}
-            >
+            <label className={s('base', { disabled: this.props.disabled })}>
                 <input
                     type="radio"
                     name={this.props.name}

--- a/src/core/Radio/styles.css
+++ b/src/core/Radio/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
     pointer-events: all;
@@ -10,7 +10,7 @@
     cursor: pointer;
 }
 
-.container input[type='radio'] {
+.base input[type='radio'] {
     display: none;
 }
 

--- a/src/core/SelectField/index.js
+++ b/src/core/SelectField/index.js
@@ -92,7 +92,7 @@ class SelectField extends React.Component {
         return (
             <div
                 ref={c => (this.elContainer = c)}
-                className={s('container', {
+                className={s('base', {
                     selected: !!this.props.value,
                     disabled: this.props.disabled,
                     [`kind-${this.props.kind}`]: true,

--- a/src/core/SelectField/styles.css
+++ b/src/core/SelectField/styles.css
@@ -1,13 +1,13 @@
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 
     position: relative;
 }
-.container.disabled {
+.base.disabled {
     cursor: not-allowed;
 }
-.container.disabled .icon,
-.container.disabled .dropdown-icon {
+.base.disabled .icon,
+.base.disabled .dropdown-icon {
     color: rgba(0, 0, 0, 0.3);
 }
 
@@ -40,17 +40,17 @@
     user-select: none;
 }
 
-.container.size-default {
+.base.size-default {
     height: 68px;
 }
-.container.size-dense {
+.base.size-dense {
     height: 56px;
 }
 
-.container.size-default .select {
+.base.size-default .select {
     height: 56px;
 }
-.container.size-dense .select {
+.base.size-dense .select {
     height: 44px;
 }
 
@@ -58,32 +58,32 @@
     color: #000;
     font-size: 16px;
 }
-.container.kind-filled .value {
+.base.kind-filled .value {
     margin-left: 14px;
 }
-.container.kind-outlined .value {
+.base.kind-outlined .value {
     margin-left: 20px;
 }
-.container.selected.kind-filled.size-dense .select .value {
+.base.selected.kind-filled.size-dense .select .value {
     margin-top: 17px;
     font-size: 13px;
 }
-.container.selected.kind-filled.size-default .select .value {
+.base.selected.kind-filled.size-default .select .value {
     margin-top: 15px;
 }
 
 /* icon in filled bg, default size */
-.container.selected.kind-filled.size-default .icon {
+.base.selected.kind-filled.size-default .icon {
     margin: 11px 4px 0 14px;
 }
-.container.selected.kind-filled.size-dense .icon {
+.base.selected.kind-filled.size-dense .icon {
     margin: 22px 3px 0 10px;
 }
-.container.kind-filled .icon + .value,
-.container.kind-outlined .icon + .value {
+.base.kind-filled .icon + .value,
+.base.kind-outlined .icon + .value {
     margin-left: 0;
 }
-.container.selected.kind-filled.size-dense .icon i {
+.base.selected.kind-filled.size-dense .icon i {
     font-size: 18px;
 }
 

--- a/src/core/Switch/index.js
+++ b/src/core/Switch/index.js
@@ -16,7 +16,7 @@ class Switch extends React.Component {
         const { status, disabled } = this.props
         return (
             <label
-                className={s('container', status, { disabled })}
+                className={s('base', status, { disabled })}
                 onChange={this.onChange}
             >
                 <input

--- a/src/core/Switch/styles.css
+++ b/src/core/Switch/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../mixins/globals.css';
 }
 .input {

--- a/src/core/helpers/Divider/index.js
+++ b/src/core/helpers/Divider/index.js
@@ -4,7 +4,7 @@ import s from './styles'
 
 export function Divider({ margin }) {
     const style = { margin }
-    return <div style={style} className={s('divider')} />
+    return <div style={style} className={s('base')} />
 }
 
 Divider.defaultProps = {

--- a/src/core/helpers/Divider/styles.css
+++ b/src/core/helpers/Divider/styles.css
@@ -1,4 +1,4 @@
-.divider {
+.base {
     width: 100%;
     height: 1px;
     background-color: #e0e0e0;

--- a/src/core/helpers/Help/index.js
+++ b/src/core/helpers/Help/index.js
@@ -5,7 +5,7 @@ import s from './styles'
 function Help({ text, status }) {
     return (
         <div
-            className={s('container', {
+            className={s('base', {
                 [`status-${status}`]: true,
             })}
         >

--- a/src/core/helpers/Help/styles.css
+++ b/src/core/helpers/Help/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../../mixins/globals.css';
 
     cursor: help;
@@ -8,19 +8,19 @@
     color: #494949;
     font-size: 12px;
 }
-.container.status-default {
+.base.status-default {
     color: #494949;
     border-color: #c4c4c4;
 }
-.container.status-valid {
+.base.status-valid {
     color: #1976d2;
     border-color: #1976d2;
 }
-.container.status-error {
+.base.status-error {
     color: #e53935;
     border-color: #e53935;
 }
-.container.status-warning {
+.base.status-warning {
     color: #f19c02;
     border-color: #f19c02;
 }

--- a/src/core/helpers/Label/index.js
+++ b/src/core/helpers/Label/index.js
@@ -22,7 +22,7 @@ function Label({
 }) {
     return (
         <div
-            className={s('container', {
+            className={s('base', {
                 disabled,
                 'has-icon': hasIcon,
                 [`focused`]: focused,

--- a/src/core/helpers/Label/styles.css
+++ b/src/core/helpers/Label/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../../mixins/globals.css';
 
     position: absolute;
@@ -8,34 +8,34 @@
     height: 100%;
     border-radius: 5px;
 }
-.container.disabled,
-.container.disabled.status-default,
-.container.disabled.status-error,
-.container.disabled.status-valid,
-.container.disabled.status-warning {
+.base.disabled,
+.base.disabled.status-default,
+.base.disabled.status-error,
+.base.disabled.status-valid,
+.base.disabled.status-warning {
     color: #9e9e9e;
     border-color: rgba(196, 196, 196, 0.2);
 }
-.container.disabled .content,
-.container.disabled.status-default .content,
-.container.disabled.status-error .content,
-.container.disabled.status-valid .content,
-.container.disabled.status-warning .content {
+.base.disabled .content,
+.base.disabled.status-default .content,
+.base.disabled.status-error .content,
+.base.disabled.status-valid .content,
+.base.disabled.status-warning .content {
     color: #9e9e9e;
 }
 
-.container.size-default {
+.base.size-default {
     height: 56px;
     line-height: 56px;
 }
-.container.size-dense {
+.base.size-dense {
     height: 44px;
     line-height: 44px;
 }
-.container.kind-filled.focused {
+.base.kind-filled.focused {
     border-bottom: 2px solid #00796b;
 }
-.container.kind-outlined.focused {
+.base.kind-outlined.focused {
     border: 1.5px solid #00796b;
 }
 
@@ -106,29 +106,29 @@
     right: 28px;
 }
 
-.container.status-default,
-.container.status-default .content {
+.base.status-default,
+.base.status-default .content {
     color: #494949;
     border-color: #c4c4c4;
 }
-.container.status-default.focused .content {
+.base.status-default.focused .content {
     color: #00796b;
 }
-.container.status-valid,
-.container.status-valid.focused,
-.container.status-valid .content {
+.base.status-valid,
+.base.status-valid.focused,
+.base.status-valid .content {
     color: #1976d2;
     border-color: #1976d2;
 }
-.container.status-error,
-.container.status-error.focused,
-.container.status-error .content {
+.base.status-error,
+.base.status-error.focused,
+.base.status-error .content {
     color: #e53935;
     border-color: #e53935;
 }
-.container.status-warning,
-.container.status-warning.focused,
-.container.status-warning .content {
+.base.status-warning,
+.base.status-warning.focused,
+.base.status-warning .content {
     color: #f19c02;
     border-color: #f19c02;
 }

--- a/src/widgets/HeaderBar/HeaderBar.Component.js
+++ b/src/widgets/HeaderBar/HeaderBar.Component.js
@@ -25,7 +25,7 @@ function HeaderBar({
     interpretations,
 }) {
     return (
-        <header className={s('container', 'blue')}>
+        <header className={s('base', 'blue')}>
             <div className={s('first')}>
                 <div className={s('logo')}>
                     <a href={`${baseURL}`}>

--- a/src/widgets/HeaderBar/styles.css
+++ b/src/widgets/HeaderBar/styles.css
@@ -212,7 +212,7 @@
 .profile .contents {
     z-index: 10000;
     position: absolute;
-    top: 36px;
+    top: 34px;
     right: -6px;
     border-top: 4px solid transparent;
     width: 310px;

--- a/src/widgets/HeaderBar/styles.css
+++ b/src/widgets/HeaderBar/styles.css
@@ -1,4 +1,4 @@
-.container {
+.base {
     composes: boxmodel font from '../../core/mixins/globals.css';
 
     border-bottom: 1px solid rgba(32, 32, 32, 0.15);
@@ -10,11 +10,14 @@
 }
 
 .first {
+    box-sizing: border-box;
     display: flex;
     flex-direction: row;
     align-items: center;
 }
+
 .logo {
+    box-sizing: border-box;
     margin: 0 12px 0 0;
     border-right: 1px solid rgba(32, 32, 32, 0.15);
     padding-top: 12px;
@@ -22,6 +25,7 @@
     height: 48px;
     text-align: center;
 }
+
 .logo svg,
 .logo a {
     width: 27px;
@@ -263,6 +267,6 @@
 .blue > .last > .apps > i:first-child {
     color: #fff;
 }
-.container.blue .profile > .icon > .initials {
+.base.blue .profile > .icon > .initials {
     color: #fff;
 }


### PR DESCRIPTION
This PR allows the App to use or not use a reset stylesheet without affecting the components.

In general we need a better way to ensure that no matter what the App does, the components will not be affected.

The common way to do this is to e.g. set `all: initial` for each component, and then start building it up from there.

The problem with that approach is that putting e.g. a **Menu** inside a **Card** means that **Menu** will reset everything from the **Card**, so in effect, it becomes transparent. Setting certain properties like `background` and `box-shadow` to `inherit` fixes it, but this becomes slightly tedious and error prone.

gzipped filesize changes:

```
 58.81 KB (-217 B)  build/static/js/main.8bb83303.js
 8.36 KB (-99 B)  build/static/css/main.fe623f5a.css
```