### PR TITLE
fix(headerbar): display avatar img

### DIFF
--- a/src/widgets/HeaderBar/HeaderBar.Container.js
+++ b/src/widgets/HeaderBar/HeaderBar.Container.js
@@ -19,6 +19,14 @@ function appPath(path) {
     return `${serverURL}/api/${path}`
 }
 
+function avatarPath(avatar) {
+    if (!avatar) {
+        return null
+    }
+
+    return `${serverURL}/api/fileResources/${avatar.id}/data`
+}
+
 class HeaderBarContainer extends React.Component {
     state = {
         type: 'blue',
@@ -69,6 +77,7 @@ class HeaderBarContainer extends React.Component {
                             profile: {
                                 name: me.name,
                                 email: me.email,
+                                img: avatarPath(me.avatar),
                             },
                         }
                     })


### PR DESCRIPTION
There was already some code for displaying the user-avatar if the profile had a truthy `img` property. However, this property was not being plucked of the API response. I think this was because the avatar wasn't really supported via the API when Adeel worked on this.