### PR TITLE
docs: link to dhis2/ui docs instead of create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ Make a PR from the component branch. Add a team member who can review the code a
 
 ## Documentation
 
-You can find the most recent documentation [here](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md).
+You can find the most recent documentation [here](https://d2-ci.github.io/ui/).


### PR DESCRIPTION
Maybe I'm missing something, but having a link to create-react-app docs here seems wrong.  Updating to point at the gh-pages publication, but maybe this section is not needed since that page is liked from the top of the readme?