### PR TITLE
fix(reset): b and strong should be bold and i and em italic

### DIFF
--- a/src/defaults/reset.css
+++ b/src/defaults/reset.css
@@ -91,6 +91,14 @@ video {
     font-size: 100%;
     vertical-align: baseline;
 }
+b,
+strong {
+    font-weight: bold;
+}
+i,
+em {
+    font-style: italic;
+}
 /* HTML5 display-role reset for older browsers */
 article,
 aside,


### PR DESCRIPTION
@joakimia pointed out that the some of the resets might be a bit too aggressive. Specifically, the rule `font: inherit;` has some big consequences, it touches the following font-related styles:
```css
font-style: inherit; /* this is a problem for <i> and <em> */
font-variant-ligatures: inherit;
font-variant-caps: inherit;
font-variant-numeric: inherit;
font-variant-east-asian: inherit;
font-weight: inherit; /* this is a problem for <b> and <strong> */
font-stretch: inherit;
font-size: 100%;
line-height: inherit;
font-family: inherit;
```
I've added two additional rules to address these issues.