### PR TITLE
chore: add netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "yarn install --frozen-lockfile && yarn build && cd docs && yarn install --frozen-lockfile && yarn build"
+  publish = "docs/build"


### PR DESCRIPTION
This file moves Netlify build configuration into the repository so that the commands configured in Netlify's UI won't get out-of-sync with the codebase.

Adding a netlify.toml file isn't technically required, but this is also a good showcase for netlify deployment of a pull request.

See linked netlify deployment below or [here](https://deploy-preview-153--dhis2-ui.netlify.com/))