### PR TITLE
docs: fix storybook prefixes

### DIFF
--- a/packages/widgets/src/Layer/Layer.stories.js
+++ b/packages/widgets/src/Layer/Layer.stories.js
@@ -64,38 +64,47 @@ DivInLayer.propTypes = {
     className: propTypes.string,
 }
 
-storiesOf('Layer', module).add('Stacked layers (pure nesting)', () => (
-    <>
-        <DivInLayer stackLevel={layers.alert} className="layer-a-child">
-            A
-            <DivInLayer stackLevel={layers.blocking} className="layer-b-child">
-                B
-                <DivInLayer stackLevel={4561} className="layer-c-child">
-                    C
-                </DivInLayer>
-            </DivInLayer>
-        </DivInLayer>
-        <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
-            D
-            <DivInLayer stackLevel={layers.blocking} className="layer-e-child">
-                E
+storiesOf('Component/Widget/Layer', module).add(
+    'Stacked layers (pure nesting)',
+    () => (
+        <>
+            <DivInLayer stackLevel={layers.alert} className="layer-a-child">
+                A
                 <DivInLayer
-                    stackLevel={layers.applicationTop}
-                    className="layer-f-child"
+                    stackLevel={layers.blocking}
+                    className="layer-b-child"
                 >
-                    F
+                    B
+                    <DivInLayer stackLevel={4561} className="layer-c-child">
+                        C
+                    </DivInLayer>
                 </DivInLayer>
             </DivInLayer>
-        </DivInLayer>
-        <style jsx>{`
-            :global(#root) {
-                height: auto !important;
-            }
-        `}</style>
-    </>
-))
+            <DivInLayer stackLevel={layers.blocking} className="layer-d-child">
+                D
+                <DivInLayer
+                    stackLevel={layers.blocking}
+                    className="layer-e-child"
+                >
+                    E
+                    <DivInLayer
+                        stackLevel={layers.applicationTop}
+                        className="layer-f-child"
+                    >
+                        F
+                    </DivInLayer>
+                </DivInLayer>
+            </DivInLayer>
+            <style jsx>{`
+                :global(#root) {
+                    height: auto !important;
+                }
+            `}</style>
+        </>
+    )
+)
 
-storiesOf('Layer', module).add('Inverse nesting', () => (
+storiesOf('Component/Widget/Layer', module).add('Inverse nesting', () => (
     <>
         <DivInLayer stackLevel={layers.blocking} className="layer-a-child">
             A

--- a/packages/widgets/src/MenuItem/MenuItem.stories.js
+++ b/packages/widgets/src/MenuItem/MenuItem.stories.js
@@ -20,7 +20,7 @@ const MenuItemPositions = () => (
     </Menu>
 )
 
-storiesOf('MenuItem', module)
+storiesOf('Component/Widget/MenuItem', module)
     .add('With onClick and value', () => (
         <MenuItem label="Menu item" value="Value" onClick={window.onClick} />
     ))

--- a/packages/widgets/src/MultiSelect/MultiSelect.stories.js
+++ b/packages/widgets/src/MultiSelect/MultiSelect.stories.js
@@ -16,7 +16,7 @@ CustomMultiSelectOption.propTypes = {
     onClick: propTypes.func,
 }
 
-storiesOf('MultiSelect', module)
+storiesOf('Component/Widget/MultiSelect', module)
     .add('With options', () => (
         <MultiSelect className="select">
             <MultiSelectOption value="1" label="option one" />
@@ -25,7 +25,11 @@ storiesOf('MultiSelect', module)
         </MultiSelect>
     ))
     .add('With options and onChange', () => (
-        <MultiSelect className="select" onChange={window.onChange}>
+        <MultiSelect
+            className="select"
+            onChange={val => console.log(val)}
+            selected={['1']}
+        >
             <MultiSelectOption value="1" label="option one" />
             <MultiSelectOption value="2" label="option two" />
             <MultiSelectOption value="3" label="option three" />

--- a/packages/widgets/src/SingleSelect/SingleSelect.stories.js
+++ b/packages/widgets/src/SingleSelect/SingleSelect.stories.js
@@ -18,7 +18,7 @@ CustomSingleSelectOption.propTypes = {
     onClick: propTypes.func,
 }
 
-storiesOf('SingleSelect', module)
+storiesOf('Component/Widget/SingleSelect', module)
     .add('With options', () => (
         <SingleSelect className="select">
             <SingleSelectOption value="1" label="option one" />

--- a/packages/widgets/src/Tooltip/Tooltip.stories.js
+++ b/packages/widgets/src/Tooltip/Tooltip.stories.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Tooltip } from './Tooltip.js'
 
 export default {
-    title: 'Tooltip',
+    title: 'Component/Widget/Tooltip',
     component: Tooltip,
     decorators: [
         storyFn => (


### PR DESCRIPTION
I noticed that certain components did not have the prefixes that the others all have (`component/widget`). I've added it for the ones that were lacking a prefix. I assumed that this was necessary, so feel free to close if this was intentional.

(The changes in the Layer story are changes made by prettier btw)