### PR TITLE
fix: update number range validation error to match actual bounds

### DIFF
--- a/packages/forms/src/validators/createNumberRange.js
+++ b/packages/forms/src/validators/createNumberRange.js
@@ -14,7 +14,7 @@ const createNumberRange = (lowerBound, upperBound, customMessage) => {
     const errorMessage =
         customMessage ||
         i18n.t(
-            'Please enter a number between {{lowerBound}} and {{upperBound}}',
+            'Number cannot be less than {{lowerBound}} or more than {{upperBound}}',
             { lowerBound, upperBound }
         )
 


### PR DESCRIPTION
The other validation messages (min and maxNumber) can be left as is in my opinion, they seem easy to understand correctly to me. The tests of createNumberRange are accurate as well. So it's just the wording that I've updated slightly.

See the linked issue for more details.

Closes #13 