### PR TITLE
fix: display submit errors

### DIFF
--- a/packages/forms/src/shared/helpers/getValidationText.js
+++ b/packages/forms/src/shared/helpers/getValidationText.js
@@ -1,6 +1,21 @@
 import { hasError } from './hasError.js'
 
-const getValidationText = (meta, validationText, error) =>
-    validationText || (hasError(meta, error) && meta.error) || ''
+const getValidationText = (meta, validationText, error) => {
+    if (validationText) {
+        return validationText
+    }
+
+    if (hasError(meta, error)) {
+        if (meta.error) {
+            return meta.error
+        }
+
+        if (meta.submitError) {
+            return meta.submitError
+        }
+    }
+
+    return ''
+}
 
 export { getValidationText }


### PR DESCRIPTION
This fixes the display of field specific submitErrors (see here: [meta.submitError](https://final-form.org/docs/react-final-form/types/FieldRenderProps)). The hasError helper is already dealing with this properly, since it looks at meta.invalid and that's triggered for validation and submission errors.

Using if blocks instead of an expression here for readability, since otherwise it got quite long and difficult to parse. Plus, this only returns the value if it's truthy, slightly different logic, but should be the same in practice (since the values should only be strings and it returns `''` at the end).

I noticed the forms tests aren't being run (or it seems like it): https://dhis2.slack.com/archives/CBM8LNEQM/p1587567537209200. After that's resolved I'll take a look at updating tests where necessary.

Closes #33