### PR TITLE
fix(prop-types): add missing dhis2 prop-types for ui-icons

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -18,6 +18,9 @@
     "scripts": {
         "build": "d2-app-scripts build"
     },
+    "dependencies": {
+        "@dhis2/prop-types": "^1.6.4"
+    },
     "files": [
         "build"
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1473,7 +1473,7 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/prop-types@^1.5", "@dhis2/prop-types@^1.5.0", "@dhis2/prop-types@^1.6.4":
+"@dhis2/prop-types@^1.5", "@dhis2/prop-types@^1.6.4":
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.6.4.tgz#ec4d256c9440d4d00071524422a727c61ddaa6f6"
   integrity sha512-qkVj8OuyjDmSxzYDlCWZllvC9hIbrIImMp79/U5CVsIRbjUF0zA/tfbv4rWnsWALmwEHOQFbzl5GnO5D8RNneA==


### PR DESCRIPTION
See slack here: https://dhis2.slack.com/archives/CPGUFVC56/p1588258220328000

ui-icons uses `@dhis2/prop-types`, but doesn't bundle it. So it defaulted to the top level one, which in my case, was the wrong version. This PR fixes that.