### PR TITLE
feat(widgets): add default translated texts

### DIFF
--- a/cypress/integration/FileInputField/has_default_button_label.feature
+++ b/cypress/integration/FileInputField/has_default_button_label.feature
@@ -1,0 +1,5 @@
+Feature: Button label for the FileInputField
+
+    Scenario: Rendering a FileInputField
+        Given a default FileInputField is rendered
+        Then the default button label is visible

--- a/cypress/integration/FileInputField/has_default_button_label/index.js
+++ b/cypress/integration/FileInputField/has_default_button_label/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a default FileInputField is rendered', () => {
+    cy.visitStory('FileInputField', 'Default')
+})
+
+Then('the default button label is visible', () => {
+    cy.contains('Upload a file').should('be.visible')
+})

--- a/cypress/integration/FileInputField/has_default_placeholder.feature
+++ b/cypress/integration/FileInputField/has_default_placeholder.feature
@@ -1,0 +1,5 @@
+Feature: Placeholder for the FileInputField
+
+    Scenario: Rendering a FileInputField
+        Given a default FileInputField is rendered
+        Then the default placeholder is visible

--- a/cypress/integration/FileInputField/has_default_placeholder/index.js
+++ b/cypress/integration/FileInputField/has_default_placeholder/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a default FileInputField is rendered', () => {
+    cy.visitStory('FileInputField', 'Default')
+})
+
+Then('the default placeholder is visible', () => {
+    cy.contains('No file uploaded yet').should('be.visible')
+})

--- a/cypress/integration/FileInputFieldWithList/has_default_button_label.feature
+++ b/cypress/integration/FileInputFieldWithList/has_default_button_label.feature
@@ -1,0 +1,5 @@
+Feature: Button label for the FileInputFieldWithList
+
+    Scenario: Rendering a FileInputFieldWithList
+        Given a default FileInputFieldWithList is rendered
+        Then the default button label is visible

--- a/cypress/integration/FileInputFieldWithList/has_default_button_label/index.js
+++ b/cypress/integration/FileInputFieldWithList/has_default_button_label/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a default FileInputFieldWithList is rendered', () => {
+    cy.visitStory('FileInputFieldWithList', 'With default texts')
+})
+
+Then('the default button label is visible', () => {
+    cy.contains('Upload a file').should('be.visible')
+})

--- a/cypress/integration/FileInputFieldWithList/has_default_placeholder.feature
+++ b/cypress/integration/FileInputFieldWithList/has_default_placeholder.feature
@@ -1,0 +1,5 @@
+Feature: Placeholder for the FileInputFieldWithList
+
+    Scenario: Rendering a FileInputFieldWithList
+        Given a default FileInputFieldWithList is rendered
+        Then the default placeholder is visible

--- a/cypress/integration/FileInputFieldWithList/has_default_placeholder/index.js
+++ b/cypress/integration/FileInputFieldWithList/has_default_placeholder/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a default FileInputFieldWithList is rendered', () => {
+    cy.visitStory('FileInputFieldWithList', 'With default texts')
+})
+
+Then('the default placeholder is visible', () => {
+    cy.contains('No file uploaded yet').should('be.visible')
+})

--- a/cypress/integration/FileInputFieldWithList/has_default_remove_text.feature
+++ b/cypress/integration/FileInputFieldWithList/has_default_remove_text.feature
@@ -1,0 +1,5 @@
+Feature: Placeholder for the FileInputFieldWithList
+
+    Scenario: Rendering a FileInputFieldWithList
+        Given a default FileInputFieldWithList is rendered
+        Then the default remove text is visible

--- a/cypress/integration/FileInputFieldWithList/has_default_remove_text/index.js
+++ b/cypress/integration/FileInputFieldWithList/has_default_remove_text/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a default FileInputFieldWithList is rendered', () => {
+    cy.visitStory('FileInputFieldWithList', 'With file and default texts')
+})
+
+Then('the default remove text is visible', () => {
+    cy.contains('Remove').should('be.visible')
+})

--- a/cypress/integration/MultiSelectField/has_default_clear_text.feature
+++ b/cypress/integration/MultiSelectField/has_default_clear_text.feature
@@ -1,0 +1,5 @@
+Feature: Clear text for the MultiSelectField
+
+    Scenario: Rendering a clearable MultiSelectField
+        Given a clearable MultiSelectField with selected option is rendered
+        Then the clear text is visible

--- a/cypress/integration/MultiSelectField/has_default_clear_text/index.js
+++ b/cypress/integration/MultiSelectField/has_default_clear_text/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a clearable MultiSelectField with selected option is rendered', () => {
+    cy.visitStory('MultiSelectField', 'With clearable and selected option')
+})
+
+Then('the clear text is visible', () => {
+    cy.contains('Clear').should('be.visible')
+})

--- a/cypress/integration/MultiSelectField/has_default_empty_text.feature
+++ b/cypress/integration/MultiSelectField/has_default_empty_text.feature
@@ -1,0 +1,6 @@
+Feature: Empty text for the MultiSelectField
+
+    Scenario: Rendering an empty MultiSelectField
+        Given an empty MultiSelectField is rendered
+        When the Select is opened
+        Then the empty text is visible

--- a/cypress/integration/MultiSelectField/has_default_empty_text/index.js
+++ b/cypress/integration/MultiSelectField/has_default_empty_text/index.js
@@ -1,0 +1,13 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an empty MultiSelectField is rendered', () => {
+    cy.visitStory('MultiSelectField', 'Without options')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+Then('the empty text is visible', () => {
+    cy.contains('No data found').should('be.visible')
+})

--- a/cypress/integration/MultiSelectField/has_default_filter_nomatch_text.feature
+++ b/cypress/integration/MultiSelectField/has_default_filter_nomatch_text.feature
@@ -1,0 +1,7 @@
+Feature: Nomatchtext for the MultiSelectField
+
+    Scenario: Rendering a filterable MultiSelectField
+        Given a filterable MultiSelectField is rendered
+        When the Select is opened
+        And a filter that does not match any options is entered
+        Then the no match text is visible

--- a/cypress/integration/MultiSelectField/has_default_filter_nomatch_text/index.js
+++ b/cypress/integration/MultiSelectField/has_default_filter_nomatch_text/index.js
@@ -1,0 +1,17 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a filterable MultiSelectField is rendered', () => {
+    cy.visitStory('MultiSelectField', 'With filterable')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+When('a filter that does not match any options is entered', () => {
+    cy.focused().type('Two')
+})
+
+Then('the no match text is visible', () => {
+    cy.contains('No options found').should('be.visible')
+})

--- a/cypress/integration/MultiSelectField/has_default_filter_placeholder.feature
+++ b/cypress/integration/MultiSelectField/has_default_filter_placeholder.feature
@@ -1,0 +1,6 @@
+Feature: Filter placeholder for the MultiSelectField
+
+    Scenario: Rendering a filterable MultiSelectField
+        Given a filterable MultiSelectField is rendered
+        When the Select is opened
+        Then the filter placeholder exists

--- a/cypress/integration/MultiSelectField/has_default_filter_placeholder/index.js
+++ b/cypress/integration/MultiSelectField/has_default_filter_placeholder/index.js
@@ -1,0 +1,15 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a filterable MultiSelectField is rendered', () => {
+    cy.visitStory('MultiSelectField', 'With filterable')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+Then('the filter placeholder exists', () => {
+    cy.get(
+        '[data-test="dhis2-uicore-multiselect-filterinput"] [placeholder="Type to filter options"]'
+    ).should('exist')
+})

--- a/cypress/integration/MultiSelectField/has_default_loading_text.feature
+++ b/cypress/integration/MultiSelectField/has_default_loading_text.feature
@@ -1,0 +1,6 @@
+Feature: Filter placeholder for the MultiSelectField
+
+    Scenario: Rendering a filterable MultiSelectField
+        Given a loading MultiSelectField is rendered
+        When the Select is opened
+        Then the loading text is visible

--- a/cypress/integration/MultiSelectField/has_default_loading_text/index.js
+++ b/cypress/integration/MultiSelectField/has_default_loading_text/index.js
@@ -1,0 +1,13 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a loading MultiSelectField is rendered', () => {
+    cy.visitStory('MultiSelectField', 'With loading')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+Then('the loading text is visible', () => {
+    cy.contains('Loading options').should('be.visible')
+})

--- a/cypress/integration/SingleSelectField/has_default_clear_text.feature
+++ b/cypress/integration/SingleSelectField/has_default_clear_text.feature
@@ -1,0 +1,5 @@
+Feature: Clear text for the SingleSelectField
+
+    Scenario: Rendering a clearable SingleSelectField
+        Given a clearable SingleSelectField with selected option is rendered
+        Then the clear text is visible

--- a/cypress/integration/SingleSelectField/has_default_clear_text/index.js
+++ b/cypress/integration/SingleSelectField/has_default_clear_text/index.js
@@ -1,0 +1,9 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a clearable SingleSelectField with selected option is rendered', () => {
+    cy.visitStory('SingleSelectField', 'With clearable and selected option')
+})
+
+Then('the clear text is visible', () => {
+    cy.contains('Clear').should('be.visible')
+})

--- a/cypress/integration/SingleSelectField/has_default_empty_text.feature
+++ b/cypress/integration/SingleSelectField/has_default_empty_text.feature
@@ -1,0 +1,6 @@
+Feature: Empty text for the SingleSelectField
+
+    Scenario: Rendering an empty SingleSelectField
+        Given an empty SingleSelectField is rendered
+        When the Select is opened
+        Then the empty text is visible

--- a/cypress/integration/SingleSelectField/has_default_empty_text/index.js
+++ b/cypress/integration/SingleSelectField/has_default_empty_text/index.js
@@ -1,0 +1,13 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('an empty SingleSelectField is rendered', () => {
+    cy.visitStory('SingleSelectField', 'Without options')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+Then('the empty text is visible', () => {
+    cy.contains('No data found').should('be.visible')
+})

--- a/cypress/integration/SingleSelectField/has_default_filter_nomatch_text.feature
+++ b/cypress/integration/SingleSelectField/has_default_filter_nomatch_text.feature
@@ -1,0 +1,7 @@
+Feature: Nomatchtext for the SingleSelectField
+
+    Scenario: Rendering a filterable SingleSelectField
+        Given a filterable SingleSelectField is rendered
+        When the Select is opened
+        And a filter that does not match any options is entered
+        Then the no match text is visible

--- a/cypress/integration/SingleSelectField/has_default_filter_nomatch_text/index.js
+++ b/cypress/integration/SingleSelectField/has_default_filter_nomatch_text/index.js
@@ -1,0 +1,17 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a filterable SingleSelectField is rendered', () => {
+    cy.visitStory('SingleSelectField', 'With filterable')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+When('a filter that does not match any options is entered', () => {
+    cy.focused().type('Two')
+})
+
+Then('the no match text is visible', () => {
+    cy.contains('No options found').should('be.visible')
+})

--- a/cypress/integration/SingleSelectField/has_default_filter_placeholder.feature
+++ b/cypress/integration/SingleSelectField/has_default_filter_placeholder.feature
@@ -1,0 +1,6 @@
+Feature: Filter placeholder for the SingleSelectField
+
+    Scenario: Rendering a filterable SingleSelectField
+        Given a filterable SingleSelectField is rendered
+        When the Select is opened
+        Then the filter placeholder exists

--- a/cypress/integration/SingleSelectField/has_default_filter_placeholder/index.js
+++ b/cypress/integration/SingleSelectField/has_default_filter_placeholder/index.js
@@ -1,0 +1,15 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a filterable SingleSelectField is rendered', () => {
+    cy.visitStory('SingleSelectField', 'With filterable')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+Then('the filter placeholder exists', () => {
+    cy.get(
+        '[data-test="dhis2-uicore-singleselect-filterinput"] [placeholder="Type to filter options"]'
+    ).should('exist')
+})

--- a/cypress/integration/SingleSelectField/has_default_loading_text.feature
+++ b/cypress/integration/SingleSelectField/has_default_loading_text.feature
@@ -1,0 +1,6 @@
+Feature: Filter placeholder for the SingleSelectField
+
+    Scenario: Rendering a filterable SingleSelectField
+        Given a loading SingleSelectField is rendered
+        When the Select is opened
+        Then the loading text is visible

--- a/cypress/integration/SingleSelectField/has_default_loading_text/index.js
+++ b/cypress/integration/SingleSelectField/has_default_loading_text/index.js
@@ -1,0 +1,13 @@
+import { Given, Then, When } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a loading SingleSelectField is rendered', () => {
+    cy.visitStory('SingleSelectField', 'With loading')
+})
+
+When('the Select is opened', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').click()
+})
+
+Then('the loading text is visible', () => {
+    cy.contains('Loading options').should('be.visible')
+})

--- a/packages/widgets/i18n/en.pot
+++ b/packages/widgets/i18n/en.pot
@@ -5,8 +5,17 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-02-18T13:19:29.126Z\n"
-"PO-Revision-Date: 2020-02-18T13:19:29.126Z\n"
+"POT-Creation-Date: 2020-05-14T13:50:41.269Z\n"
+"PO-Revision-Date: 2020-05-14T13:50:41.269Z\n"
+
+msgid "Upload a file"
+msgstr ""
+
+msgid "No file uploaded yet"
+msgstr ""
+
+msgid "Remove"
+msgstr ""
 
 msgid "Search apps"
 msgstr ""
@@ -29,5 +38,20 @@ msgstr ""
 msgid "Logout"
 msgstr ""
 
-msgid "Something went wrong with loading the children."
+msgid "Clear"
+msgstr ""
+
+msgid "No data found"
+msgstr ""
+
+msgid "Type to filter options"
+msgstr ""
+
+msgid "Loading options"
+msgstr ""
+
+msgid "No options found"
+msgstr ""
+
+msgid "Could not load children"
 msgstr ""

--- a/packages/widgets/src/FileInputField/FileInputField.js
+++ b/packages/widgets/src/FileInputField/FileInputField.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
+import i18n from '@dhis2/d2-i18n'
 
 import { sharedPropTypes } from '@dhis2/ui-constants'
 
@@ -10,6 +11,7 @@ import {
     Field,
     Label,
 } from '@dhis2/ui-core'
+import translate from '../translate'
 
 /**
  * @module
@@ -63,7 +65,7 @@ const FileInputField = ({
 
         <FileInput
             accept={accept}
-            buttonLabel={buttonLabel}
+            buttonLabel={translate(buttonLabel)}
             className={className}
             disabled={disabled}
             error={error}
@@ -81,10 +83,12 @@ const FileInputField = ({
         />
 
         <FileList>
-            {!children && placeholder ? (
-                <FileListPlaceholder>{placeholder}</FileListPlaceholder>
-            ) : (
+            {children ? (
                 children
+            ) : (
+                <FileListPlaceholder>
+                    {translate(placeholder)}
+                </FileListPlaceholder>
             )}
         </FileList>
     </Field>
@@ -93,6 +97,9 @@ const FileInputField = ({
 FileInputField.defaultProps = {
     accept: '*',
     dataTest: 'dhis2-uiwidgets-fileinputfield',
+
+    buttonLabel: () => i18n.t('Upload a file'),
+    placeholder: () => i18n.t('No file uploaded yet'),
 }
 
 /**
@@ -104,9 +111,9 @@ FileInputField.defaultProps = {
  * @prop {function} [onBlur]
  * @prop {function} [onFocus]
  * @prop {string} [label]
- * @prop {string} [buttonLabel]
+ * @prop {string|function} [buttonLabel]
  * @prop {string} [className]
- * @prop {string} [placeholder]
+ * @prop {string|function} [placeholder]
  * @prop {string} [tabIndex]
  *
  * @prop {boolean} [required]
@@ -130,7 +137,7 @@ FileInputField.defaultProps = {
  */
 FileInputField.propTypes = {
     accept: propTypes.string,
-    buttonLabel: propTypes.string,
+    buttonLabel: propTypes.oneOfType([propTypes.string, propTypes.func]),
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
@@ -142,7 +149,7 @@ FileInputField.propTypes = {
     large: sharedPropTypes.sizePropType,
     multiple: propTypes.bool,
     name: propTypes.string,
-    placeholder: propTypes.string,
+    placeholder: propTypes.oneOfType([propTypes.string, propTypes.func]),
     required: propTypes.bool,
     small: sharedPropTypes.sizePropType,
     tabIndex: propTypes.string,

--- a/packages/widgets/src/FileInputField/FileInputField.stories.e2e.js
+++ b/packages/widgets/src/FileInputField/FileInputField.stories.e2e.js
@@ -2,11 +2,15 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { FileInputField } from './FileInputField.js'
 
-storiesOf('FileInputField', module).add('With label and required', () => (
-    <FileInputField
-        name="upload"
-        label="upload something"
-        buttonLabel="Upload file"
-        required
-    />
-))
+storiesOf('FileInputField', module)
+    .add('With label and required', () => (
+        <FileInputField
+            name="upload"
+            label="upload something"
+            buttonLabel="Upload file"
+            required
+        />
+    ))
+    .add('Default', () => (
+        <FileInputField name="upload" label="upload something" />
+    ))

--- a/packages/widgets/src/FileInputField/FileInputField.stories.js
+++ b/packages/widgets/src/FileInputField/FileInputField.stories.js
@@ -207,3 +207,6 @@ storiesOf('Components/Widgets/FileInputField', module)
             name="upload"
         />
     ))
+    .add('Default: buttonLabel and placeholder', () => (
+        <FileInputField onChange={onChange} name="upload" />
+    ))

--- a/packages/widgets/src/FileInputFieldWithList/FileInputFieldWithList.js
+++ b/packages/widgets/src/FileInputFieldWithList/FileInputFieldWithList.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
 import propTypes from '@dhis2/prop-types'
 import { sharedPropTypes } from '@dhis2/ui-constants'
+import i18n from '@dhis2/d2-i18n'
 
 import { FileInputField } from '../FileInputField/FileInputField.js'
-
 import { FileListItemWithRemove } from './FileListItemWithRemove.js'
+import translate from '../translate'
 
 /**
  * @module
@@ -92,7 +93,7 @@ class FileInputFieldWithList extends Component {
         return (
             <FileInputField
                 accept={accept}
-                buttonLabel={buttonLabel}
+                buttonLabel={translate(buttonLabel)}
                 className={className}
                 dataTest={dataTest}
                 disabled={disabled || (!multiple && files.length >= 1)}
@@ -106,7 +107,7 @@ class FileInputFieldWithList extends Component {
                 onBlur={onBlur}
                 onChange={this.handleChange}
                 onFocus={onFocus}
-                placeholder={placeholder}
+                placeholder={translate(placeholder)}
                 required={required}
                 small={small}
                 tabIndex={tabIndex}
@@ -114,15 +115,16 @@ class FileInputFieldWithList extends Component {
                 validationText={validationText}
                 warning={warning}
             >
-                {files.map(file => (
-                    <FileListItemWithRemove
-                        key={file.name}
-                        label={file.name}
-                        removeText={removeText}
-                        onRemove={this.handleRemove}
-                        file={file}
-                    />
-                ))}
+                {files.length > 0 &&
+                    files.map(file => (
+                        <FileListItemWithRemove
+                            key={file.name}
+                            label={file.name}
+                            removeText={translate(removeText)}
+                            onRemove={this.handleRemove}
+                            file={file}
+                        />
+                    ))}
             </FileInputField>
         )
     }
@@ -131,22 +133,26 @@ class FileInputFieldWithList extends Component {
 FileInputFieldWithList.defaultProps = {
     dataTest: 'dhis2-uiwidgets-fileinputfieldwithlist',
     files: [],
+
+    buttonLabel: () => i18n.t('Upload a file'),
+    placeholder: () => i18n.t('No file uploaded yet'),
+    removeText: () => i18n.t('Remove'),
 }
 
 /**
  * @typedef {Object} PropTypes
  * @static
  *
- * @prop {string} [removeText]
+ * @prop {string|function} [removeText]
  * @prop {function} onChange
  * @prop {Array<File>} [files=[]] - an array of File instances (NOTE: not a FileList instance)
  * @prop {string} [name]
  * @prop {function} [onBlur]
  * @prop {function} [onFocus]
  * @prop {string} [label]
- * @prop {string} [buttonLabel]
+ * @prop {string|function} [buttonLabel]
  * @prop {string} [className]
- * @prop {string} [placeholder]
+ * @prop {string|function} [placeholder]
  * @prop {string} [tabIndex]
  *
  * @prop {boolean} [required]
@@ -171,7 +177,7 @@ FileInputFieldWithList.defaultProps = {
 FileInputFieldWithList.propTypes = {
     onChange: propTypes.func.isRequired,
     accept: propTypes.string,
-    buttonLabel: propTypes.string,
+    buttonLabel: propTypes.oneOfType([propTypes.string, propTypes.func]),
     className: propTypes.string,
     dataTest: propTypes.string,
     disabled: propTypes.bool,
@@ -183,8 +189,8 @@ FileInputFieldWithList.propTypes = {
     large: sharedPropTypes.sizePropType,
     multiple: propTypes.bool,
     name: propTypes.string,
-    placeholder: propTypes.string,
-    removeText: propTypes.string,
+    placeholder: propTypes.oneOfType([propTypes.string, propTypes.func]),
+    removeText: propTypes.oneOfType([propTypes.string, propTypes.func]),
     required: propTypes.bool,
     small: sharedPropTypes.sizePropType,
     tabIndex: propTypes.string,

--- a/packages/widgets/src/FileInputFieldWithList/FileInputFieldWithList.stories.e2e.js
+++ b/packages/widgets/src/FileInputFieldWithList/FileInputFieldWithList.stories.e2e.js
@@ -62,3 +62,13 @@ storiesOf('FileInputFieldWithList', module)
             onChange={onChange}
         />
     ))
+    .add('With file and default texts', () => (
+        <FileInputFieldWithList
+            name="upload"
+            files={singleFileArray}
+            onChange={onChange}
+        />
+    ))
+    .add('With default texts', () => (
+        <FileInputFieldWithList name="upload" onChange={onChange} />
+    ))

--- a/packages/widgets/src/FileInputFieldWithList/FileInputFieldWithList.stories.js
+++ b/packages/widgets/src/FileInputFieldWithList/FileInputFieldWithList.stories.js
@@ -10,9 +10,8 @@ const onChange = ({ files }) => {
     console.log('files: ', files)
 }
 
-storiesOf('Components/Widgets/FileInputFieldWithList', module).add(
-    'Default',
-    () => (
+storiesOf('Components/Widgets/FileInputFieldWithList', module)
+    .add('Default', () => (
         <FileInputFieldWithList
             multiple
             onChange={onChange}
@@ -21,5 +20,15 @@ storiesOf('Components/Widgets/FileInputFieldWithList', module).add(
             files={files}
             removeText="remove"
         />
-    )
-)
+    ))
+    .add('Default: buttonLabel and removeText', () => (
+        <FileInputFieldWithList
+            multiple
+            onChange={onChange}
+            name="upload"
+            files={files}
+        />
+    ))
+    .add('Default: placeholder', () => (
+        <FileInputFieldWithList multiple onChange={onChange} name="upload" />
+    ))

--- a/packages/widgets/src/MultiSelectField/MultiSelectField.js
+++ b/packages/widgets/src/MultiSelectField/MultiSelectField.js
@@ -1,8 +1,10 @@
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
 
+import i18n from '@dhis2/d2-i18n'
 import { sharedPropTypes } from '@dhis2/ui-constants'
 import { Field, Box, MultiSelect } from '@dhis2/ui-core'
+import translate from '../translate'
 
 /**
  * @module
@@ -80,14 +82,14 @@ class MultiSelectField extends React.Component {
                         valid={valid}
                         disabled={disabled}
                         clearable={clearable}
-                        clearText={clearText}
+                        clearText={translate(clearText)}
                         filterable={filterable}
-                        filterPlaceholder={filterPlaceholder}
+                        filterPlaceholder={translate(filterPlaceholder)}
                         placeholder={placeholder}
                         prefix={prefix}
-                        empty={empty}
-                        loadingText={loadingText}
-                        noMatchText={noMatchText}
+                        empty={translate(empty)}
+                        loadingText={translate(loadingText)}
+                        noMatchText={translate(noMatchText)}
                         initialFocus={initialFocus}
                         dense={dense}
                     >
@@ -102,6 +104,12 @@ class MultiSelectField extends React.Component {
 MultiSelectField.defaultProps = {
     selected: [],
     dataTest: 'dhis2-uiwidgets-multiselectfield',
+
+    clearText: () => i18n.t('Clear'),
+    empty: () => i18n.t('No data found'),
+    filterPlaceholder: () => i18n.t('Type to filter options'),
+    loadingText: () => i18n.t('Loading options'),
+    noMatchText: () => i18n.t('No options found'),
 }
 
 /**
@@ -126,16 +134,16 @@ MultiSelectField.defaultProps = {
  * @prop {boolean} [initialFocus]
  * @prop {string} [validationText]
  * @prop {string} [helpText]
- * @prop {string} [clearText] - Only required if clearable is true
+ * @prop {string|function} [clearText]
  * @prop {boolean} [clearable]
- * @prop {Node} [empty]
- * @prop {string} [filterPlaceholder]
+ * @prop {Node|function} [empty]
+ * @prop {string|function} [filterPlaceholder]
  * @prop {boolean} [filterable]
- * @prop {string} [loadingText]
+ * @prop {string|function} [loadingText]
  * @prop {string} [maxHeight]
  * @prop {string} [inputMaxHeight]
  * @prop {string} [inputWidth]
- * @prop {string} [noMatchText] - Only required if filterable is true
+ * @prop {string|function} [noMatchText]
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
  * @prop {string} [dataTest]
@@ -143,14 +151,14 @@ MultiSelectField.defaultProps = {
 MultiSelectField.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
-    clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
+    clearText: propTypes.oneOfType([propTypes.string, propTypes.func]),
     clearable: propTypes.bool,
     dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
-    empty: propTypes.node,
+    empty: propTypes.oneOfType([propTypes.node, propTypes.func]),
     error: sharedPropTypes.statusPropType,
-    filterPlaceholder: propTypes.string,
+    filterPlaceholder: propTypes.oneOfType([propTypes.node, propTypes.func]),
     filterable: propTypes.bool,
     helpText: propTypes.string,
     initialFocus: propTypes.bool,
@@ -158,12 +166,9 @@ MultiSelectField.propTypes = {
     inputWidth: propTypes.string,
     label: propTypes.string,
     loading: propTypes.bool,
-    loadingText: propTypes.string,
+    loadingText: propTypes.oneOfType([propTypes.string, propTypes.func]),
     maxHeight: propTypes.string,
-    noMatchText: propTypes.requiredIf(
-        props => props.filterable,
-        propTypes.string
-    ),
+    noMatchText: propTypes.oneOfType([propTypes.string, propTypes.func]),
     placeholder: propTypes.string,
     prefix: propTypes.string,
     required: propTypes.bool,

--- a/packages/widgets/src/MultiSelectField/MultiSelectField.stories.e2e.js
+++ b/packages/widgets/src/MultiSelectField/MultiSelectField.stories.e2e.js
@@ -34,3 +34,15 @@ storiesOf('MultiSelectField', module)
             <MultiSelectOption value="3" label="three" />
         </MultiSelectField>
     ))
+    .add('With clearable and selected option', () => (
+        <MultiSelectField selected={['1']} clearable>
+            <MultiSelectOption key="1" value="1" label="One" />
+        </MultiSelectField>
+    ))
+    .add('With filterable', () => (
+        <MultiSelectField filterable>
+            <MultiSelectOption key="1" value="1" label="One" />
+        </MultiSelectField>
+    ))
+    .add('With loading', () => <MultiSelectField loading />)
+    .add('Without options', () => <MultiSelectField />)

--- a/packages/widgets/src/MultiSelectField/MultiSelectField.stories.js
+++ b/packages/widgets/src/MultiSelectField/MultiSelectField.stories.js
@@ -79,3 +79,17 @@ storiesOf('Components/Widgets/MultiSelectField', module)
             {options}
         </MultiSelectField>
     ))
+    .add('Default: clearText', () => (
+        <MultiSelectField selected={['1']} clearable>
+            <MultiSelectOption
+                key="1"
+                value="1"
+                label="Not translated, just for showing clear button"
+            />
+        </MultiSelectField>
+    ))
+    .add('Default: filterPlaceholder and noMatchText', () => (
+        <MultiSelectField filterable />
+    ))
+    .add('Default: loadingText', () => <MultiSelectField loading />)
+    .add('Default: empty', () => <MultiSelectField />)

--- a/packages/widgets/src/SingleSelectField/SingleSelectField.js
+++ b/packages/widgets/src/SingleSelectField/SingleSelectField.js
@@ -1,8 +1,10 @@
 import React from 'react'
 
+import i18n from '@dhis2/d2-i18n'
 import propTypes from '@dhis2/prop-types'
 import { Field, SingleSelect, Box } from '@dhis2/ui-core'
 import { sharedPropTypes } from '@dhis2/ui-constants'
+import translate from '../translate'
 
 /**
  * @module
@@ -80,14 +82,14 @@ class SingleSelectField extends React.Component {
                         valid={valid}
                         disabled={disabled}
                         clearable={clearable}
-                        clearText={clearText}
+                        clearText={translate(clearText)}
                         filterable={filterable}
-                        filterPlaceholder={filterPlaceholder}
+                        filterPlaceholder={translate(filterPlaceholder)}
                         placeholder={placeholder}
                         prefix={prefix}
-                        empty={empty}
-                        loadingText={loadingText}
-                        noMatchText={noMatchText}
+                        empty={translate(empty)}
+                        loadingText={translate(loadingText)}
+                        noMatchText={translate(noMatchText)}
                         initialFocus={initialFocus}
                         dense={dense}
                     >
@@ -100,8 +102,14 @@ class SingleSelectField extends React.Component {
 }
 
 SingleSelectField.defaultProps = {
-    selected: '',
     dataTest: 'dhis2-uiwidgets-singleselectfield',
+    selected: '',
+
+    clearText: () => i18n.t('Clear'),
+    empty: () => i18n.t('No data found'),
+    filterPlaceholder: () => i18n.t('Type to filter options'),
+    loadingText: () => i18n.t('Loading options'),
+    noMatchText: () => i18n.t('No options found'),
 }
 
 /**
@@ -126,16 +134,16 @@ SingleSelectField.defaultProps = {
  * @prop {boolean} [initialFocus]
  * @prop {string} [validationText]
  * @prop {string} [helpText]
- * @prop {string} [clearText] - Only required if clearable is true
+ * @prop {string|function} [clearText]
  * @prop {boolean} [clearable]
- * @prop {Node} [empty]
- * @prop {string} [filterPlaceholder]
+ * @prop {Node|function} [empty]
+ * @prop {string|function} [filterPlaceholder]
  * @prop {boolean} [filterable]
- * @prop {string} [loadingText]
+ * @prop {string|function} [loadingText]
  * @prop {string} [maxHeight]
  * @prop {string} [inputMaxHeight]
  * @prop {string} [inputWidth]
- * @prop {string} [noMatchText] - Only required if filterable is true
+ * @prop {string|function} [noMatchText]
  * @prop {string} [placeholder]
  * @prop {string} [prefix]
  * @prop {string} [dataTest]
@@ -143,14 +151,14 @@ SingleSelectField.defaultProps = {
 SingleSelectField.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
-    clearText: propTypes.requiredIf(props => props.clearable, propTypes.string),
+    clearText: propTypes.oneOfType([propTypes.string, propTypes.func]),
     clearable: propTypes.bool,
     dataTest: propTypes.string,
     dense: propTypes.bool,
     disabled: propTypes.bool,
-    empty: propTypes.node,
+    empty: propTypes.oneOfType([propTypes.node, propTypes.func]),
     error: sharedPropTypes.statusPropType,
-    filterPlaceholder: propTypes.string,
+    filterPlaceholder: propTypes.oneOfType([propTypes.node, propTypes.func]),
     filterable: propTypes.bool,
     helpText: propTypes.string,
     initialFocus: propTypes.bool,
@@ -158,12 +166,9 @@ SingleSelectField.propTypes = {
     inputWidth: propTypes.string,
     label: propTypes.string,
     loading: propTypes.bool,
-    loadingText: propTypes.string,
+    loadingText: propTypes.oneOfType([propTypes.string, propTypes.func]),
     maxHeight: propTypes.string,
-    noMatchText: propTypes.requiredIf(
-        props => props.filterable,
-        propTypes.string
-    ),
+    noMatchText: propTypes.oneOfType([propTypes.string, propTypes.func]),
     placeholder: propTypes.string,
     prefix: propTypes.string,
     required: propTypes.bool,

--- a/packages/widgets/src/SingleSelectField/SingleSelectField.stories.e2e.js
+++ b/packages/widgets/src/SingleSelectField/SingleSelectField.stories.e2e.js
@@ -34,3 +34,15 @@ storiesOf('SingleSelectField', module)
             <SingleSelectOption value="3" label="three" />
         </SingleSelectField>
     ))
+    .add('With clearable and selected option', () => (
+        <SingleSelectField selected="1" clearable>
+            <SingleSelectOption key="1" value="1" label="One" />
+        </SingleSelectField>
+    ))
+    .add('With filterable', () => (
+        <SingleSelectField filterable>
+            <SingleSelectOption key="1" value="1" label="One" />
+        </SingleSelectField>
+    ))
+    .add('With loading', () => <SingleSelectField loading />)
+    .add('Without options', () => <SingleSelectField />)

--- a/packages/widgets/src/SingleSelectField/SingleSelectField.stories.js
+++ b/packages/widgets/src/SingleSelectField/SingleSelectField.stories.js
@@ -78,3 +78,17 @@ storiesOf('Components/Widgets/SingleSelectField', module)
             {options}
         </SingleSelectField>
     ))
+    .add('Default: clearText', () => (
+        <SingleSelectField selected="1" clearable>
+            <SingleSelectOption
+                key="1"
+                value="1"
+                label="Not translated, just for showing clear button"
+            />
+        </SingleSelectField>
+    ))
+    .add('Default: filterPlaceholder and noMatchText', () => (
+        <SingleSelectField filterable />
+    ))
+    .add('Default: loadingText', () => <SingleSelectField loading />)
+    .add('Default: empty', () => <SingleSelectField />)

--- a/packages/widgets/src/translate/__tests__/index.test.js
+++ b/packages/widgets/src/translate/__tests__/index.test.js
@@ -1,0 +1,17 @@
+import translate from '../index.js'
+
+describe('translate', () => {
+    it('should call prop and return the result if it is a function', () => {
+        const spy = jest.fn(() => 'translated string')
+        const result = translate(spy)
+
+        expect(spy).toHaveBeenCalled()
+        expect(result).toBe('translated string')
+    })
+
+    it('should return prop as is if it is not a function', () => {
+        const result = translate('just a string')
+
+        expect(result).toBe('just a string')
+    })
+})

--- a/packages/widgets/src/translate/index.js
+++ b/packages/widgets/src/translate/index.js
@@ -1,0 +1,19 @@
+/*
+ * This allows us to delay calling i18n.t until after the
+ * language has been set. Otherwise the translations could
+ * potentially use the wrong language.
+ *
+ * It checks if the passed prop is a function. If so,
+ * it'll execute it. Since this should only be called during
+ * render, we can be certain that i18n will have initialized.
+ */
+
+const translate = prop => {
+    if (typeof prop === 'function') {
+        return prop()
+    }
+
+    return prop
+}
+
+export default translate


### PR DESCRIPTION
This adds default, translated texts for our widgets, where appropriate. So say, a placeholder for a filter input. Usually devs will leave those types of placeholders as is, so it makes sense for us to set a proper default.

Since we're not relying on the namespace being set correctly when the modules are parsed, we're delaying the call to i18n.t by allowing a function as prop for the translatable texts. A potential follow up: do we want to allow that for all our string/renderable text props, so that our users can do the same?

Currently I'm just changing things in widgets, so core components are not affected for the time being.

See also: https://dhis2.slack.com/archives/CBM8LNEQM/p1588767905388900 (translations)

Todo:

- [x] multiselect
- [x] singleselect
- [x] What do we do with props that accept a node (like the Select's empty prop)?
- [x] organisationunittree (doesn't seem like it needs translations?)
- [x] Add stories demonstrating texts
- [x] Add tests (verify that the translations work correctly)
- [x] Update jsdoc & prop-types
- [x] Verify the translations I've chosen (ask Joe)
- [x] Check if we can interpolate the filter noMatch text (unfortunately not with the current strategy)
- [x] Remove requiredif's everywhere
- [x] FileInput (verify translations, add demos and https://github.com/dhis2/ui/issues/70, technically there are duplicate translations, but they do make the components a bit more independent maybe?)

Follow up:

- [ ] allow func for all our string props?
- [ ] transfer?
- [ ] follow up fileinput (Cancel link (Cancel) & Loading state (Uploading))