### PR TITLE
fix: remove margin of first child conditionally for correct alignment

### DIFF
--- a/packages/core/src/ButtonStrip/ButtonStrip.js
+++ b/packages/core/src/ButtonStrip/ButtonStrip.js
@@ -58,14 +58,14 @@ ButtonStrip.defaultProps = {
  * @static
  *
  * @prop {string} [className]
- * @prop {Array.<Button>} [children]
+ * @prop {Node} [children]
  * @prop {boolean} [middle] - The props `middle`, and `end` are
  * mutually exlusive
  * @prop {boolean} [end]
  * @prop {string} [dataTest]
  */
 ButtonStrip.propTypes = {
-    children: propTypes.arrayOf(propTypes.element),
+    children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
     end: alignmentPropType,

--- a/packages/core/src/ButtonStrip/ButtonStrip.js
+++ b/packages/core/src/ButtonStrip/ButtonStrip.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Children } from 'react'
 import propTypes from '@dhis2/prop-types'
 import cx from 'classnames'
 
@@ -17,7 +17,9 @@ const ButtonStrip = ({ className, children, middle, end, dataTest }) => (
         className={cx(className, { start: !middle && !end, middle, end })}
         data-test={dataTest}
     >
-        {children}
+        {Children.map(children, child => (
+            <div className="box">{child}</div>
+        ))}
 
         <style jsx>{`
             div {
@@ -32,12 +34,11 @@ const ButtonStrip = ({ className, children, middle, end, dataTest }) => (
                 justify-content: flex-end;
             }
 
-            div > :global(button) {
+            .box {
                 margin-left: ${spacers.dp16};
             }
 
-            div.start > :global(button):first-child,
-            div.middle > :global(button):first-child {
+            .box:first-child {
                 margin-left: 0;
             }
         `}</style>

--- a/packages/core/src/ButtonStrip/ButtonStrip.js
+++ b/packages/core/src/ButtonStrip/ButtonStrip.js
@@ -13,21 +13,32 @@ import { spacers } from '@dhis2/ui-constants'
  * @see Live demo: {@link /demo/?path=/story/buttonstrip--default|Storybook}
  */
 const ButtonStrip = ({ className, children, middle, end, dataTest }) => (
-    <div className={cx(className, { middle, end })} data-test={dataTest}>
+    <div
+        className={cx(className, { start: !middle && !end, middle, end })}
+        data-test={dataTest}
+    >
         {children}
 
         <style jsx>{`
             div {
                 display: flex;
             }
+
             div.middle {
                 justify-content: center;
             }
+
             div.end {
                 justify-content: flex-end;
             }
+
             div > :global(button) {
                 margin-left: ${spacers.dp16};
+            }
+
+            div.start > :global(button):first-child,
+            div.middle > :global(button):first-child {
+                margin-left: 0;
             }
         `}</style>
     </div>

--- a/packages/core/src/ButtonStrip/ButtonStrip.stories.js
+++ b/packages/core/src/ButtonStrip/ButtonStrip.stories.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { ButtonStrip } from './ButtonStrip.js'
-import { Button } from '../index.js'
+import { Button, SplitButton } from '../index.js'
 
 const Wrapper = fn => (
     <div
         style={{
-            width: '450px',
+            display: 'inline-block',
             border: '1px solid #c4c9cc',
             padding: 8,
         }}
@@ -23,6 +23,7 @@ storiesOf('ButtonStrip', module)
             <Button>Save</Button>
             <Button>Save</Button>
             <Button>Save</Button>
+            <SplitButton>Label?</SplitButton>
         </ButtonStrip>
     ))
     .add('Default - aligned middle', () => (


### PR DESCRIPTION
Fixed #92 

I've also changed the prop type of `children` to `propTypes.node`, because a prop types error is thrown when providing only one child