### PR TITLE
test: use should for assertions

### DIFF
--- a/cypress/integration/AlertBar/api/hidden_callback.js
+++ b/cypress/integration/AlertBar/api/hidden_callback.js
@@ -11,7 +11,7 @@ When('the Alertbar is hidden', () => {
 })
 
 Then('the onHidden handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onHidden).to.be.calledOnce
         expect(win.onHidden).to.be.calledWith({}, null)
     })

--- a/cypress/integration/Button/can_be_blurred/index.js
+++ b/cypress/integration/Button/can_be_blurred/index.js
@@ -9,7 +9,7 @@ When('the Button is blurred', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledWith({
             value: 'default',
             name: 'Button',

--- a/cypress/integration/Button/can_be_clicked/index.js
+++ b/cypress/integration/Button/can_be_clicked/index.js
@@ -9,7 +9,7 @@ When('the Button is clicked', () => {
 })
 
 Then('the onClick handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).to.be.calledWith({
             name: 'Button',
             value: 'default',

--- a/cypress/integration/Button/can_be_focused/index.js
+++ b/cypress/integration/Button/can_be_focused/index.js
@@ -9,7 +9,7 @@ When('the Button is focused', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledWith({
             value: 'default',
             name: 'Button',

--- a/cypress/integration/Checkbox/can_be_blurred/index.js
+++ b/cypress/integration/Checkbox/can_be_blurred/index.js
@@ -9,7 +9,7 @@ When('the Checkbox is blurred', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Checkbox/can_be_changed/index.js
+++ b/cypress/integration/Checkbox/can_be_changed/index.js
@@ -9,7 +9,7 @@ When('the Checkbox is clicked', () => {
 })
 
 Then('the onChange handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Checkbox/can_be_disabled/index.js
+++ b/cypress/integration/Checkbox/can_be_disabled/index.js
@@ -9,7 +9,7 @@ When('the Checkbox is clicked', () => {
 })
 
 Then('the onClick handler is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).not.to.be.called
     })
 })

--- a/cypress/integration/Checkbox/can_be_focused/index.js
+++ b/cypress/integration/Checkbox/can_be_focused/index.js
@@ -9,7 +9,7 @@ When('the Checkbox is focused', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Checkbox/has_indeterminate_prop/index.js
+++ b/cypress/integration/Checkbox/has_indeterminate_prop/index.js
@@ -9,7 +9,7 @@ Given('the checkbox is not marked as indeterminate', () => {
 })
 
 Then("its input-element's indeterminate prop is {word}", bool => {
-    cy.get('input').then($input => {
+    cy.get('input').should($input => {
         if (bool === 'true') {
             expect($input[0].indeterminate).to.be.true
         } else {

--- a/cypress/integration/Chip/is_clickable/index.js
+++ b/cypress/integration/Chip/is_clickable/index.js
@@ -9,7 +9,7 @@ When('the Chip is clicked', () => {
 })
 
 Then('the onClick handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).to.be.calledWith({})
     })
 })

--- a/cypress/integration/Chip/is_removable/index.js
+++ b/cypress/integration/Chip/is_removable/index.js
@@ -9,7 +9,7 @@ When('the remove icon is clicked', () => {
 })
 
 Then('the onRemove handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onRemove).to.be.calledWith({})
     })
 })

--- a/cypress/integration/ComponentCover/click_behavior/index.js
+++ b/cypress/integration/ComponentCover/click_behavior/index.js
@@ -35,25 +35,25 @@ When('the user clicks on the button coordinates', () => {
 })
 
 Then('the onClick handler of the button is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onButtonClick).to.be.calledOnce
     })
 })
 
 Then('the onClick handler of the ComponentCover is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onComponentCoverClick).to.be.calledOnce
     })
 })
 
 Then('the onClick handler of the button is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onButtonClick).to.have.callCount(0)
     })
 })
 
 Then('the onClick handler of the ComponentCover is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onComponentCoverClick).to.have.callCount(0)
     })
 })

--- a/cypress/integration/DropdownButton/button_is_clickable/index.js
+++ b/cypress/integration/DropdownButton/button_is_clickable/index.js
@@ -6,7 +6,7 @@ Given('a DropdownButton with onClick handler is rendered', () => {
 })
 
 Then('the onClick handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).to.be.calledWith({
             name: 'Button',
             value: 'default',

--- a/cypress/integration/DropdownButton/can_be_disabled/index.js
+++ b/cypress/integration/DropdownButton/can_be_disabled/index.js
@@ -11,7 +11,7 @@ When('the DropdownButton is clicked', () => {
 })
 
 Then('the onClick handler is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).not.to.be.called
     })
 })

--- a/cypress/integration/FileInput/accepts_multiple_files/index.js
+++ b/cypress/integration/FileInput/accepts_multiple_files/index.js
@@ -16,8 +16,12 @@ When('the user selected multiple files', () => {
 })
 
 Then("the onChange handler's payload contains multiple files", () => {
-    cy.get('@payload').then(payload => {
+    cy.window().should(win => {
+        const calls = win.onChange.getCalls()
+        const callArgs = calls[0].args
+        const payload = callArgs[0]
         const files = payload.files
+
         expect(files).to.have.lengthOf(2)
 
         const file1 = files[0]

--- a/cypress/integration/FileInput/can_be_blurred/index.js
+++ b/cypress/integration/FileInput/can_be_blurred/index.js
@@ -10,11 +10,13 @@ When('the FileInput is blurred', () => {
 
 Then('the onBlur handler is called', () => {
     cy.window().then(win => {
-        cy.get('[data-test="dhis2-uicore-fileinput"] input').then(fileInput => {
-            expect(win.onBlur).to.be.calledWith({
-                name: 'upload',
-                files: fileInput[0].files,
-            })
-        })
+        cy.get('[data-test="dhis2-uicore-fileinput"] input').should(
+            fileInput => {
+                expect(win.onBlur).to.be.calledWith({
+                    name: 'upload',
+                    files: fileInput[0].files,
+                })
+            }
+        )
     })
 })

--- a/cypress/integration/FileInput/can_be_changed/index.js
+++ b/cypress/integration/FileInput/can_be_changed/index.js
@@ -13,8 +13,12 @@ When('a file is selected', () => {
 })
 
 Then("the onChange handler's payload contains the file", () => {
-    cy.get('@payload').then(payload => {
+    cy.window().should(win => {
+        const calls = win.onChange.getCalls()
+        const callArgs = calls[0].args
+        const payload = callArgs[0]
         const files = payload.files
+
         expect(files).to.have.lengthOf(1)
 
         const file1 = files[0]

--- a/cypress/integration/FileInput/can_be_focused/index.js
+++ b/cypress/integration/FileInput/can_be_focused/index.js
@@ -10,11 +10,13 @@ When('the FileInput is focused', () => {
 
 Then('the onFocus handler is called', () => {
     cy.window().then(win => {
-        cy.get('[data-test="dhis2-uicore-fileinput"] input').then(fileInput => {
-            expect(win.onFocus).to.be.calledWith({
-                name: 'upload',
-                files: fileInput[0].files,
-            })
-        })
+        cy.get('[data-test="dhis2-uicore-fileinput"] input').should(
+            fileInput => {
+                expect(win.onFocus).to.be.calledWith({
+                    name: 'upload',
+                    files: fileInput[0].files,
+                })
+            }
+        )
     })
 })

--- a/cypress/integration/FileInput/common/index.js
+++ b/cypress/integration/FileInput/common/index.js
@@ -8,7 +8,7 @@ Given('the FileInput does not have any files', () => {
 })
 
 Then('the onChange handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         const calls = win.onChange.getCalls()
         expect(calls).to.have.lengthOf(1)
 
@@ -17,7 +17,5 @@ Then('the onChange handler is called', () => {
 
         const payload = callArgs[0]
         expect(Object.keys(payload)).to.include.members(['files', 'name'])
-
-        cy.wrap(payload).as('payload')
     })
 })

--- a/cypress/integration/FileInputFieldWithList/common/index.js
+++ b/cypress/integration/FileInputFieldWithList/common/index.js
@@ -5,7 +5,7 @@ Given('a FileInputFieldWithList with multiple files is rendered', () => {
 })
 
 Then('the onChange handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         const calls = win.onChange.getCalls()
         expect(calls).to.have.lengthOf(1)
 
@@ -14,7 +14,5 @@ Then('the onChange handler is called', () => {
 
         const payload = callArgs[0]
         expect(Object.keys(payload)).to.include.members(['files', 'name'])
-
-        cy.wrap(payload).as('payload')
     })
 })

--- a/cypress/integration/FileInputFieldWithList/deduplicates_the_file_list/index.js
+++ b/cypress/integration/FileInputFieldWithList/deduplicates_the_file_list/index.js
@@ -11,22 +11,28 @@ Given('the list contains the file duplicate.md', () => {
 
 When('the file duplicate.md is selected', () => {
     cy.window().then(win => {
-        cy.get('[data-test="dhis2-uicore-fileinput"] input').then($input => {
-            // name, lastModified, size and type are equal to the file created in the story
-            const duplicate = new File(...win.duplicateFileConstructorArgs)
-            const dataTransfer = new DataTransfer()
-            dataTransfer.items.add(duplicate)
-            $input[0].files = dataTransfer.files
-            cy.wrap($input).trigger('change', { force: true })
-        })
+        cy.get('[data-test="dhis2-uicore-fileinput"] input')
+            .then($input => {
+                // name, lastModified, size and type are equal to the file created in the story
+                const duplicate = new File(...win.duplicateFileConstructorArgs)
+                const dataTransfer = new DataTransfer()
+
+                dataTransfer.items.add(duplicate)
+                $input[0].files = dataTransfer.files
+            })
+            .trigger('change', { force: true })
     })
 })
 
 Then(
     "the onChange handler's payload contains a single entry for file.md",
     () => {
-        cy.get('@payload').then(payload => {
+        cy.window().should(win => {
+            const calls = win.onChange.getCalls()
+            const callArgs = calls[0].args
+            const payload = callArgs[0]
             const files = payload.files
+
             expect(files).to.have.lengthOf(3)
 
             const filesWithNameFileMd = files.filter(

--- a/cypress/integration/FileInputFieldWithList/files_can_be_removed/index.js
+++ b/cypress/integration/FileInputFieldWithList/files_can_be_removed/index.js
@@ -10,10 +10,16 @@ When('the remove handle behind a file is clicked', () => {
 Then(
     "the onChange handler's payload does not contain an entry for that file",
     () => {
-        cy.get('@payload')
-            .its('files')
-            .should('have.lengthOf', 2)
-            .then(files => files.filter(f => f.name === 'test1.md'))
-            .should('have.lengthOf', 0)
+        cy.window().should(win => {
+            const calls = win.onChange.getCalls()
+            const callArgs = calls[0].args
+
+            const payload = callArgs[0]
+            const files = payload.files
+            expect(files).to.have.lengthOf(2)
+
+            const filtered = files.filter(file => file.name === 'test1.md')
+            expect(filtered).to.have.lengthOf(0)
+        })
     }
 )

--- a/cypress/integration/FileListItem/can_be_removed/index.js
+++ b/cypress/integration/FileListItem/can_be_removed/index.js
@@ -9,7 +9,7 @@ When('the user clicks on the remove text', () => {
 })
 
 Then('the onRemove handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onRemove).to.be.calledWith({})
     })
 })

--- a/cypress/integration/FileListItem/loading_can_be_cancelled/index.js
+++ b/cypress/integration/FileListItem/loading_can_be_cancelled/index.js
@@ -9,7 +9,7 @@ When('the user clicks on the cancel text', () => {
 })
 
 Then('the onCancel handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onCancel).to.be.calledWith({})
     })
 })

--- a/cypress/integration/HeaderBar/common/index.js
+++ b/cypress/integration/HeaderBar/common/index.js
@@ -1,27 +1,5 @@
 import { Before, Given } from 'cypress-cucumber-preprocessor/steps'
 
-/**
- * Will be executed before any `Given` statement,
- * so these can be overriden by using a different fixture, e. g:
- *
- * Given('foo bar baz', () => {
- *   cy.fixture('HeaderBar/systemInfoBarbaz').as('systemInfoFixture')
- * })
- *
- * or
- *
- * Given('foo bar baz', () => {
- *   cy.fixture('HeaderBar/systemInfo')
- *      then(response => ({
- *          ...response,
- *          foo: {
- *              ...response.foo,
- *              bar: 'baz'
- *          }
- *      })).as('systemInfoFixture')
- * })
- *
- */
 Before(() => {
     cy.fixture('HeaderBar/systemInfo').as('systemInfoFixture')
     cy.fixture('HeaderBar/me').as('meFixture')

--- a/cypress/integration/HeaderBar/the_headerbar_contains_a_profile_menu/the_user_name_and_email_are_displayed.js
+++ b/cypress/integration/HeaderBar/the_headerbar_contains_a_profile_menu/the_user_name_and_email_are_displayed.js
@@ -2,17 +2,18 @@ import '../common/index'
 import { Then } from 'cypress-cucumber-preprocessor/steps'
 
 Then('contains the user name', () => {
-    cy.get('@meFixture').then(({ name }) => {
-        cy.get('[data-test="headerbar-profile-username"]').then($name => {
+    cy.getAll('@meFixture', '[data-test="headerbar-profile-username"]').should(
+        ([{ name }, $name]) => {
             expect($name.text()).to.equal(name)
-        })
-    })
+        }
+    )
 })
 
 Then('contains the user email', () => {
-    cy.get('@meFixture').then(({ email }) => {
-        cy.get('[data-test="headerbar-profile-user-email"]').then($email => {
-            expect($email.text()).to.equal(email)
-        })
+    cy.getAll(
+        '@meFixture',
+        '[data-test="headerbar-profile-user-email"]'
+    ).should(([{ email }, $email]) => {
+        expect($email.text()).to.equal(email)
     })
 })

--- a/cypress/integration/HeaderBar/the_headerbar_displays_a_link_to_interpretations_and_an_unread_count/there_are_some_unread_interpretations.js
+++ b/cypress/integration/HeaderBar/the_headerbar_displays_a_link_to_interpretations_and_an_unread_count/there_are_some_unread_interpretations.js
@@ -11,7 +11,7 @@ Given('there are 10 unread interpretations', () => {
 })
 
 Then('the interpretations link contains an icon with the number 10', () => {
-    cy.get('[data-test="headerbar-interpretations-count"]').then($count => {
+    cy.get('[data-test="headerbar-interpretations-count"]').should($count => {
         expect($count.text()).to.equal('10')
     })
 })

--- a/cypress/integration/HeaderBar/the_headerbar_displays_a_link_to_messages_and_an_unread_count/there_are_some_unread_messages.js
+++ b/cypress/integration/HeaderBar/the_headerbar_displays_a_link_to_messages_and_an_unread_count/there_are_some_unread_messages.js
@@ -11,7 +11,7 @@ Given('there are 5 unread messages', () => {
 })
 
 Then('the messages link contains an icon with the number 5', () => {
-    cy.get('[data-test="headerbar-messages-count"]').then($count => {
+    cy.get('[data-test="headerbar-messages-count"]').should($count => {
         expect($count.text()).to.equal('5')
     })
 })

--- a/cypress/integration/HeaderBar/the_headerbar_should_contain_a_logo_that_links_to_the_homepage/headerbar_contains_logo.js
+++ b/cypress/integration/HeaderBar/the_headerbar_should_contain_a_logo_that_links_to_the_homepage/headerbar_contains_logo.js
@@ -6,9 +6,9 @@ Then('the HeaderBar should display the dhis2 logo', () => {
 })
 
 Then('the logo should link to the homepage', () => {
-    cy.get('@systemInfoFixture').then(({ contextPath }) => {
-        cy.get('[data-test="headerbar-logo"] a').then($a => {
+    cy.getAll('@systemInfoFixture', '[data-test="headerbar-logo"] a').should(
+        ([{ contextPath }, $a]) => {
             expect($a.attr('href')).to.equal(contextPath)
-        })
-    })
+        }
+    )
 })

--- a/cypress/integration/HeaderBar/the_headerbar_should_display_the_title_provided_by_the_backend_and_the_app/the_headerbar_displays_the_custom_title.js
+++ b/cypress/integration/HeaderBar/the_headerbar_should_display_the_title_provided_by_the_backend_and_the_app/the_headerbar_displays_the_custom_title.js
@@ -14,7 +14,7 @@ Given(
 )
 
 Then('the displayed title should be "Barbaz - Example!"', () => {
-    cy.get('[data-test="headerbar-title"]').then($title => {
+    cy.get('[data-test="headerbar-title"]').should($title => {
         expect($title.text()).to.equal('Barbaz - Example!')
     })
 })

--- a/cypress/integration/Input/can_be_blurred/index.js
+++ b/cypress/integration/Input/can_be_blurred/index.js
@@ -9,7 +9,7 @@ When('the Input is blurred', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledWith({
             value: '',
             name: 'Default',

--- a/cypress/integration/Input/can_be_changed/index.js
+++ b/cypress/integration/Input/can_be_changed/index.js
@@ -11,7 +11,7 @@ When('the Input is filled with a character', () => {
 })
 
 Then('the onChange handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledWith({
             value: 'a',
             name: 'Default',

--- a/cypress/integration/Input/can_be_focused/index.js
+++ b/cypress/integration/Input/can_be_focused/index.js
@@ -9,7 +9,7 @@ When('the Input is focused', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledWith({
             value: '',
             name: 'Default',

--- a/cypress/integration/Layer/click_behavior/index.js
+++ b/cypress/integration/Layer/click_behavior/index.js
@@ -35,25 +35,25 @@ When('the user clicks on the button coordinates', () => {
 })
 
 Then('the onClick handler of the button is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onButtonClick).to.be.calledOnce
     })
 })
 
 Then('the onClick handler of the layer is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onLayerClick).to.be.calledOnce
     })
 })
 
 Then('the onClick handler of the button is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onButtonClick).to.have.callCount(0)
     })
 })
 
 Then('the onClick handler of the layer is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onLayerClick).to.have.callCount(0)
     })
 })

--- a/cypress/integration/Layer/stacking/index.js
+++ b/cypress/integration/Layer/stacking/index.js
@@ -34,19 +34,35 @@ Given(
 )
 
 Then('the second layer is on top of the first layer', () => {
-    assertLayerIsOnTop('second')
+    cy.get('body').click()
+    cy.window().should(win => {
+        expect(win.onLayerClick).to.be.calledOnce
+        expect(win.onLayerClick).to.be.calledWith('second')
+    })
 })
 
 Then('the alert layer is on top', () => {
-    assertLayerIsOnTop('alert')
+    cy.get('body').click()
+    cy.window().should(win => {
+        expect(win.onLayerClick).to.be.calledOnce
+        expect(win.onLayerClick).to.be.calledWith('alert')
+    })
 })
 
 Then('the layer with level 1001 is on top', () => {
-    assertLayerIsOnTop('1001')
+    cy.get('body').click()
+    cy.window().should(win => {
+        expect(win.onLayerClick).to.be.calledOnce
+        expect(win.onLayerClick).to.be.calledWith('1001')
+    })
 })
 
 Then('the blocking layer is on top', () => {
-    assertLayerIsOnTop('blocking')
+    cy.get('body').click()
+    cy.window().should(win => {
+        expect(win.onLayerClick).to.be.calledOnce
+        expect(win.onLayerClick).to.be.calledWith('blocking')
+    })
 })
 
 Then('the blocking layer is a child of the alert layer', () => {
@@ -60,11 +76,3 @@ Then('the alert layer is a sibling of the blocking layer', () => {
         .next()
         .should('have.data', 'test', 'alert')
 })
-
-function assertLayerIsOnTop(layerName) {
-    cy.get('body').click()
-    cy.window().then(win => {
-        expect(win.onLayerClick).to.be.calledOnce
-        expect(win.onLayerClick).to.be.calledWith(layerName)
-    })
-}

--- a/cypress/integration/MenuItem/is_clickable/index.js
+++ b/cypress/integration/MenuItem/is_clickable/index.js
@@ -9,7 +9,7 @@ When('the MenuItem is clicked', () => {
 })
 
 Then('the onClick handler is called with value', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).to.be.calledWith({
             value: 'Value',
         })

--- a/cypress/integration/MenuItem/position/index.js
+++ b/cypress/integration/MenuItem/position/index.js
@@ -28,7 +28,7 @@ When('the user hovers over the MenuItem', () => {
 Then(
     'the right of the MenuItem is aligned with the left of the SubMenu',
     () => {
-        getMenuItemAndSubMenuRects().then(([menuItemRect, subMenuRect]) => {
+        getMenuItemAndSubMenuRects().should(([menuItemRect, subMenuRect]) => {
             expect(menuItemRect.right).to.equal(subMenuRect.left)
         })
     }
@@ -37,14 +37,14 @@ Then(
 Then(
     'the left of the MenuItem is aligned with the right of the SubMenu',
     () => {
-        getMenuItemAndSubMenuRects().then(([menuItemRect, subMenuRect]) => {
+        getMenuItemAndSubMenuRects().should(([menuItemRect, subMenuRect]) => {
             expect(menuItemRect.left).to.equal(subMenuRect.right)
         })
     }
 )
 
 Then('the SubMenu is rendered on top of the MenuItem', () => {
-    getMenuItemAndSubMenuRects().then(([menuItemRect, subMenuRect]) => {
+    getMenuItemAndSubMenuRects().should(([menuItemRect, subMenuRect]) => {
         expect(menuItemRect.right).to.be.greaterThan(subMenuRect.left)
         expect(subMenuRect.right).to.be.greaterThan(menuItemRect.right)
     })
@@ -56,7 +56,7 @@ Then(
         cy.getPositionsBySelectors(
             '[data-test="dhis2-uicore-menuitem"]',
             '[data-test="dhis2-uicore-popper"]'
-        ).then(([menuItemRect, popperRect]) => {
+        ).should(([menuItemRect, popperRect]) => {
             expect(menuItemRect.top).to.equal(popperRect.top)
         })
     }

--- a/cypress/integration/Modal/can_be_closed/index.js
+++ b/cypress/integration/Modal/can_be_closed/index.js
@@ -9,7 +9,7 @@ When('the Screencover is clicked', () => {
 })
 
 Then('the onClose handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClose).to.be.calledWith({})
     })
 })

--- a/cypress/integration/MultiSelect/accepts_blur_cb/index.js
+++ b/cypress/integration/MultiSelect/accepts_blur_cb/index.js
@@ -6,7 +6,7 @@ Given('a MultiSelect with onBlur handler is rendered', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledOnce
         expect(win.onBlur).to.be.calledWith({
             selected: [],

--- a/cypress/integration/MultiSelect/accepts_focus_cb/index.js
+++ b/cypress/integration/MultiSelect/accepts_focus_cb/index.js
@@ -6,7 +6,7 @@ Given('a MultiSelect with onFocus handler is rendered', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledOnce
         expect(win.onFocus).to.be.calledWith({
             selected: [],

--- a/cypress/integration/MultiSelect/allows_selecting/index.js
+++ b/cypress/integration/MultiSelect/allows_selecting/index.js
@@ -44,7 +44,7 @@ When('the selected option is clicked again', () => {
 })
 
 Then('the clicked option is selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledOnce
         expect(win.onChange).to.be.calledWith({
             selected: ['1'],
@@ -53,7 +53,7 @@ Then('the clicked option is selected', () => {
 })
 
 Then('the clicked option is selected as well', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledOnce
         expect(win.onChange).to.be.calledWith({
             selected: ['1', '2'],
@@ -62,20 +62,20 @@ Then('the clicked option is selected as well', () => {
 })
 
 Then('the selected option is deselected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledOnce
         expect(win.onChange).to.be.calledWith({ selected: [] })
     })
 })
 
 Then('the onchange handler is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.not.be.called
     })
 })
 
 Then('the previously selected option is deselected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledTwice
         expect(win.onChange).to.be.calledWith({ selected: [] })
     })

--- a/cypress/integration/MultiSelect/can_be_cleared/index.js
+++ b/cypress/integration/MultiSelect/can_be_cleared/index.js
@@ -16,7 +16,7 @@ When('the clear button is clicked', () => {
 })
 
 Then('the MultiSelect is cleared', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledOnce
         expect(win.onChange).to.be.calledWith({ selected: [] })
     })

--- a/cypress/integration/MultiSelect/common/index.js
+++ b/cypress/integration/MultiSelect/common/index.js
@@ -13,6 +13,7 @@ Given(
 
 Given('a MultiSelect is rendered to which options can be added', () => {
     cy.visitStory('MultiSelect', 'With options that can be added to the input')
+    cy.get('[data-test="dhis2-uicore-multiselect"]').should('exist')
 })
 
 Given('the MultiSelect is open', () => {

--- a/cypress/integration/MultiSelect/position/index.js
+++ b/cypress/integration/MultiSelect/position/index.js
@@ -22,6 +22,21 @@ Given(
     }
 )
 
+Given('the input is empty', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]')
+        .should('exist')
+        .should('have.length', 1)
+        .then(inputs => {
+            const $input = inputs[0]
+            const inputRect = $input.getBoundingClientRect()
+
+            return inputRect.height
+        })
+        .as('emptyInputHeight')
+
+    cy.get('[data-test="dhis2-uicore-select-input"] .root').should('be.empty')
+})
+
 When('the MultiSelect is clicked', () => {
     cy.get('[data-test="dhis2-uicore-multiselect"]').click()
 })
@@ -36,19 +51,6 @@ When('the window is resized to a greater width', () => {
 
 When('an option is clicked', () => {
     cy.contains('option one').click()
-})
-
-Then('the input is empty', () => {
-    cy.get('[data-test="dhis2-uicore-select-input"]').then(inputs => {
-        expect(inputs.length).to.equal(1)
-
-        const $input = inputs[0]
-        const inputRect = $input.getBoundingClientRect()
-
-        cy.wrap(inputRect.height).as('emptyInputHeight')
-    })
-
-    cy.get('[data-test="dhis2-uicore-select-input"] .root').should('be.empty')
 })
 
 Then('the Input grows in height', () => {

--- a/cypress/integration/Node/can_be_closed/index.js
+++ b/cypress/integration/Node/can_be_closed/index.js
@@ -9,7 +9,7 @@ When('the arrow is clicked', () => {
 })
 
 Then('the onClose handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClose).to.be.calledWith({ open: false })
     })
 })

--- a/cypress/integration/Node/can_be_opened/index.js
+++ b/cypress/integration/Node/can_be_opened/index.js
@@ -9,7 +9,7 @@ When('the arrow is clicked', () => {
 })
 
 Then('the onOpen handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onOpen).to.be.calledWith({ open: true })
     })
 })

--- a/cypress/integration/OrganisationUnitTree/multi_selection/index.js
+++ b/cypress/integration/OrganisationUnitTree/multi_selection/index.js
@@ -5,7 +5,7 @@ Given('an OrganisationUnitTree with two levels is rendered', () => {
 })
 
 Given('no unit is selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.selection).to.eql([])
     })
 })
@@ -52,13 +52,13 @@ When('the user selects the second unit on the second level', () => {
 })
 
 Then('a unit is selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.selection).to.eql(['/A0000000000'])
     })
 })
 
 Then('the unit on the second level is selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.selection).to.eql(['/A0000000000/A0000000001'])
     })
 })
@@ -68,26 +68,26 @@ Then('the unit on the first level is marked as selected intermediately', () => {
         .find(
             '[data-test="dhis2-uiwidgets-orgunittree-node-label"] [data-test="dhis2-uicore-checkbox"] input'
         )
-        .then($input => {
+        .should($input => {
             expect($input[0].indeterminate).to.be.true
         })
 })
 
 Then('the root unit is marked as selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.selection.includes('/A0000000000')).to.be.true
     })
 })
 
 Then('the first unit is selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.selection.includes('/A0000000000/A0000000001')).to.be.true
         expect(win.selection).to.have.length(2)
     })
 })
 
 Then('the second unit is selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.selection.includes('/A0000000000/A0000000002')).to.be.true
         expect(win.selection).to.have.length(2)
     })

--- a/cypress/integration/OrganisationUnitTree/single_selection/index.js
+++ b/cypress/integration/OrganisationUnitTree/single_selection/index.js
@@ -37,7 +37,7 @@ Then('the second unit is selected', () => {
 })
 
 Then('no unit is selected', () => {
-    cy.get('[data-test="dhis2-uiwidgets-orgunittree-node"]').then($nodes => {
+    cy.get('[data-test="dhis2-uiwidgets-orgunittree-node"]').should($nodes => {
         $nodes.each((index, node) => {
             cy.wrap(Cypress.$(node)).shouldNotBeASelectedOrgUnitNode()
         })

--- a/cypress/integration/OrganisationUnitTree/tree_api/index.js
+++ b/cypress/integration/OrganisationUnitTree/tree_api/index.js
@@ -25,7 +25,7 @@ Given('the node has been expanded', () => {
 })
 
 Given("the children haven't been loaded yet", () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onExpand).not.to.be.called
     })
 })
@@ -51,67 +51,67 @@ When('the children have been loaded', () => {
 })
 
 Then('the onChange callback gets called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.called
     })
 })
 
 Then('the payload includes the path of the selected node', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expectStubPayloadToEqual(win.onChange, 'path', '/A0000000000')
     })
 })
 
 Then('the payload includes checked which is set to "true"', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expectStubPayloadToEqual(win.onChange, 'checked', true)
     })
 })
 
 Then('the payload includes all selected nodes', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expectStubPayloadToEqual(win.onChange, 'selected', ['/A0000000000'])
     })
 })
 
 Then('the payload includes checked which is set to "false"', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expectStubPayloadToEqual(win.onChange, 'checked', false)
     })
 })
 
 Then('the onExpand callback gets called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onExpand).to.be.called
     })
 })
 
 Then('the payload includes the path of the expanded node', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expectStubPayloadToEqual(win.onExpand, 'path', '/A0000000000')
     })
 })
 
 Then('the onCollapse callback gets called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onCollapse).to.be.called
     })
 })
 
 Then('the payload includes the path of the collapsed node', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expectStubPayloadToEqual(win.onCollapse, 'path', '/A0000000000')
     })
 })
 
 Then('the onChildrenLoaded callback gets called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChildrenLoaded).to.be.called
     })
 })
 
 Then("the payload contains the loaded children's data", () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         const calls = win.onChildrenLoaded.getCalls()
         const { args } = calls[calls.length - 1]
         expect(args[0].A0000000001).to.deep.eql(

--- a/cypress/integration/Popover/clicking_outside/index.js
+++ b/cypress/integration/Popover/clicking_outside/index.js
@@ -10,7 +10,7 @@ When('the user clicks outside of the Popover', () => {
     cy.get('[data-test="dhis2-uicore-layer"]').click()
 })
 Then('the clickOutside handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClickOutside).to.be.calledOnce
     })
 })

--- a/cypress/integration/Popover/position/index.js
+++ b/cypress/integration/Popover/position/index.js
@@ -48,7 +48,7 @@ Given(
 Given(
     'there is sufficient space between the bottom of the reference element and the bottom of the Popover to show the arrow',
     () => {
-        getRefAndPopoverPositions().then(([refPos, popoverPos]) => {
+        getRefAndPopoverPositions().should(([refPos, popoverPos]) => {
             expect(refPos.bottom).to.be.greaterThan(popoverPos.bottom + 8)
         })
     }
@@ -71,7 +71,7 @@ Then('the arrow is showing', () => {
 Then(
     'the horizontal center of the popover is aligned with the horizontal center of the reference element',
     () => {
-        getRefAndPopoverPositions().then(([refPos, popoverPos]) => {
+        getRefAndPopoverPositions().should(([refPos, popoverPos]) => {
             const refCenter = refPos.left + refPos.width / 2
             const popoverCenter = popoverPos.left + popoverPos.width / 2
             expect(refCenter).to.equal(popoverCenter)
@@ -80,26 +80,26 @@ Then(
 )
 
 Then('the popover is placed above the reference element', () => {
-    getRefAndPopoverPositions().then(([refPos, popoverPos]) => {
+    getRefAndPopoverPositions().should(([refPos, popoverPos]) => {
         expect(refPos.top).to.be.greaterThan(popoverPos.bottom)
     })
 })
 
 Then('the popover is placed below the reference element', () => {
-    getRefAndPopoverPositions().then(([refPos, popoverPos]) => {
+    getRefAndPopoverPositions().should(([refPos, popoverPos]) => {
         expect(popoverPos.top).to.be.greaterThan(refPos.bottom)
     })
 })
 
 Then('the popover is placed op top of the reference element', () => {
-    getRefAndPopoverPositions().then(([refPos, popoverPos]) => {
+    getRefAndPopoverPositions().should(([refPos, popoverPos]) => {
         expect(popoverPos.bottom).to.be.greaterThan(refPos.top)
         expect(refPos.top).to.be.greaterThan(popoverPos.top)
     })
 })
 
 Then('there is some space between the anchor and the popover', () => {
-    getRefAndPopoverPositions().then(([refPos, popoverPos]) => {
+    getRefAndPopoverPositions().should(([refPos, popoverPos]) => {
         expect(popoverPos.bottom + 8).to.equal(refPos.top)
     })
 })

--- a/cypress/integration/Popper/positions/index.js
+++ b/cypress/integration/Popper/positions/index.js
@@ -43,7 +43,7 @@ Given('the Popper is rendered with placement left-end', () => {
 Then(
     'the bottom of the popper is adjacent to the top of the reference element',
     () => {
-        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        getRefAndPopperPositions().should(([refPos, popperPos]) => {
             expect(refPos.top).to.equal(popperPos.bottom)
         })
     }
@@ -52,7 +52,7 @@ Then(
 Then(
     'the left of the popper is adjacent to the right of the reference element',
     () => {
-        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        getRefAndPopperPositions().should(([refPos, popperPos]) => {
             expect(refPos.right).to.equal(popperPos.left)
         })
     }
@@ -61,7 +61,7 @@ Then(
 Then(
     'the top of the popper is adjacent to the bottom of the reference element',
     () => {
-        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        getRefAndPopperPositions().should(([refPos, popperPos]) => {
             expect(refPos.bottom).to.equal(popperPos.top)
         })
     }
@@ -70,7 +70,7 @@ Then(
 Then(
     'the right of the popper is adjacent to the left of the reference element',
     () => {
-        getRefAndPopperPositions().then(([refPos, popperPos]) => {
+        getRefAndPopperPositions().should(([refPos, popperPos]) => {
             expect(refPos.left).to.equal(popperPos.right)
         })
     }
@@ -79,13 +79,13 @@ Then(
 // Horizontal alignments
 // *-start
 Then('it is horizontally left aligned with the reference element', () => {
-    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+    getRefAndPopperPositions().should(([refPos, popperPos]) => {
         expect(refPos.left).to.equal(popperPos.left)
     })
 })
 // * (no suffix)
 Then('it is horizontally center aligned with the reference element', () => {
-    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+    getRefAndPopperPositions().should(([refPos, popperPos]) => {
         const refCenterX = refPos.left + refPos.width / 2
         const popperCenterX = popperPos.left + popperPos.width / 2
 
@@ -94,7 +94,7 @@ Then('it is horizontally center aligned with the reference element', () => {
 })
 // *-end
 Then('it is horizontally right aligned with the reference element', () => {
-    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+    getRefAndPopperPositions().should(([refPos, popperPos]) => {
         expect(refPos.right).to.equal(popperPos.right)
     })
 })
@@ -102,13 +102,13 @@ Then('it is horizontally right aligned with the reference element', () => {
 // Vertical alignments
 // *-start
 Then('it is vertically top aligned with the reference element', () => {
-    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+    getRefAndPopperPositions().should(([refPos, popperPos]) => {
         expect(refPos.top).to.equal(popperPos.top)
     })
 })
 // * (no suffix)
 Then('it is vertically center aligned with the reference element', () => {
-    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+    getRefAndPopperPositions().should(([refPos, popperPos]) => {
         const refCenterY = refPos.top + refPos.height / 2
         const popperCenterY = popperPos.top + popperPos.height / 2
 
@@ -117,7 +117,7 @@ Then('it is vertically center aligned with the reference element', () => {
 })
 // *-end
 Then('it is vertically bottom aligned with the reference element', () => {
-    getRefAndPopperPositions().then(([refPos, popperPos]) => {
+    getRefAndPopperPositions().should(([refPos, popperPos]) => {
         expect(refPos.bottom).to.equal(popperPos.bottom)
     })
 })

--- a/cypress/integration/Radio/can_be_blurred/index.js
+++ b/cypress/integration/Radio/can_be_blurred/index.js
@@ -9,7 +9,7 @@ When('the Radio is blurred', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Radio/can_be_changed/index.js
+++ b/cypress/integration/Radio/can_be_changed/index.js
@@ -9,7 +9,7 @@ When('the Radio is checked', () => {
 })
 
 Then('the onChange handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Radio/can_be_focused/index.js
+++ b/cypress/integration/Radio/can_be_focused/index.js
@@ -9,7 +9,7 @@ When('the Radio is focused', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/SingleSelect/accepts_blur_cb/index.js
+++ b/cypress/integration/SingleSelect/accepts_blur_cb/index.js
@@ -6,7 +6,7 @@ Given('a SingleSelect with onBlur handler is rendered', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledOnce
         expect(win.onBlur).to.be.calledWith({
             selected: '',

--- a/cypress/integration/SingleSelect/accepts_focus_cb/index.js
+++ b/cypress/integration/SingleSelect/accepts_focus_cb/index.js
@@ -6,7 +6,7 @@ Given('a SingleSelect with onFocus handler is rendered', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledOnce
         expect(win.onFocus).to.be.calledWith({
             selected: '',

--- a/cypress/integration/SingleSelect/allows_selecting/index.js
+++ b/cypress/integration/SingleSelect/allows_selecting/index.js
@@ -24,7 +24,7 @@ When('the disabled option is clicked', () => {
 })
 
 Then('the clicked option is selected', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledOnce
         expect(win.onChange).to.be.calledWith({
             selected: '1',
@@ -33,7 +33,7 @@ Then('the clicked option is selected', () => {
 })
 
 Then('the onchange handler is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.not.be.called
     })
 })

--- a/cypress/integration/SingleSelect/can_be_cleared/index.js
+++ b/cypress/integration/SingleSelect/can_be_cleared/index.js
@@ -16,7 +16,7 @@ When('the clear button is clicked', () => {
 })
 
 Then('the SingleSelect is cleared', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledOnce
         expect(win.onChange).to.be.calledWith({ selected: '' })
     })

--- a/cypress/integration/Switch/can_be_blurred/index.js
+++ b/cypress/integration/Switch/can_be_blurred/index.js
@@ -9,7 +9,7 @@ When('the Switch is blurred', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Switch/can_be_changed/index.js
+++ b/cypress/integration/Switch/can_be_changed/index.js
@@ -9,7 +9,7 @@ When('the Switch is clicked', () => {
 })
 
 Then('the onChange handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Switch/can_be_focused/index.js
+++ b/cypress/integration/Switch/can_be_focused/index.js
@@ -9,7 +9,7 @@ When('the Switch is focused', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledWith({
             value: 'default',
             name: 'Ex',

--- a/cypress/integration/Tab/is_clickable/index.js
+++ b/cypress/integration/Tab/is_clickable/index.js
@@ -13,13 +13,13 @@ When('the Tab is clicked', () => {
 })
 
 Then('the onClick handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).to.be.calledWith({})
     })
 })
 
 Then('the onClick handler is not called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onClick).not.to.be.called
     })
 })

--- a/cypress/integration/TextArea/can_be_blurred/index.js
+++ b/cypress/integration/TextArea/can_be_blurred/index.js
@@ -9,7 +9,7 @@ When('the TextArea is blurred', () => {
 })
 
 Then('the onBlur handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onBlur).to.be.calledWith({
             value: '',
             name: 'textarea',

--- a/cypress/integration/TextArea/can_be_changed/index.js
+++ b/cypress/integration/TextArea/can_be_changed/index.js
@@ -12,7 +12,7 @@ When('the TextArea is filled with a character', () => {
 })
 
 Then('the onChange handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onChange).to.be.calledWith({
             value: 'a',
             name: 'textarea',

--- a/cypress/integration/TextArea/can_be_focused/index.js
+++ b/cypress/integration/TextArea/can_be_focused/index.js
@@ -10,7 +10,7 @@ When('the TextArea is focused', () => {
 })
 
 Then('the onFocus handler is called', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.onFocus).to.be.calledWith({
             value: '',
             name: 'textarea',

--- a/cypress/integration/Tooltip/common/index.js
+++ b/cypress/integration/Tooltip/common/index.js
@@ -25,7 +25,7 @@ Then('the Tooltip is rendered above the anchor', () => {
     cy.getPositionsBySelectors(
         '[data-test="dhis2-uicore-tooltip-reference"]',
         '[data-test="dhis2-uicore-tooltip-content"]'
-    ).then(([refPos, contentPos]) => {
+    ).should(([refPos, contentPos]) => {
         expect(refPos.top).to.be.greaterThan(contentPos.bottom)
     })
 })
@@ -40,7 +40,7 @@ Then('the Tooltip is rendered on top of the anchor', () => {
     cy.getPositionsBySelectors(
         '[data-test="dhis2-uicore-tooltip-reference"]',
         '[data-test="dhis2-uicore-tooltip-content"]'
-    ).then(([refPos, contentPos]) => {
+    ).should(([refPos, contentPos]) => {
         expect(contentPos.bottom).to.be.greaterThan(refPos.top)
         expect(refPos.top).to.be.greaterThan(contentPos.top)
     })

--- a/cypress/integration/Tooltip/positions/index.js
+++ b/cypress/integration/Tooltip/positions/index.js
@@ -14,7 +14,7 @@ Given(
 Given(
     'there is enough space between the anchor bottom and the body bottom to fit the Tooltip',
     () => {
-        getReferenceAndBodyPositions().then(([refPos, bodyPos]) => {
+        getReferenceAndBodyPositions().should(([refPos, bodyPos]) => {
             expect(bodyPos.bottom).to.be.greaterThan(
                 refPos.bottom + TOOLTIP_OFFSET + TOOLTIP_HEIGHT
             )
@@ -29,7 +29,7 @@ Given('there is limited space available to the left of the anchor', () => {
 Then(
     'the horizontal center of the Tooltip is aligned with the horizontal center of the anchor',
     () => {
-        getReferenceAndContentPositions().then(([refPos, contentPos]) => {
+        getReferenceAndContentPositions().should(([refPos, contentPos]) => {
             const refCenterX = refPos.left + refPos.width / 2
             const contentCenterX = contentPos.left + contentPos.width / 2
 
@@ -41,7 +41,7 @@ Then(
 Then(
     'the horizontal center of the Tooltip is to the right of the horizontal center of the anchor',
     () => {
-        getReferenceAndContentPositions().then(([refPos, contentPos]) => {
+        getReferenceAndContentPositions().should(([refPos, contentPos]) => {
             const contentCenterX = contentPos.left + contentPos.width / 2
             const refCenterX = refPos.left + refPos.width / 2
 
@@ -53,7 +53,7 @@ Then(
 Then(
     'there is some space between the anchor bottom and the Tooltip top',
     () => {
-        getReferenceAndContentPositions().then(([refPos, contentPos]) => {
+        getReferenceAndContentPositions().should(([refPos, contentPos]) => {
             expect(refPos.bottom + TOOLTIP_OFFSET).to.equal(contentPos.top)
         })
     }
@@ -62,14 +62,14 @@ Then(
 Then(
     'there is some space between the anchor top and the Tooltip bottom',
     () => {
-        getReferenceAndContentPositions().then(([refPos, contentPos]) => {
+        getReferenceAndContentPositions().should(([refPos, contentPos]) => {
             expect(refPos.top).to.equal(contentPos.bottom + TOOLTIP_OFFSET)
         })
     }
 )
 
 Then('the Tooltip is rendered below the anchor', () => {
-    getReferenceAndContentPositions().then(([refPos, contentPos]) => {
+    getReferenceAndContentPositions().should(([refPos, contentPos]) => {
         expect(contentPos.top).to.be.greaterThan(refPos.bottom)
     })
 })

--- a/cypress/integration/Transfer/disabled-transfer-options/index.js
+++ b/cypress/integration/Transfer/disabled-transfer-options/index.js
@@ -146,7 +146,7 @@ Then('only the previously highlighted items are highlighted', () => {
     cy.all(
         () => cy.get('{transfer-sourceoptions} {transferoption}'),
         () => cy.get('@enabledHighlightedSourceOptions')
-    ).then(([$sourceOptions, $previouslyHighlightedOptions]) => {
+    ).should(([$sourceOptions, $previouslyHighlightedOptions]) => {
         const sourceOptions = $sourceOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -178,12 +178,14 @@ Then('the enabled options in the range are highlighted', () => {
         () => cy.get('{transfer-sourceoptions} {transferoption}'),
         () => cy.get('@clickedEnabledOption'),
         () => cy.get('@clickedWithShiftEnabledOption')
-    ).then(([$all, $clickedEnabledOption, $clickedWithShiftEnabledOption]) => {
-        const from = $clickedEnabledOption.index()
-        const to = $clickedWithShiftEnabledOption.index()
-        const $allInRange = $all.slice(from, to + 1)
-        const $allInRangeEnabled = $allInRange.filter(':not(.disabled)')
+    ).should(
+        ([$all, $clickedEnabledOption, $clickedWithShiftEnabledOption]) => {
+            const from = $clickedEnabledOption.index()
+            const to = $clickedWithShiftEnabledOption.index()
+            const $allInRange = $all.slice(from, to + 1)
+            const $allInRangeEnabled = $allInRange.filter(':not(.disabled)')
 
-        expect($allInRangeEnabled).to.have.class('highlighted')
-    })
+            expect($allInRangeEnabled).to.have.class('highlighted')
+        }
+    )
 })

--- a/cypress/integration/Transfer/display-order/index.js
+++ b/cypress/integration/Transfer/display-order/index.js
@@ -75,7 +75,7 @@ Then(
         cy.all(
             () => cy.window(),
             () => cy.get('{transfer-sourceoptions} {transferoption}')
-        ).then(([win, $options]) => {
+        ).should(([win, $options]) => {
             const { options } = win
             const selectableSourceOptions = $options
                 .toArray()
@@ -92,7 +92,7 @@ Then(
         cy.all(
             () => cy.window(),
             () => cy.get('{transfer-sourceoptions} {transferoption}')
-        ).then(([win, $options]) => {
+        ).should(([win, $options]) => {
             const selectableSourceOptions = $options
                 .toArray()
                 .map(extractOptionFromElement)
@@ -116,7 +116,7 @@ Then(
             () => cy.window(),
             () => cy.get('{transfer-sourceoptions} {transferoption}'),
             () => cy.get('@deselectedOptions')
-        ).then(([win, $selectableSourceOptions, deselectedOptions]) => {
+        ).should(([win, $selectableSourceOptions, deselectedOptions]) => {
             // filter out non-selectable options and compare with selectable options
             // this confirms that the order is correct
             const selectableSourceOptions = $selectableSourceOptions
@@ -149,7 +149,7 @@ Then(
             () => cy.window(),
             () => cy.get('{transfer-sourceoptions} {transferoption}'),
             () => cy.get('@deselectedOptions')
-        ).then(([win, $selectableSourceOptions, deselectedOptions]) => {
+        ).should(([win, $selectableSourceOptions, deselectedOptions]) => {
             console.log('deselectedOptions', deselectedOptions)
             const selectableSourceOptions = $selectableSourceOptions
                 .toArray()
@@ -183,7 +183,7 @@ Then('it should be added to the end of the selected options list', () => {
     cy.all(
         () => cy.get('@selectedOptions'),
         () => cy.get('{transfer-pickedoptions} {transferoption}')
-    ).then(([transferredOptions, $selectedOptions]) => {
+    ).should(([transferredOptions, $selectedOptions]) => {
         const lastSelectedOptions = $selectedOptions
             .toArray()
             .slice(transferredOptions.length * -1)
@@ -199,7 +199,7 @@ Then(
         cy.all(
             () => cy.get('@selectedOptions'),
             () => cy.get('{transfer-pickedoptions} {transferoption}')
-        ).then(([transferredOptions, $selectedOptions]) => {
+        ).should(([transferredOptions, $selectedOptions]) => {
             const lastSelectedOptions = $selectedOptions
                 .toArray()
                 .slice(transferredOptions.length * -1)

--- a/cypress/integration/Transfer/filter-options-list/index.js
+++ b/cypress/integration/Transfer/filter-options-list/index.js
@@ -81,7 +81,7 @@ Then('all the matching items should be shown in the options list', () => {
     cy.all(
         () => cy.get('{transfer-filter}'),
         () => cy.get('{transferoption}')
-    ).then(([$filter, $options]) => {
+    ).should(([$filter, $options]) => {
         const searchTerm = $filter.val()
 
         expect($options).to.have.length.of.at.least(1)
@@ -104,7 +104,7 @@ Then('the same options should be shown', () => {
     cy.all(
         () => cy.get('@firstCaseOptions'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([$firstCaseOptions, $secondCaseOptions]) => {
+    ).should(([$firstCaseOptions, $secondCaseOptions]) => {
         const firstCaseOptions = $firstCaseOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -123,7 +123,7 @@ Then('only the results including the word "ANC" are included', () => {
 })
 
 Then('the onFilterChange callback will be called with the new value', () => {
-    cy.window().then(win => {
+    cy.window().should(win => {
         expect(win.customFilterCallback.callCount).to.equal(4)
         expect(win.customFilterCallback.getCall(0).args[1]).to.equal('')
         expect(win.customFilterCallback.getCall(1).args[1]).to.equal('A')

--- a/cypress/integration/Transfer/highlight-range-of-options/index.js
+++ b/cypress/integration/Transfer/highlight-range-of-options/index.js
@@ -191,7 +191,7 @@ Then('the option is not highlighted', () => {
     cy.all(
         () => cy.get('@hiddenHighlighted'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([hiddenHighlighted, $options]) => {
+    ).should(([hiddenHighlighted, $options]) => {
         const $hiddenHighlighted = $options.filter((index, optionEl) => {
             const option = extractOptionFromElement(optionEl)
 
@@ -209,7 +209,7 @@ Then('the clicked options should be highlighted', () => {
     cy.all(
         () => cy.get('@initiallyHighlighted'),
         () => cy.get('@secondBelowInitiallyHighlighted')
-    ).then(([$initiallyHighlighted, $secondBelowInitiallyHighlighted]) => {
+    ).should(([$initiallyHighlighted, $secondBelowInitiallyHighlighted]) => {
         expect($initiallyHighlighted).to.have.class('highlighted')
         expect($secondBelowInitiallyHighlighted).to.have.class('highlighted')
     })
@@ -261,7 +261,7 @@ Then(
                     .last()
                     .invoke('index'),
             () => cy.get('@initiallyHighlightedMultiple')
-        ).then(
+        ).should(
             ([
                 lastInitiallyHighlightedIndex,
                 $initiallyHighlightedMultiple,
@@ -287,25 +287,29 @@ Then(
             () => cy.get('@initiallyHighlightedMultiple'),
             () => cy.get('@firstShiftClicked'),
             () => cy.get('@list').find('{transferoption}')
-        ).then(([$initiallyHighlightedMultiple, $firstShiftClicked, $all]) => {
-            const firstVisibleHighlightedIndex = $initiallyHighlightedMultiple
-                .filter(':visible')
-                .eq(0)
-                .index()
-            const shiftIndex = $firstShiftClicked.index()
-            const from = Math.min(firstVisibleHighlightedIndex, shiftIndex)
-            const to = Math.max(firstVisibleHighlightedIndex, shiftIndex)
-            const $insideRange = $all.slice(from, to + 1)
-            const $outsideRange = $all.slice(0, from).add($all.slice(to + 1))
+        ).should(
+            ([$initiallyHighlightedMultiple, $firstShiftClicked, $all]) => {
+                const firstVisibleHighlightedIndex = $initiallyHighlightedMultiple
+                    .filter(':visible')
+                    .eq(0)
+                    .index()
+                const shiftIndex = $firstShiftClicked.index()
+                const from = Math.min(firstVisibleHighlightedIndex, shiftIndex)
+                const to = Math.max(firstVisibleHighlightedIndex, shiftIndex)
+                const $insideRange = $all.slice(from, to + 1)
+                const $outsideRange = $all
+                    .slice(0, from)
+                    .add($all.slice(to + 1))
 
-            $insideRange.each((index, option) => {
-                expect(Cypress.$(option)).to.have.class('highlighted')
-            })
+                $insideRange.each((index, option) => {
+                    expect(Cypress.$(option)).to.have.class('highlighted')
+                })
 
-            $outsideRange.each(option =>
-                expect(Cypress.$(option)).to.not.have.class('highlighted')
-            )
-        })
+                $outsideRange.each(option =>
+                    expect(Cypress.$(option)).to.not.have.class('highlighted')
+                )
+            }
+        )
     }
 )
 
@@ -316,7 +320,7 @@ Then(
             () => cy.get('@firstClickedIndexWithShift'),
             () => cy.get('@secondClickedIndexWithShift'),
             () => cy.get('@list').find('{transferoption}')
-        ).then(
+        ).should(
             ([
                 firstClickedIndexWithShift,
                 secondClickedIndexWithShift,

--- a/cypress/integration/Transfer/set_unset-highlighted-option/index.js
+++ b/cypress/integration/Transfer/set_unset-highlighted-option/index.js
@@ -75,7 +75,7 @@ Then('the option is visible', () => {
     cy.all(
         () => cy.get('@hiddenHighlighted'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([hiddenHighlighted, $options]) => {
+    ).should(([hiddenHighlighted, $options]) => {
         const $hiddenHighlighted = $options.filter((index, optionEl) => {
             const option = extractOptionFromElement(optionEl)
 
@@ -93,7 +93,7 @@ Then('the option is highlighted', () => {
     cy.all(
         () => cy.get('@hiddenHighlighted'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([hiddenHighlighted, $options]) => {
+    ).should(([hiddenHighlighted, $options]) => {
         const $hiddenHighlighted = $options.filter((index, optionEl) => {
             const option = extractOptionFromElement(optionEl)
 
@@ -111,7 +111,7 @@ Then('the option is not highlighted', () => {
     cy.all(
         () => cy.get('@hiddenHighlighted'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([hiddenHighlighted, $options]) => {
+    ).should(([hiddenHighlighted, $options]) => {
         const $hiddenHighlighted = $options.filter((index, optionEl) => {
             const option = extractOptionFromElement(optionEl)
 

--- a/cypress/integration/Transfer/transferring-items/index.js
+++ b/cypress/integration/Transfer/transferring-items/index.js
@@ -83,7 +83,7 @@ Then('the highlighted items should be removed from the options list', () => {
     cy.all(
         () => cy.get('@itemsToBeSelected'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([itemsToBeSelected, $selectableSourceOptions]) => {
+    ).should(([itemsToBeSelected, $selectableSourceOptions]) => {
         const selectableSourceOptions = $selectableSourceOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -107,7 +107,7 @@ Then('the highlighted items should be visible in the selected list', () => {
     cy.all(
         () => cy.get('@itemsToBeSelected'),
         () => cy.get('{transfer-pickedoptions} {transferoption}')
-    ).then(([itemsToBeSelected, $selectedOptions]) => {
+    ).should(([itemsToBeSelected, $selectedOptions]) => {
         const selectedOptions = $selectedOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -129,7 +129,7 @@ Then(
         cy.all(
             () => cy.get('@itemsToBeSelected'),
             () => cy.get('{transfer-pickedoptions} {transferoption}')
-        ).then(([itemsToBeSelected, $selectedOptions]) => {
+        ).should(([itemsToBeSelected, $selectedOptions]) => {
             const lastNSelectedOptions = $selectedOptions
                 .toArray()
                 .map(extractOptionFromElement)
@@ -144,7 +144,7 @@ Then('the highlighted items should be removed from the selected list', () => {
     cy.all(
         () => cy.get('@itemsToBeDeselected'),
         () => cy.get('{transfer-pickedoptions} {transferoption}')
-    ).then(([itemsToBeDeselected, $selectedOptions]) => {
+    ).should(([itemsToBeDeselected, $selectedOptions]) => {
         const selectedOptions = $selectedOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -168,7 +168,7 @@ Then('the highlighted items should be visible in the options list', () => {
     cy.all(
         () => cy.get('@itemsToBeDeselected'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([itemsToBeDeselected, $selectedOptions]) => {
+    ).should(([itemsToBeDeselected, $selectedOptions]) => {
         const selectedOptions = $selectedOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -193,7 +193,7 @@ Then(
             () => cy.window(),
             () => cy.get('{transfer-sourceoptions} {transferoption}'),
             () => cy.get('{transfer-pickedoptions} {transferoption}')
-        ).then(([win, $selectableSourceOptions, $selectedOptions]) => {
+        ).should(([win, $selectableSourceOptions, $selectedOptions]) => {
             const selectedOptions = $selectedOptions
                 .toArray()
                 .map(extractOptionFromElement)
@@ -222,7 +222,7 @@ Then(
         cy.all(
             () => cy.get('@itemsToBeSelected'),
             () => cy.get('{transfer-pickedoptions} {transferoption}')
-        ).then(([itemsToBeSelected, $selectedOptions]) => {
+        ).should(([itemsToBeSelected, $selectedOptions]) => {
             const selectedOptions = $selectedOptions
                 .toArray()
                 .map(extractOptionFromElement)
@@ -244,7 +244,7 @@ Then(
         cy.all(
             () => cy.get('@itemsToBeSelected'),
             () => cy.get('{transfer-pickedoptions} {transferoption}')
-        ).then(([itemsToBeSelected, $selectedOptions]) => {
+        ).should(([itemsToBeSelected, $selectedOptions]) => {
             const selectedOptions = $selectedOptions
                 .toArray()
                 .map(extractOptionFromElement)
@@ -267,7 +267,7 @@ Then(
         cy.all(
             () => cy.get('@itemsToBeDeselected'),
             () => cy.get('{transfer-sourceoptions} {transferoption}')
-        ).then(([itemsToBeDeselected, $selectableSourceOptions]) => {
+        ).should(([itemsToBeDeselected, $selectableSourceOptions]) => {
             const selectableSourceOptions = $selectableSourceOptions
                 .toArray()
                 .map(extractOptionFromElement)
@@ -289,7 +289,7 @@ Then(
         cy.all(
             () => cy.get('@itemsToBeSelected'),
             () => cy.get('{transfer-pickedoptions} {transferoption}')
-        ).then(([itemsToBeSelected, $selectedOptions]) => {
+        ).should(([itemsToBeSelected, $selectedOptions]) => {
             const selectedOptions = $selectedOptions
                 .toArray()
                 .map(extractOptionFromElement)
@@ -312,7 +312,7 @@ Then('the options list items should be ordered in the original order', () => {
                     parseSelectorWithDataTest('{transferoption}')
                 )
             })
-    ).then(([win, $selectableSourceOptions, $pickedOptions]) => {
+    ).should(([win, $selectableSourceOptions, $pickedOptions]) => {
         const pickedPlainOptions = $pickedOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -339,7 +339,7 @@ Then('the item should be removed from its options list', () => {
     cy.all(
         () => cy.get('@doubleClickedPlainOption'),
         () => cy.get('{transfer-sourceoptions} {transferoption}')
-    ).then(([doubleClickedPlainOption, $sourceOptions]) => {
+    ).should(([doubleClickedPlainOption, $sourceOptions]) => {
         const sourcePlainOptions = $sourceOptions
             .toArray()
             .map(extractOptionFromElement)
@@ -358,7 +358,7 @@ Then('the item should be visible at the bottom of the selected list', () => {
     cy.all(
         () => cy.get('@doubleClickedPlainOption'),
         () => cy.get('{transfer-pickedoptions} {transferoption}')
-    ).then(([doubleClickedPlainOption, $pickedOptions]) => {
+    ).should(([doubleClickedPlainOption, $pickedOptions]) => {
         const lastSourcePlainOption = $pickedOptions
             .last()
             .toArray()
@@ -377,7 +377,7 @@ Then('the item should be removed from the selected list', () => {
     cy.all(
         () => cy.get('@doubleClickedPlainOption'),
         () => cy.get('{transfer-pickedoptions} {transferoption}')
-    ).then(([doubleClickedPlainOption, $pickedOptions]) => {
+    ).should(([doubleClickedPlainOption, $pickedOptions]) => {
         const pickedPlainOptions = $pickedOptions
             .toArray()
             .map(extractOptionFromElement)


### PR DESCRIPTION
Since we still see assertions failing randomly, I thought I'd change the assertions to use .should now instead of later.

I've noticed that when moving to `.should`, tests start failing if there's a `wrap` call in the callback passed to should. Moving the call to `wrap` outside of `should` fixes it. Maybe this is because `wrap` can be considered a side effect.

I've not touched the tests for our forms components. There are calls to `wrap` nested in `should` there, but it's going to be a fair amount of work to separate those as the tests depends a lot on passing around wrapped values.