### PR TITLE
docs: add link to CHANGELOG on docsite

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,3 +3,5 @@
 -   [**Concepts**](concepts)
 -   [**Live demos**](/demo/ ':ignore Live demos')
 -   [**Troubleshooting**](troubleshooting)
+-   &nbsp;
+-   [Changelog](CHANGELOG.md)


### PR DESCRIPTION
The docsite tool [automatically copies the CHANGELOG into the docsite](https://ui.dhis2.nu/#/CHANGELOG), but we need to include a link in the Sidebar

Relates to #119 