### PR TITLE
test(popper): additional popper and popover e2e tests

### DIFF
--- a/cypress/integration/Popover/arrow_position.feature
+++ b/cypress/integration/Popover/arrow_position.feature
@@ -1,0 +1,27 @@
+Feature: Popover arrow positions
+
+    Scenario: The Arrow is at the bottom of a Popper with placement top
+        Given a Popover is rendered with placement top
+        Then the Arrow is at the bottom of the Popper
+        And the Arrow is horizontally aligned with the Popper
+
+    Scenario: The Arrow is at the left of a Popper with placement right
+        Given a Popover is rendered with placement right
+        Then the Arrow is at the left of the Popper
+        And the Arrow is vertically aligned with the Popper
+
+    Scenario: The Arrow is at the top of a Popper with placement bottom
+        Given a Popover is rendered with placement bottom
+        Then the Arrow is at the top of the Popper
+        And the Arrow is horizontally aligned with the Popper
+
+    Scenario: The Arrow is at the right of a Popper with placement left
+        Given a Popover is rendered with placement left
+        Then the Arrow is at the right of the Popper
+        And the Arrow is vertically aligned with the Popper
+
+    Scenario: The Arrow is shifted along the Popper to align with the reference element
+        Given a Popover with position left is shifted into view
+        Then the Arrow is at the right of the Popper
+        And the Arrow is at the top half of the Popper
+        And the Arrow is vertically aligned with the reference element

--- a/cypress/integration/Popover/arrow_position/index.js
+++ b/cypress/integration/Popover/arrow_position/index.js
@@ -1,0 +1,121 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Popover is rendered with placement top', () => {
+    cy.visitStory('Popover', 'Placement Top')
+})
+Given('a Popover is rendered with placement right', () => {
+    cy.visitStory('Popover', 'Placement Right')
+})
+Given('a Popover is rendered with placement bottom', () => {
+    cy.visitStory('Popover', 'Placement Bottom')
+})
+Given('a Popover is rendered with placement left', () => {
+    cy.visitStory('Popover', 'Placement Left')
+})
+Given('a Popover with position left is shifted into view', () => {
+    cy.visitStory('Popover', 'Shifted Arrow')
+})
+
+Then('the Arrow is horizontally aligned with the Popper', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-popover"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$popover, $arrow]) => {
+        const popoverRect = $popover.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const popoverCenterX = popoverRect.left + popoverRect.width / 2
+        const arrowCenterX = arrowRect.left + arrowRect.width / 2
+
+        expect(popoverCenterX).to.equal(arrowCenterX)
+    })
+})
+Then('the Arrow is vertically aligned with the Popper', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-popover"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$popover, $arrow]) => {
+        const popoverRect = $popover.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const popoverCenterY = popoverRect.top + popoverRect.height / 2
+        const arrowCenterY = arrowRect.top + arrowRect.height / 2
+
+        expect(popoverCenterY).to.equal(arrowCenterY)
+    })
+})
+
+Then('the Arrow is vertically aligned with the reference element', () => {
+    cy.all(
+        () => cy.get('[data-test="reference-element"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$reference, $arrow]) => {
+        const referenceRect = $reference.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const referenceCenterY = referenceRect.top + referenceRect.height / 2
+        const arrowCenterY = arrowRect.top + arrowRect.height / 2
+
+        expect(referenceCenterY).to.equal(arrowCenterY)
+    })
+})
+
+Then('the Arrow is at the bottom of the Popper', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-popover"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$popover, $arrow]) => {
+        const popoverRect = $popover.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const arrowCenterY = arrowRect.top + arrowRect.height / 2
+
+        expect(popoverRect.bottom).to.equal(arrowCenterY)
+    })
+})
+Then('the Arrow is at the left of the Popper', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-popover"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$popover, $arrow]) => {
+        const popoverRect = $popover.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const arrowCenterX = arrowRect.left + arrowRect.width / 2
+
+        expect(popoverRect.left).to.equal(arrowCenterX)
+    })
+})
+Then('the Arrow is at the top of the Popper', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-popover"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$popover, $arrow]) => {
+        const popoverRect = $popover.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const arrowCenterY = arrowRect.top + arrowRect.height / 2
+
+        expect(popoverRect.top).to.equal(arrowCenterY)
+    })
+})
+Then('the Arrow is at the right of the Popper', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-popover"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$popover, $arrow]) => {
+        const popoverRect = $popover.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const arrowCenterX = arrowRect.left + arrowRect.width / 2
+
+        expect(popoverRect.right).to.equal(arrowCenterX)
+    })
+})
+
+Then('the Arrow is at the top half of the Popper', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-popover"]'),
+        () => cy.get('[data-test="dhis2-uicore-popoverarrow"]')
+    ).should(([$popover, $arrow]) => {
+        const popoverRect = $popover.get(0).getBoundingClientRect()
+        const arrowRect = $arrow.get(0).getBoundingClientRect()
+        const popoverCenterY = popoverRect.top + popoverRect.height / 2
+        const arrowCenterY = arrowRect.top + arrowRect.height / 2
+
+        expect(popoverCenterY).to.greaterThan(arrowCenterY)
+    })
+})

--- a/cypress/integration/Popover/clicking_outside.feature
+++ b/cypress/integration/Popover/clicking_outside.feature
@@ -1,6 +1,6 @@
 Feature: Popover clicking outside
 
     Scenario: Responds to a click outdside the Popover
-        Given a default Popper is rendered with an onClickOutside handler
+        Given a default Popover is rendered with an onClickOutside handler
         When the user clicks outside of the Popover
         Then the clickOutside handler is called

--- a/cypress/integration/Popover/clicking_outside/index.js
+++ b/cypress/integration/Popover/clicking_outside/index.js
@@ -3,7 +3,7 @@ import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 Given('a default Popper is rendered with arrow set to true', () => {
     cy.visitStory('Popover', 'Default')
 })
-Given('a default Popper is rendered with an onClickOutside handler', () => {
+Given('a default Popover is rendered with an onClickOutside handler', () => {
     cy.visitStory('Popover', 'With On Click Outside')
 })
 When('the user clicks outside of the Popover', () => {

--- a/cypress/integration/Popper/accepts_different_reference_types.feature
+++ b/cypress/integration/Popper/accepts_different_reference_types.feature
@@ -1,0 +1,16 @@
+Feature: Accept different reference types
+
+    Scenario: Accepts a React Ref
+        Given a Popper with placement bottom-start has a React Ref as its reference
+        Then the top of the popper is adjacent to the bottom of the reference element
+        And the left of the popper is aligned with the left of the reference element
+
+    Scenario: Accepts a DOM node
+        Given a Popper with placement bottom-start has a DOM node as its reference
+        Then the top of the popper is adjacent to the bottom of the reference element
+        And the left of the popper is aligned with the left of the reference element
+
+    Scenario: Accepts a virtual element
+        Given a Popper with placement bottom-start has a virtual element as its reference
+        Then the top and left of the popper correspond with the virtualElement
+

--- a/cypress/integration/Popper/accepts_different_reference_types/index.js
+++ b/cypress/integration/Popper/accepts_different_reference_types/index.js
@@ -1,0 +1,58 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+Given(
+    'a Popper with placement bottom-start has a React Ref as its reference',
+    () => {
+        cy.visitStory('Popper', 'React Ref As Reference')
+    }
+)
+Given(
+    'a Popper with placement bottom-start has a DOM node as its reference',
+    () => {
+        cy.visitStory('Popper', 'DOM Node As Reference')
+    }
+)
+Given(
+    'a Popper with placement bottom-start has a virtual element as its reference',
+    () => {
+        cy.visitStory('Popper', 'Virtual Element As Reference')
+    }
+)
+Then(
+    'the left of the popper is aligned with the left of the reference element',
+    () => {
+        cy.all(
+            () => cy.get('button'),
+            () => cy.get('[data-test="dhis2-uicore-popper"]')
+        ).should(([$reference, $popper]) => {
+            const referenceRect = $reference.get(0).getBoundingClientRect()
+            const popperRect = $popper.get(0).getBoundingClientRect()
+
+            expect(referenceRect.left).to.equal(popperRect.left)
+        })
+    }
+)
+Then(
+    'the top of the popper is adjacent to the bottom of the reference element',
+    () => {
+        cy.all(
+            () => cy.get('button'),
+            () => cy.get('[data-test="dhis2-uicore-popper"]')
+        ).should(([$reference, $popper]) => {
+            const referenceRect = $reference.get(0).getBoundingClientRect()
+            const popperRect = $popper.get(0).getBoundingClientRect()
+
+            expect(referenceRect.bottom).to.equal(popperRect.top)
+        })
+    }
+)
+Then(
+    'the top and left of the popper correspond with the virtualElement',
+    () => {
+        cy.get('[data-test="dhis2-uicore-popper"]').should($popper => {
+            const popperRect = $popper.get(0).getBoundingClientRect()
+
+            expect(popperRect.top).to.equal(200)
+            expect(popperRect.left).to.equal(200)
+        })
+    }
+)

--- a/packages/core/src/Popover/Arrow.js
+++ b/packages/core/src/Popover/Arrow.js
@@ -18,6 +18,7 @@ const Arrow = forwardRef(({ hidden, popperPlacement, styles }, ref) => (
             div {
                 width: ${ARROW_SIZE}px;
                 height: ${ARROW_SIZE}px;
+                position: absolute;
             }
 
             div.top {

--- a/packages/core/src/Popover/Popover.stories.e2e.js
+++ b/packages/core/src/Popover/Popover.stories.e2e.js
@@ -22,7 +22,12 @@ class PopperInBoxWithCenteredReferenceElement extends Component {
     ref = createRef()
 
     render() {
-        const { paddingTop, ...popoverProps } = this.props
+        const {
+            paddingTop,
+            popoverHeight,
+            popoverWidth,
+            ...popoverProps
+        } = this.props
         return (
             <div style={{ ...boxStyle, paddingTop, height: paddingTop + 100 }}>
                 <div
@@ -35,9 +40,10 @@ class PopperInBoxWithCenteredReferenceElement extends Component {
                 <Popover reference={this.ref} {...popoverProps}>
                     <div
                         data-test="popover-content"
-                        style={{ width: 336, height: 200 }}
+                        style={{ width: popoverWidth, height: popoverHeight }}
                     >
-                        I am in a box with width: 360px and height: 200px
+                        I am in a box with width: {popoverWidth}px and height:{' '}
+                        {popoverHeight}px
                     </div>
                 </Popover>
             </div>
@@ -46,9 +52,13 @@ class PopperInBoxWithCenteredReferenceElement extends Component {
 }
 PopperInBoxWithCenteredReferenceElement.defaultProps = {
     paddingTop: 220,
+    popoverHeight: 200,
+    popoverWidth: 336,
 }
 PopperInBoxWithCenteredReferenceElement.propTypes = {
     paddingTop: propTypes.number,
+    popoverHeight: propTypes.number,
+    popoverWidth: propTypes.number,
 }
 
 window.onClickOutside = window.Cypress && window.Cypress.cy.stub()
@@ -71,5 +81,49 @@ export const NoArrow = () => (
 export const WithOnClickOutside = () => (
     <PopperInBoxWithCenteredReferenceElement
         onClickOutside={window.onClickOutside}
+    />
+)
+export const PlacementTop = () => (
+    <PopperInBoxWithCenteredReferenceElement
+        popoverHeight={40}
+        popoverWidth={180}
+        paddingTop={50}
+        placement="top"
+    />
+)
+
+export const PlacementRight = () => (
+    <PopperInBoxWithCenteredReferenceElement
+        popoverHeight={60}
+        popoverWidth={130}
+        paddingTop={50}
+        placement="right"
+    />
+)
+
+export const PlacementBottom = () => (
+    <PopperInBoxWithCenteredReferenceElement
+        popoverHeight={40}
+        popoverWidth={180}
+        paddingTop={50}
+        placement="bottom"
+    />
+)
+
+export const PlacementLeft = () => (
+    <PopperInBoxWithCenteredReferenceElement
+        popoverHeight={60}
+        popoverWidth={130}
+        paddingTop={50}
+        placement="left"
+    />
+)
+
+export const ShiftedArrow = () => (
+    <PopperInBoxWithCenteredReferenceElement
+        popoverHeight={160}
+        popoverWidth={130}
+        paddingTop={1}
+        placement="left"
     />
 )

--- a/packages/core/src/Popper/Popper.js
+++ b/packages/core/src/Popper/Popper.js
@@ -104,7 +104,7 @@ Popper.propTypes = {
     observePopperResize: propTypes.bool,
     observeReferenceResize: propTypes.bool,
     placement: sharedPropTypes.popperPlacementPropType,
-    reference: sharedPropTypes.elementRefPropType,
+    reference: sharedPropTypes.popperReferencePropType,
     strategy: propTypes.oneOf(['absolute', 'fixed']), // defaults to 'absolute'
     onFirstUpdate: propTypes.func,
 }

--- a/packages/core/src/Popper/Popper.stories.e2e.js
+++ b/packages/core/src/Popper/Popper.stories.e2e.js
@@ -1,145 +1,124 @@
-import React, { Component, createRef } from 'react'
+import React, { useRef, useState } from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { Popper } from './Popper.js'
 
-const boxStyle = {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 400,
-    height: 400,
-    marginBottom: 1000,
-    backgroundColor: 'aliceblue',
-}
+const PopperPlacement = ({ placement }) => {
+    const ref = useRef()
 
-const referenceElementStyle = {
-    width: 100,
-    height: 50,
-    backgroundColor: 'cadetblue',
-    textAlign: 'center',
-    padding: 6,
-}
-
-const popperStyle = {
-    width: 80,
-    height: 30,
-    backgroundColor: 'lightblue',
-    textAlign: 'center',
-    padding: 6,
-}
-
-class BoxWithCenteredReferenceElement extends Component {
-    ref = createRef()
-
-    render() {
-        const { renderChildren } = this.props
-        return (
-            <div className="box" style={boxStyle}>
-                <div
-                    className="reference-element"
-                    style={referenceElementStyle}
-                    ref={this.ref}
-                >
-                    Reference element
-                </div>
-                {renderChildren({ referenceElement: this.ref })}
+    return (
+        <div className="box">
+            <div className="reference-element" ref={ref}>
+                Reference element
             </div>
-        )
-    }
-}
-BoxWithCenteredReferenceElement.propTypes = {
-    renderChildren: propTypes.func,
+            <Popper reference={ref} placement={placement}>
+                <div className="popper-content">Popper</div>
+            </Popper>
+            <style jsx>{`
+                .box {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 400px;
+                    height: 400px;
+                    margin-bottom: 1000px;
+                    background-color: aliceblue;
+                }
+
+                .reference-element {
+                    width: 100px;
+                    height: 50px;
+                    background-color: cadetblue;
+                    text-align: center;
+                    padding: 6px;
+                }
+
+                .popper-content {
+                    width: 80px;
+                    height: 30px;
+                    background-color: lightblue;
+                    text-align: center;
+                    padding: 6px;
+                }
+            `}</style>
+        </div>
+    )
 }
 
-const PopperWithStyledContent = ({ referenceElement, placement }) => (
-    <Popper reference={referenceElement} placement={placement} className="test">
-        <div style={popperStyle}>Popper</div>
-    </Popper>
-)
-PopperWithStyledContent.propTypes = {
+PopperPlacement.propTypes = {
     placement: propTypes.string,
-    referenceElement: propTypes.object,
 }
 
 export default {
     title: 'Popper',
     component: Popper,
-    decorators: [
-        storyFN => <BoxWithCenteredReferenceElement renderChildren={storyFN} />,
-    ],
 }
 
-/* eslint-disable react/prop-types */
-export const Top = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="top"
-    />
-)
-export const TopStart = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="top-start"
-    />
-)
-export const TopEnd = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="top-end"
-    />
-)
-export const Bottom = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="bottom"
-    />
-)
-export const BottomStart = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="bottom-start"
-    />
-)
-export const BottomEnd = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="bottom-end"
-    />
-)
-export const Right = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="right"
-    />
-)
-export const RightStart = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="right-start"
-    />
-)
-export const RightEnd = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="right-end"
-    />
-)
-export const Left = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="left"
-    />
-)
-export const LeftStart = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="left-start"
-    />
-)
-export const LeftEnd = ({ referenceElement }) => (
-    <PopperWithStyledContent
-        referenceElement={referenceElement}
-        placement="left-end"
-    />
-)
+export const Top = () => <PopperPlacement placement="top" />
+
+export const TopStart = () => <PopperPlacement placement="top-start" />
+
+export const TopEnd = () => <PopperPlacement placement="top-end" />
+
+export const Bottom = () => <PopperPlacement placement="bottom" />
+
+export const BottomStart = () => <PopperPlacement placement="bottom-start" />
+
+export const BottomEnd = () => <PopperPlacement placement="bottom-end" />
+
+export const Right = () => <PopperPlacement placement="right" />
+
+export const RightStart = () => <PopperPlacement placement="right-start" />
+
+export const RightEnd = () => <PopperPlacement placement="right-end" />
+
+export const Left = () => <PopperPlacement placement="left" />
+
+export const LeftStart = () => <PopperPlacement placement="left-start" />
+
+export const LeftEnd = () => <PopperPlacement placement="left-end" />
+
+export const ReactRefAsReference = () => {
+    const ref = useRef()
+
+    return (
+        <>
+            <button ref={ref}>Reference</button>
+            <Popper placement="bottom-start" reference={ref}>
+                Popper
+            </Popper>
+        </>
+    )
+}
+
+export const DOMNodeAsReference = () => {
+    const [node, setNode] = useState(null)
+
+    return (
+        <>
+            <button ref={setNode}>Reference</button>
+            <Popper placement="bottom-start" reference={node}>
+                Popper
+            </Popper>
+        </>
+    )
+}
+
+export const VirtualElementAsReference = () => {
+    const virtualElement = {
+        getBoundingClientRect: () => ({
+            top: 200,
+            left: 200,
+            bottom: 'auto',
+            right: 'auto',
+            width: 0,
+            height: 0,
+        }),
+    }
+
+    return (
+        <Popper placement="bottom-start" reference={virtualElement}>
+            Popper
+        </Popper>
+    )
+}


### PR DESCRIPTION
This adds some tests to check the arrow positions for the `Popover` and different reference types for the `Popper`. When merged, issue https://github.com/dhis2/ui/issues/83 can be closed.

Along the way I also fixed a few typos and a bug (see commit 209e5be and this issue popperjs/react-popper#354)
