### PR TITLE
fix: force left-to-right element flow in Headerbar

### DIFF
--- a/packages/widgets/src/HeaderBar/HeaderBar.js
+++ b/packages/widgets/src/HeaderBar/HeaderBar.js
@@ -53,8 +53,9 @@ export const HeaderBar = ({ appName, className }) => {
         i18n.changeLanguage(locale)
     }
 
+    // TODO: Remove dir="ltr" when rtl element flow is supported (DHIS2-8648)
     return (
-        <header className={className}>
+        <header className={className} dir="ltr">
             {!loading && !error && (
                 <>
                     <Logo />

--- a/packages/widgets/src/HeaderBar/HeaderBar.js
+++ b/packages/widgets/src/HeaderBar/HeaderBar.js
@@ -11,7 +11,7 @@ import { Logo } from './Logo.js'
 import { Title } from './Title.js'
 import { Notifications } from './Notifications.js'
 
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales'
 import { joinPath } from './joinPath.js'
 
 const query = {

--- a/packages/widgets/src/HeaderBar/HeaderBar.js
+++ b/packages/widgets/src/HeaderBar/HeaderBar.js
@@ -11,7 +11,7 @@ import { Logo } from './Logo.js'
 import { Title } from './Title.js'
 import { Notifications } from './Notifications.js'
 
-import i18n from '../locales'
+import i18n from '../locales/index.js'
 import { joinPath } from './joinPath.js'
 
 const query = {

--- a/packages/widgets/src/HeaderBar/HeaderBar.stories.js
+++ b/packages/widgets/src/HeaderBar/HeaderBar.stories.js
@@ -143,6 +143,25 @@ const customLocaleData = {
     },
 }
 
+const customRtlData = {
+    ...customData,
+    'systemSettings/applicationTitle': {
+        applicationTitle: 'الأعظم في كل الأوقات', // The greatest of all time
+    },
+    me: {
+        ...customData.me,
+        settings: {
+            keyUiLocale: 'ar',
+        },
+    },
+    'action::menu/getModules': {
+        modules: customData['action::menu/getModules'].modules.map(mod => ({
+            ...mod,
+            displayName: 'مرحبا بالعالم', // Hello, world
+        })),
+    },
+}
+
 const customAuthoritiesData = {
     ...customData,
     me: {
@@ -166,13 +185,25 @@ storiesOf('Components/Widgets/HeaderBar', module)
             </CustomDataProvider>
         </Provider>
     ))
-    .add('Non-english user locale', () => (
+    .add('locale: French', () => (
         <Provider config={mockConfig}>
             <CustomDataProvider data={customLocaleData}>
                 <HeaderBar appName="Exemple!" />
             </CustomDataProvider>
         </Provider>
     ))
+    .add('locale: Arabic (right-to-left)', () => {
+        const appName = 'تتريس' // Tetris
+        return (
+            <Provider config={mockConfig}>
+                <CustomDataProvider data={customRtlData}>
+                    <div dir="rtl">
+                        <HeaderBar appName={appName} />
+                    </div>
+                </CustomDataProvider>
+            </Provider>
+        )
+    })
     .add('No authority for interpretations app', () => (
         <Provider config={mockConfig}>
             <CustomDataProvider data={customAuthoritiesData}>


### PR DESCRIPTION
This is a temporary fix for applications (such as the Capture app) which set `dir="rtl"` on `<html>` or `<body>`.  We might want to support rtl element flow in the Headerbar, but currently it breaks in that mode.

TODO: Story or cypress tests?