### PR TITLE
docs(readme): add link to v5 blogpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 
+Read our blogpost for the release of `@dhis2/ui` version 5 here: https://developers.dhis2.org/2020/05/ui-5
+
 ---
 
 -   Docs: [ui.dhis2.nu](https://ui.dhis2.nu)


### PR DESCRIPTION
Adds a link to the readme for the blogpost, so that it's a bit easier to discover.