### PR TITLE
docs(getting-started): fix badge and polyfills section

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,3 @@ yarn add @dhis2/ui
 ### React >= 16.3
 
 This library uses the official React Context API (introduced in 16.3) and React Fragments.
-
-### Polyfills
-
-> TODO

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-[![npm](https://img.shields.io/npm/v/@dhis2/ui-core.svg)](https://www.npmjs.com/package/@dhis2/ui-core)
+[![npm](https://img.shields.io/npm/v/@dhis2/ui.svg)](https://www.npmjs.com/package/@dhis2/ui)
 
 ## Installation
 


### PR DESCRIPTION
If we want to add a polyfills section we can always do that later. I don't see any added value in having the TODO there, so I removed it.

The badge was pointing to ui-core, so I fixed that as well.