### PR TITLE
docs(concepts): remove concepts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,5 @@
 # Conceptual design of @dhis2/ui
 
-## :warning: UNDER CONSTRUCTION :warning:
-
-The alpha version is still under construction, these are the steps we need to
-turn go get this version into a stable one:
-
--   [x] Move components from `ui-core` & `ui-widget` to the `ui` monorepo
--   [ ] Add breaking changes
--   [ ] Re-organize library
-
 ## Monorepo
 
 UI is a monorepo that contains all the UI-related packages for DHIS 2.


### PR DESCRIPTION
I've gone through the concepts doc, and I think it's actually not very interesting to our users in its current form. I can see the use of an overview of our libraries, but I think this document is currently written more from our point of view, as developers, not for consumers of the lib.

I propose we remove this section, as in its current state I think it's a bit confusing to lib users, and move it to an issue, where we plan adding a `Developing` section. Then we can rewrite where necessary, and add this section back as an instruction to developers that want to contribute.