### PR TITLE
fix: move internal and singleton dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,10 +55,12 @@
         "watch:widgets": "yarn build:widgets --watch --dev"
     },
     "devDependencies": {
+        "@dhis2/app-runtime": "^2.2.2",
         "@dhis2/cli-app-scripts": "^4.0.8",
         "@dhis2/cli-style": "^7.0.0",
         "@dhis2/cli-utils-cypress": "^2.2.1",
         "@dhis2/cli-utils-docsite": "^2.0.2",
+        "@dhis2/d2-i18n": "^1.0.6",
         "@storybook/addons": "^5.3.9",
         "@storybook/components": "^5.3.19",
         "@storybook/csf": "^0.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,14 +19,14 @@
         "build": "d2-app-scripts build"
     },
     "peerDependencies": {
+        "@dhis2/ui-constants": "^5.3",
+        "@dhis2/ui-icons": "^5.3",
         "react": "^16.8",
         "react-dom": "^16.8",
         "styled-jsx": "^3.2"
     },
     "dependencies": {
         "@dhis2/prop-types": "^1.6.4",
-        "@dhis2/ui-constants": "5.3.2",
-        "@dhis2/ui-icons": "5.3.2",
         "@popperjs/core": "^2.4.2",
         "classnames": "^2.2.6",
         "react-popper": "^2.2.3",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -16,12 +16,12 @@
         "build": "d2-app-scripts build"
     },
     "peerDependencies": {
+        "@dhis2/ui-core": "^5.3",
         "react": "^16.8",
         "react-dom": "^16.8"
     },
     "dependencies": {
         "@dhis2/prop-types": "^1.6.4",
-        "@dhis2/ui-core": "5.3.2",
         "classnames": "^2.2.6",
         "final-form": "^4.20.0",
         "react-final-form": "^6.5.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,5 +15,12 @@
         "@dhis2/ui-core": "5.3.2",
         "@dhis2/ui-forms": "5.3.2",
         "@dhis2/ui-widgets": "5.3.2"
+    },
+    "peerDependencies": {
+        "react": "^16.8",
+        "react-dom": "^16.8",
+        "styled-jsx": "^3.2",
+        "@dhis2/app-runtime": "^2",
+        "@dhis2/d2-i18n": "^1"
     }
 }

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -20,17 +20,16 @@
     "peerDependencies": {
         "react": "^16.8",
         "react-dom": "^16.8",
-        "styled-jsx": "^3.2"
+        "styled-jsx": "^3.2",
+        "@dhis2/ui-core": "^5.3",
+        "@dhis2/ui-icons": "^5.3",
+        "@dhis2/ui-constants": "^5.3",
+        "@dhis2/app-runtime": "^2",
+        "@dhis2/d2-i18n": "^1"
     },
     "dependencies": {
-        "@dhis2/app-runtime": "^2.2.2",
-        "@dhis2/d2-i18n": "^1",
         "@dhis2/prop-types": "^1.6.4",
-        "@dhis2/ui-constants": "5.3.2",
-        "@dhis2/ui-core": "5.3.2",
-        "@dhis2/ui-icons": "5.3.2",
-        "classnames": "^2.2.6",
-        "resize-observer-polyfill": "^1.5.1"
+        "classnames": "^2.2.6"
     },
     "files": [
         "build"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1480,7 +1480,7 @@
     live-server "^1.2.1"
     match-all "^1.2.5"
 
-"@dhis2/d2-i18n@^1", "@dhis2/d2-i18n@^1.0.5":
+"@dhis2/d2-i18n@^1.0.5", "@dhis2/d2-i18n@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-i18n/-/d2-i18n-1.0.6.tgz#2914be8acf296f3a6bf7b51c76c46da6a120b0ff"
   integrity sha512-7YdA4ppFosjuyf7ZMm47BrdsA5TWLM9lmS0lUPgjcCVeeWfUgagqzf4W5JGB9XQ3w1vzK+yy5zH2Ij8IgRAGhA==


### PR DESCRIPTION
This moves internal dependencies (as well as external dependencies which operate as singletons) to peerDependencies.

Technically this is breaking, but since it was incorrect to include these as runtime deps in the very recent v5 release I think it's OK (gulp) to release this as a fix.