### PR TITLE
docs(sidebar): update sidebar links

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,7 +1,7 @@
 -   [**Getting started**](getting-started)
 -   [**API**](api)
--   [**Concepts**](concepts)
 -   [**Live demos**](/demo/ ':ignore Live demos')
 -   [**Troubleshooting**](troubleshooting)
+-   [**Advanced usage**](advanced-usage)
 -   &nbsp;
 -   [Changelog](CHANGELOG.md)


### PR DESCRIPTION
I forgot to update the sidebar links, I thought these were automatically generated but they're not.