### PR TITLE
docs(readme): update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Read our blogpost for the release of `@dhis2/ui` version 5 here: https://develop
 
 ---
 
-| Package             | Description | Link                                           |
-| ------------------- | ----------- | ---------------------------------------------- |
-| @dhis2/ui           | n/a         | [packages/ui](packages/ui)                     |
-| @dhis2/ui-constants | n/a         | [packages/ui-constants](packages/ui-constants) |
-| @dhis2/ui-core      | n/a         | [packages/ui-core](packages/ui-core)           |
-| @dhis2/ui-forms     | n/a         | [packages/ui-forms](packages/ui-forms)         |
-| @dhis2/ui-icons     | n/a         | [packages/ui-icons](packages/ui-icons)         |
-| @dhis2/ui-widgets   | n/a         | [packages/ui-widgets](packages/ui-widgets)     |
+| Package             | Link                                           |
+| ------------------- | ---------------------------------------------- |
+| @dhis2/ui           | [packages/ui](packages/ui)                     |
+| @dhis2/ui-constants | [packages/ui-constants](packages/ui-constants) |
+| @dhis2/ui-core      | [packages/ui-core](packages/ui-core)           |
+| @dhis2/ui-forms     | [packages/ui-forms](packages/ui-forms)         |
+| @dhis2/ui-icons     | [packages/ui-icons](packages/ui-icons)         |
+| @dhis2/ui-widgets   | [packages/ui-widgets](packages/ui-widgets)     |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DHIS2 UI
 
-[![@dhis2/ui on npm](https://img.shields.io/npm/v/@dhis2/ui.svg)](https://www.npmjs.com/package/@dhis2/ui)
+[![@dhis2/ui on npm](https://badge.fury.io/js/%40dhis2%2Fui.svg)](https://www.npmjs.com/package/@dhis2/ui)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 


### PR DESCRIPTION
Our npm version badge isn't displaying properly. We're using the correct syntax (see docs: https://shields.io/category/version). See also these:

* https://img.shields.io/npm/v/@dhis2/ui.svg
* https://img.shields.io/npm/v/dhis2/ui.svg

In my personal experience shields.io is quite unreliable, so I've switched the badge to a provider that work atm., you can verify it here: https://github.com/dhis2/ui/blob/66d3b94c607d142889419961e27ab55cb9c72cf7/README.md. Alongside that I've removed the empty description column. If we want to add descriptions we can always do that later.