### PR TITLE
fix(menu): stop using child's dense prop to set value of hideDivider

### DIFF
--- a/packages/core/src/Menu/Menu.js
+++ b/packages/core/src/Menu/Menu.js
@@ -24,7 +24,7 @@ const Menu = ({ children, className, dataTest, dense }) => (
                           typeof child.props.hideDivider !== 'boolean' &&
                           index === 0
                               ? true
-                              : child.props.dense,
+                              : child.props.hideDivider,
                   })
                 : child
         )}

--- a/packages/core/src/Menu/Menu.stories.js
+++ b/packages/core/src/Menu/Menu.stories.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { MenuItem } from '../MenuItem/MenuItem.js'
 import { Menu } from './Menu.js'
+import { MenuSectionHeader } from '../MenuSectionHeader/MenuSectionHeader.js'
 
 export default {
     title: 'Menu',
@@ -19,6 +20,13 @@ export const Dense = () => (
     <Menu dense>
         <MenuItem label="Menu item" />
         <MenuItem label="Menu item" />
+    </Menu>
+)
+
+export const AutoHideFirstSectionHeaderDivider = () => (
+    <Menu>
+        <MenuSectionHeader label="First - no divider above" />
+        <MenuSectionHeader label="Second - with divider above" />
     </Menu>
 )
 


### PR DESCRIPTION
This relates to #176. We are dealing with two things here:
- A potentially confusing feature, hiding the divider from the menu-section-header if it's the first child of a menu. In most cases I think this behaviour does make (some) sense and it's possible to "opt out" of this behaviour by explicitly setting `hideDivider` to `false`.
- A bug in the implementation of this feature.

Currently all I've done in this PR is to fix that bug, and introduce an example of the feature.

However, I'd also be fine removing the feature. It seems to be causing more confusion than it brings convenience.

Let me know what you'd prefer.