### PR TITLE
fix(select): check if select has been mounted before accessing ref

### DIFF
--- a/packages/core/src/Select/Select.js
+++ b/packages/core/src/Select/Select.js
@@ -43,12 +43,17 @@ export class Select extends Component {
      * See: https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web
      */
     setMenuWidth = debounce(() => {
-        const inputWidth = `${this.inputRef.current.offsetWidth}px`
+        const hasOffsetWidth =
+            this.inputRef.current && this.inputRef.current.offsetWidth
 
-        if (this.state.menuWidth !== inputWidth) {
-            this.setState({
-                menuWidth: inputWidth,
-            })
+        if (hasOffsetWidth) {
+            const inputWidth = `${this.inputRef.current.offsetWidth}px`
+
+            if (this.state.menuWidth !== inputWidth) {
+                this.setState({
+                    menuWidth: inputWidth,
+                })
+            }
         }
     }, 50)
 


### PR DESCRIPTION
I forgot to add a check to make sure the select has been mounted before accessing `offsetWidth`, which at times leads to this error:

<img width="845" alt="Screenshot 2020-06-23 at 11 08 09" src="https://user-images.githubusercontent.com/7355199/85384905-eeac6a80-b541-11ea-83e4-0b4432749ec8.png">

This fixes that error.