### PR TITLE
fix(switch): use input value instead of checked for the value

### DIFF
--- a/packages/forms/src/SwitchFieldFF/SwitchFieldFF.js
+++ b/packages/forms/src/SwitchFieldFF/SwitchFieldFF.js
@@ -27,7 +27,7 @@ export const SwitchFieldFF = ({
         {...rest}
         checked={input.checked}
         name={input.name}
-        value={input.checked}
+        value={input.value}
         error={hasError(meta, error)}
         valid={isValid(meta, valid, showValidStatus)}
         validationText={getValidationText(meta, validationText, error)}

--- a/packages/widgets/src/SwitchField/SwitchField.js
+++ b/packages/widgets/src/SwitchField/SwitchField.js
@@ -133,7 +133,7 @@ SwitchField.propTypes = {
     tabIndex: propTypes.string,
     valid: sharedPropTypes.statusPropType,
     validationText: propTypes.string,
-    value: propTypes.oneOfType([propTypes.string, propTypes.bool]),
+    value: propTypes.string,
     warning: sharedPropTypes.statusPropType,
     onBlur: propTypes.func,
     onChange: propTypes.func,


### PR DESCRIPTION
My earlier fix unearthed a different issue, namely that we're passing `input.checked` to the Switch's `value` prop. According to the MDN docs on the [checkbox input](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox), the input property is just for specifying a string that will be submitted to the backend if the checkbox is checked. Final-form seems to comply with this as well:

<img width="679" alt="Screenshot 2020-07-02 at 13 54 17" src="https://user-images.githubusercontent.com/7355199/86355822-907f3600-bc6b-11ea-80ca-828406e54037.png">

> https://final-form.org/docs/react-final-form/types/FieldProps

 So instead of `checked` we should be passing `value` here. I see we already do this with the RadioFieldFF and CheckboxFieldFF, so I think this was just a typo.