### PR TITLE
fix(input): allow number proptype on input value prop

### DIFF
--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -194,7 +194,7 @@ Input.defaultProps = {
  * @prop {function} [onFocus]
  * @prop {string} [className]
  * @prop {string} [placeholder]
- * @prop {string} [value]
+ * @prop {(string|number)} [value]
  * @prop {string} [tabIndex]
  *
  * @prop {boolean} [disabled]
@@ -237,7 +237,7 @@ Input.propTypes = {
         'search',
     ]),
     valid: sharedPropTypes.statusPropType,
-    value: propTypes.string,
+    value: propTypes.oneOfType([propTypes.string, propTypes.number]),
     warning: sharedPropTypes.statusPropType,
     onBlur: propTypes.func,
     onChange: propTypes.func,

--- a/packages/widgets/src/InputField/InputField.js
+++ b/packages/widgets/src/InputField/InputField.js
@@ -97,7 +97,7 @@ InputField.defaultProps = {
  * @prop {string} [label]
  * @prop {string} [className]
  * @prop {string} [placeholder]
- * @prop {string} [value]
+ * @prop {(string|number)} [value]
  * @prop {string} [tabIndex]
  * @prop {string} [inputWidth]
  *
@@ -136,7 +136,7 @@ InputField.propTypes = {
     type: Input.propTypes.type,
     valid: sharedPropTypes.statusPropType,
     validationText: propTypes.string,
-    value: propTypes.string,
+    value: propTypes.oneOfType([propTypes.string, propTypes.number]),
     warning: sharedPropTypes.statusPropType,
     onBlur: propTypes.func,
     onChange: propTypes.func,


### PR DESCRIPTION
We currently don't allow numbers for the `Input` `value` prop, if you look at the prop-types. This adds the `number` type for `<input type="number" />`.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number