### PR TITLE
feat(tech 378): add scrollable area

### DIFF
--- a/cypress/integration/Scrollable/Notify_on_area_transition.feature
+++ b/cypress/integration/Scrollable/Notify_on_area_transition.feature
@@ -1,0 +1,26 @@
+Feature: The Scrollable component notified the subscriber when the area changes
+
+    Scenario: The user scrolls from the top area to the middle area
+        Given the top area is visible
+        When the user scrolls the top area out of the viewport
+        Then the onAreaEnter callback should be called
+        And the payload should contain middle as new area
+
+    Scenario: The user scrolls from the middle area to the top area
+        Given the top area is not visible
+        When the user scrolls the top area into the viewport
+        Then the onAreaEnter callback should be called
+        And the payload should contain top as new area
+
+    Scenario: The user scrolls from the middle area to the bottom area
+        Given the top area is not visible
+        And the bottom area is not visible
+        When the user scrolls the bottom area into the viewport
+        Then the onAreaEnter callback should be called
+        And the payload should contain bottom as new area
+
+    Scenario: The user scrolls from the bottom area to the middle area
+        Given the bottom area is visible
+        When the user scrolls the bottom area out of the viewport
+        Then the onAreaEnter callback should be called
+        And the payload should contain middle as new area

--- a/packages/core/src/Scrollable/Scrollable.js
+++ b/packages/core/src/Scrollable/Scrollable.js
@@ -1,0 +1,157 @@
+import React, { useEffect, useRef, useState } from 'react'
+import propTypes from '@dhis2/prop-types'
+;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
+
+const TOP = 'top'
+const MIDDLE = 'middle'
+const END = 'end'
+
+const onScrollFactory = ({
+    currentPosition,
+    endTolerance,
+    onAreaEnter,
+    prevScrollTop,
+    setCurrentPosition,
+    setPrevScrollTop,
+    topTolerance,
+}) => scrollableElement => {
+    // WIll contain the next area IF it changes
+    let nextArea
+
+    // scrollHeight = Height of the scrollable area in px
+    // scrollTop = How many pixels the scrollable area has been scrolled
+    // clientHeight = Height of the actual scrollable box
+    const { scrollHeight, scrollTop, clientHeight } = scrollableElement
+
+    // Initial call
+    // This way `scrolledUp` and `scrolledDown` will be true
+    // during the initial call so they won't matter
+    const initialCall = prevScrollTop === -1
+
+    // Scroll up if previously was scrolled down more
+    const scrolledUp = initialCall || scrollTop < prevScrollTop
+    // Is at top when scroll top is less than the tolerance
+    const isAtTop = scrollTop <= topTolerance
+
+    // Scroll up if previously was scrolled down less
+    const scrolledDown = initialCall || scrollTop > prevScrollTop
+    // "scrollHeight - scrollTop" will never be more than the client height
+    const isAtBottom = scrollHeight - scrollTop <= clientHeight + endTolerance
+
+    setPrevScrollTop(scrollTop)
+
+    if (scrolledDown && isAtBottom && currentPosition !== END) {
+        nextArea = END
+    } else if (scrolledUp && isAtTop && currentPosition !== TOP) {
+        nextArea = TOP
+    } else if (!isAtBottom && !isAtTop && currentPosition !== MIDDLE) {
+        nextArea = MIDDLE
+    }
+
+    if (nextArea) {
+        setCurrentPosition(nextArea)
+        onAreaEnter && onAreaEnter({ area: nextArea }, event)
+    }
+}
+
+/**
+ * @module
+ *
+ * @param {Scrollable.PropTypes} props
+ * @returns {React.Component}
+ *
+ * @example
+ * import { Scrollable } from '@dhis2/ui-core'
+ * (
+ *     <Scrollable
+ *         onAreaEnter={Put your callback here}
+ *         endTolerance={100} // in pixels
+ *         topTolerance={100} // in pixels
+ *     />
+ * )
+ *
+ * @see Specification: {@link https://github.com/dhis2/design-system/blob/master/molecules/select.md|Design system}
+ */
+export const Scrollable = ({
+    children,
+    className,
+    endTolerance,
+    topTolerance,
+    onAreaEnter,
+}) => {
+    const ref = useRef(null)
+
+    // ensures that callback is not fired again when
+    // scrolling down inside the tolerance zone
+    // Can not set initial position here as the "end" section
+    // might already be in the visible area
+    const [currentPosition, setCurrentPosition] = useState('')
+
+    // Used to check whether the user scrolled down or up.
+    // This value is -1 so the initial value of "currentPosition"
+    // will be evaluated to "end" if "end" if the end section is
+    // already in the visible area
+    const [prevScrollTop, setPrevScrollTop] = useState(-1)
+
+    const onScroll = onScrollFactory({
+        currentPosition,
+        endTolerance,
+        onAreaEnter,
+        prevScrollTop,
+        setCurrentPosition,
+        setPrevScrollTop,
+        topTolerance,
+    })
+
+    // Use the onScroll logic to determine the initial position.
+    // Additionally this will notify the consumer about the initial position
+    useEffect(() => {
+        if (ref.current && !currentPosition) {
+            onScroll(ref.current)
+        }
+    }, [ref.current, currentPosition])
+
+    return (
+        <div
+            className={className}
+            onScroll={event => onScroll(event.target)}
+            ref={ref}
+        >
+            {children}
+
+            <style jsx>{`
+                div {
+                    max-height: 100%;
+                    max-width: 100%;
+                    overflow: hidden;
+                    overflow-y: auto;
+                }
+            `}</style>
+        </div>
+    )
+}
+
+Scrollable.defaultProps = {
+    endTolerance: 0,
+    topTolerance: 0,
+}
+
+/**
+ * @typedef {Object} PropTypes
+ * @static
+ *
+ * @prop {any} [children]
+ * @prop {string} [className]
+ * @prop {number} [endTolerance]
+ * @prop {number} [topTolerance]
+ * @prop {Function} [onAreaEnter]
+ * Will be called with the following payload:
+ * { area: 'top' or 'middle' or 'end' }
+ */
+Scrollable.propTypes = {
+    children: propTypes.any,
+    className: propTypes.string,
+    endTolerance: propTypes.number,
+    topTolerance: propTypes.number,
+    onAreaEnter: propTypes.func,
+}

--- a/packages/core/src/Scrollable/Scrollable.stories.js
+++ b/packages/core/src/Scrollable/Scrollable.stories.js
@@ -1,0 +1,157 @@
+/* eslint-disable prettier/prettier, react/prop-types */
+import React, { useState } from 'react'
+import { Scrollable } from './Scrollable.js'
+
+var sizeLimitDecorator = fn => React.createElement(() => {
+    const [area, setArea] = useState('')
+    const onAreaEnter = ({ area }) => setArea(area)
+
+    return (
+        <div style={{ width: 200, height: 300 }}>
+            <p>
+                Current area: {` ${area}`}
+            </p>
+
+            <hr />
+
+            <div style={{
+                border: '1px solid black',
+                height: '100%',
+                width: '100%',
+            }}>
+                {fn({ onAreaEnter })}
+            </div>
+        </div>
+    )
+})
+
+export default { title: 'Scrollable', decorators: [sizeLimitDecorator] }
+
+export const NoTolerance = ({ onAreaEnter }) => (
+    <Scrollable onAreaEnter={onAreaEnter}>
+        <Content topTolerance={0} endTolerance={0} />
+    </Scrollable>
+)
+
+export const WithTolerance = ({ onAreaEnter }) => (
+    <Scrollable
+        topTolerance={90}
+        endTolerance={90}
+        onAreaEnter={onAreaEnter}
+    >
+        <Content topTolerance={90} endTolerance={90} />
+    </Scrollable>
+)
+
+export const TopEndBothVisible = ({ onAreaEnter }) => (
+    <Scrollable
+        topTolerance={90}
+        endTolerance={90}
+        onAreaEnter={onAreaEnter}
+    >
+        <Content
+            topTolerance={90}
+            endTolerance={90}
+            content={() => (
+                <>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Cras tempor venenatis hendrerit. Donec dictum sed ligula id
+                    efficitur. Suspendisse feugiat, elit in dictum imperdiet,
+                    mi tellus euismod nibh, vitae hendrerit turpis odio ut
+                    mauris.
+                </>
+            )}
+        />
+    </Scrollable>
+)
+
+export const OverlappingTopEnd = ({ onAreaEnter }) => (
+    <Scrollable
+        topTolerance={90}
+        endTolerance={90}
+        onAreaEnter={onAreaEnter}
+    >
+        <Content
+            topTolerance={90}
+            endTolerance={90}
+            content={() => (
+                <>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                    Cras tempor venenatis hendrerit.
+                </>
+            )}
+        />
+    </Scrollable>
+)
+
+var Text = () => (
+    <>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras tempor
+        venenatis hendrerit. Donec dictum sed ligula id efficitur. Suspendisse
+        feugiat, elit in dictum imperdiet, mi tellus euismod nibh, vitae
+        hendrerit turpis odio ut mauris. Vestibulum rhoncus interdum nunc eu
+        eleifend. Aenean viverra nibh hendrerit nulla iaculis, vitae tincidunt
+        erat ullamcorper. Donec tempus mattis faucibus. Donec nec lacus vitae
+        elit aliquet pharetra. Cras vitae odio eu lorem euismod malesuada.
+        Nunc eu rhoncus mauris. Nullam vehicula elit id vehicula maximus.
+        Phasellus gravida tincidunt mauris, vitae laoreet erat commodo id.
+        Nullam vitae erat ante. Proin id ultricies risus, in ultricies mauris.
+        Vivamus lectus enim, ultricies vel egestas nec, tempor a magna. Nam sed
+        fermentum ipsum, a ullamcorper felis. Aenean finibus erat elit, at
+        eleifend nulla rutrum at.
+    </>
+)
+
+var Content = ({ topTolerance, endTolerance, content: Content = Text }) => (
+    <div style={{ position: 'relative', lineHeight: 2 }}>
+        <Content />
+
+        <div
+            style={{
+                height: `${topTolerance}px`,
+                width: '100%',
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                zIndex: '-1',
+                boxSizing: 'border-box',
+                borderBottom: '2px solid red',
+            }}
+        >
+            <span style={{
+                fontSize: 10,
+                lineHeight: 1,
+                color: 'red',
+                position: 'absolute',
+                bottom: '-12px',
+                left: 0,
+            }}>
+                TOLERANCE LINE
+            </span>
+        </div>
+
+        <div
+            style={{
+                height: endTolerance,
+                width: '100%',
+                position: 'absolute',
+                bottom: 0,
+                left: 0,
+                zIndex: '-1',
+                boxSizing: 'border-box',
+                borderTop: '2px solid red',
+            }}
+        >
+            <span style={{
+                fontSize: 10,
+                lineHeight: 1,
+                color: 'red',
+                position: 'absolute',
+                top: '-12px',
+                left: 0,
+            }}>
+                TOLERANCE LINE
+            </span>
+        </div>
+    </div>
+)


### PR DESCRIPTION
This will add a component that notifies the consumer about what scroll position is visible.
Currently there are 3 areas: `top`, `middle` & `end` (100% open to renaming these)

* [x] Add component
* [x] Add stories
* [ ] Write cypress tests
* [ ] Discuss edge cases
   * [ ] What if both the `top` and `end` screen are visible right from the start
     *See below*
   * [ ] What if the `top` and `end` screen overlap
     *See below*

Edge cases:
Currently, if the `end` part is visible, that part will be the initial area. If that's not the case but the top part is visible (which should always be the case), the `top` will be the initial area