### PR TITLE
feat(transfer): add filter placeholder (TECH-395)

### DIFF
--- a/packages/widgets/src/Transfer/Filter.js
+++ b/packages/widgets/src/Transfer/Filter.js
@@ -3,12 +3,13 @@ import { spacers } from '@dhis2/ui-constants'
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
-export const Filter = ({ dataTest, filter, onChange, label }) => (
+export const Filter = ({ dataTest, filter, onChange, label, placeholder }) => (
     <div data-test={dataTest}>
         <Field label={label} name={dataTest} dataTest={`${dataTest}-field`}>
             <Input
                 dataTest={`${dataTest}-input`}
                 type="search"
+                placeholder={placeholder}
                 name={dataTest}
                 value={filter}
                 onChange={onChange}
@@ -32,4 +33,5 @@ Filter.propTypes = {
     filter: propTypes.string.isRequired,
     onChange: propTypes.func.isRequired,
     label: propTypes.string,
+    placeholder: propTypes.string,
 }

--- a/packages/widgets/src/Transfer/Transfer.js
+++ b/packages/widgets/src/Transfer/Transfer.js
@@ -74,6 +74,7 @@ export const Transfer = ({
     selectedEmptyComponent,
     enableOrderChange,
     filterLabel,
+    filterPlaceholder,
     filterCallback,
     filterable,
     height,
@@ -185,6 +186,7 @@ export const Transfer = ({
                         {filterable && !hideFilterInput && (
                             <Filter
                                 label={filterLabel}
+                                placeholder={filterPlaceholder}
                                 dataTest={`${dataTest}-filter`}
                                 filter={actualFilter}
                                 onChange={
@@ -387,6 +389,7 @@ Transfer.defaultProps = {
  * @prop {bool} [hideFilterInput] Automatically true when "hideFilterInput" is true
  * @prop {bool} [enableOrderChange]
  * @prop {string} [filterLabel]
+ * @prop {string} [filterPlaceholder]
  * @prop {Function} [filterCallback]
  * @prop {string} [height]
  * @prop {bool} [hideFilterInput]
@@ -421,6 +424,7 @@ Transfer.propTypes = {
     enableOrderChange: propTypes.bool,
     filterCallback: propTypes.func,
     filterLabel: propTypes.string,
+    filterPlaceholder: propTypes.string,
     filterable: propTypes.bool,
     height: propTypes.string,
     hideFilterInput: propTypes.bool,

--- a/packages/widgets/src/Transfer/Transfer.stories.js
+++ b/packages/widgets/src/Transfer/Transfer.stories.js
@@ -172,8 +172,18 @@ export const Filtered = () => (
             initialSearchTerm="ANC"
             leftHeader={<h3>Header on the left side</h3>}
             options={options}
-            filterLabel="Filter with label and placeholder"
-            filterPlaceholder="Filter placeholder"
+        />
+    </StatefulWrapper>
+)
+
+export const FilterPlaceholder = () => (
+    <StatefulWrapper>
+        <Transfer
+            filterable
+            onChange={() => console.log('Will be overriden by StatefulWrapper')}
+            options={options}
+            filterLabel="Filter with placeholder"
+            filterPlaceholder="Search"
         />
     </StatefulWrapper>
 )

--- a/packages/widgets/src/Transfer/Transfer.stories.js
+++ b/packages/widgets/src/Transfer/Transfer.stories.js
@@ -172,6 +172,8 @@ export const Filtered = () => (
             initialSearchTerm="ANC"
             leftHeader={<h3>Header on the left side</h3>}
             options={options}
+            filterLabel="Filter with label and placeholder"
+            filterPlaceholder="Filter placeholder"
         />
     </StatefulWrapper>
 )
@@ -408,6 +410,7 @@ const createCustomFilteringInHeader = hideFilterInput => {
                 onFilterChange={({ value }) => setFilter(value)}
                 height="400px"
                 filterLabel="Filter options"
+                filterPlaceholder="Search"
             />
         )
     }


### PR DESCRIPTION
Fixes #131 

Adds a `placeholder` to the `Filter` in the `Transfer` component, as per [TECH-395](https://jira.dhis2.org/browse/TECH-395).

-----------------

_Story example: Filtered_
![image](https://user-images.githubusercontent.com/12590483/87137386-166b3480-c29d-11ea-8f75-d713ac211e8a.png)

-----------------

_Story example: Custom Filtering With Filter Input_
![image](https://user-images.githubusercontent.com/12590483/87137448-313da900-c29d-11ea-9b03-3945031b6b8a.png)

