### PR TITLE
feat(transfer): add rightHeader (TECH-394)

### DIFF
--- a/packages/widgets/src/Transfer/RightHeader.js
+++ b/packages/widgets/src/Transfer/RightHeader.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import propTypes from '@dhis2/prop-types'
+
+import { spacers } from '@dhis2/ui-constants'
+
+import { borderColor } from './common/index.js'
+
+export const RightHeader = ({ children, dataTest }) => (
+    <div data-test={dataTest}>
+        {children}
+
+        <style jsx>{`
+            div {
+                border-bottom: 1px solid ${borderColor};
+                flex-grow: 0;
+                padding: 0 ${spacers.dp8};
+            }
+        `}</style>
+    </div>
+)
+
+RightHeader.propTypes = {
+    children: propTypes.node,
+    dataTest: propTypes.string,
+}

--- a/packages/widgets/src/Transfer/Transfer.js
+++ b/packages/widgets/src/Transfer/Transfer.js
@@ -13,6 +13,7 @@ import { PickedOptions } from './PickedOptions.js'
 import { RemoveAll } from './RemoveAll.js'
 import { RemoveIndividual } from './RemoveIndividual.js'
 import { ReorderingActions } from './ReorderingActions.js'
+import { RightHeader } from './RightHeader.js'
 import { RightFooter } from './RightFooter.js'
 import { RightSide } from './RightSide.js'
 import { SourceOptions } from './SourceOptions.js'
@@ -87,6 +88,7 @@ export const Transfer = ({
     maxSelections,
     optionsWidth,
     renderOption,
+    rightHeader,
     rightFooter,
     searchTerm,
     selected,
@@ -295,6 +297,11 @@ export const Transfer = ({
             </Actions>
 
             <RightSide dataTest={`${dataTest}-rightside`} width={selectedWidth}>
+                {rightHeader && (
+                    <RightHeader dataTest={`${dataTest}-rightheader`}>
+                        {rightHeader}
+                    </RightHeader>
+                )}
                 <PickedOptions
                     dataTest={`${dataTest}-pickedoptions`}
                     selectedEmptyComponent={selectedEmptyComponent}
@@ -397,6 +404,7 @@ Transfer.defaultProps = {
  * @prop {string} [optionsWidth]
  * @prop {string} [removeAllText]
  * @prop {string} [removeIndividualText]
+ * @prop {Node} [rightHeader]
  * @prop {Node} [rightFooter]
  * @prop {string} [searchTerm]
  * @prop {string[]} selected
@@ -433,6 +441,7 @@ Transfer.propTypes = {
     removeIndividualText: propTypes.string,
     renderOption: propTypes.func,
     rightFooter: propTypes.node,
+    rightHeader: propTypes.node,
     searchTerm: propTypes.string,
     selected: propTypes.arrayOf(propTypes.string),
     selectedEmptyComponent: propTypes.node,

--- a/packages/widgets/src/Transfer/Transfer.stories.js
+++ b/packages/widgets/src/Transfer/Transfer.stories.js
@@ -138,6 +138,7 @@ export const Header = () => (
         <Transfer
             onChange={() => console.log('Will be overriden')}
             leftHeader={<h3>Header on the left side</h3>}
+            rightHeader={<h4>Header on the right side</h4>}
             options={options}
         />
     </StatefulWrapper>
@@ -171,6 +172,7 @@ export const Filtered = () => (
             onChange={() => console.log('Will be overriden by StatefulWrapper')}
             initialSearchTerm="ANC"
             leftHeader={<h3>Header on the left side</h3>}
+            rightHeader={<h4>Header on the right side</h4>}
             options={options}
         />
     </StatefulWrapper>
@@ -295,6 +297,7 @@ export const IncreasedOptionsHeight = () => (
                 }
                 height="400px"
                 leftHeader={<h3>Header on the left side</h3>}
+                rightHeader={<h4>Header on the right side</h4>}
                 options={options}
             />
         </StatefulWrapper>
@@ -308,6 +311,7 @@ export const DifferentWidths = () => (
             onChange={() => console.log('Will be overriden by StatefulWrapper')}
             initialSearchTerm="Ba"
             leftHeader={<h3>Header on the left side</h3>}
+            rightHeader={<h4>Header on the right side</h4>}
             optionsWidth="500px"
             selectedWidth="240px"
             options={options}
@@ -405,6 +409,11 @@ const createCustomFilteringInHeader = hideFilterInput => {
                 searchTerm={filter}
                 filterCallback={filterCallback}
                 leftHeader={header}
+                rightHeader={
+                    <p>
+                        <b>Selected Periods</b>
+                    </p>
+                }
                 onFilterChange={({ value }) => setFilter(value)}
                 height="400px"
                 filterLabel="Filter options"


### PR DESCRIPTION
Fixes #90

Adds a `rightHeader` to the `Transfer` component, as per [TECH-394](https://jira.dhis2.org/browse/TECH-394).

-----------------

_Story example: Header_
![image](https://user-images.githubusercontent.com/12590483/87143342-3bb07080-c2a6-11ea-8a4b-7f7de811bc7a.png)

_Story example: Custom Filtering With Filter Input_
![image](https://user-images.githubusercontent.com/12590483/87143382-4834c900-c2a6-11ea-8eba-5f0a46b4cc1c.png)
