### PR TITLE
feat(table): add alternateRowBgColor prop (default: true) (TECH-416)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
         "url": "https://github.com/dhis2/ui.git"
     },
     "author": "Viktor Varland <viktor@dhis2.org>",
+    "contributors": [
+        {
+            "name": "Jan-Gerke Salomon",
+            "email": "jan-gerke@dhis2.org",
+            "url": "http://functionalprogramming.ninja"
+        }
+    ],
     "license": "BSD-3-Clause",
     "private": true,
     "workspaces": {

--- a/packages/core/src/Table/Table.js
+++ b/packages/core/src/Table/Table.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import css from 'styled-jsx/css'
 import propTypes from '@dhis2/prop-types'
+import { Provider } from './TableContext.js'
 
 const tableStyles = css`
     table {
@@ -20,12 +21,19 @@ const tableStyles = css`
  * @example import { Table } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const Table = ({ children, className, dataTest }) => (
-    <table className={className} data-test={dataTest}>
-        {children}
+export const Table = ({
+    children,
+    className,
+    dataTest,
+    suppressZebraStriping,
+}) => (
+    <Provider value={{ suppressZebraStriping }}>
+        <table className={className} data-test={dataTest}>
+            {children}
 
-        <style jsx>{tableStyles}</style>
-    </table>
+            <style jsx>{tableStyles}</style>
+        </table>
+    </Provider>
 )
 
 Table.defaultProps = {
@@ -38,9 +46,11 @@ Table.defaultProps = {
  * @prop {TableHead|TableBody|TableFoot|Array.<TableHead|TableBody|TableFoot>} [children]
  * @prop {string} [className]
  * @prop {string} [dataTest]
+ * @prop {bool} [suppressZebraStriping]
  */
 Table.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    suppressZebraStriping: propTypes.bool,
 }

--- a/packages/core/src/Table/Table.stories.js
+++ b/packages/core/src/Table/Table.stories.js
@@ -1,7 +1,5 @@
 import React from 'react'
 
-import { storiesOf } from '@storybook/react'
-
 import { Button } from '../index.js'
 
 import { Table } from './Table.js'
@@ -28,7 +26,9 @@ const TableFooterButton = () => (
 
 const TableButton = () => <Button primary>Table button</Button>
 
-storiesOf('Table', module).add('Static layout', () => (
+export default { title: 'Table' }
+
+export const StaticLayout = () => (
     <Table>
         <TableHead>
             <TableRowHead>
@@ -152,153 +152,410 @@ storiesOf('Table', module).add('Static layout', () => (
             </TableRow>
         </TableFoot>
     </Table>
-))
+)
 
-storiesOf('Table', module).add(
-    'Static layout with buttons in dense cells',
-    () => (
-        <Table>
-            <TableHead>
-                <TableRowHead>
-                    <TableCellHead>First name</TableCellHead>
-                    <TableCellHead>Last name</TableCellHead>
-                    <TableCellHead>Incident date</TableCellHead>
-                    <TableCellHead>Last updated</TableCellHead>
-                    <TableCellHead>Age</TableCellHead>
-                    <TableCellHead>Registering unit</TableCellHead>
-                    <TableCellHead>Assigned user</TableCellHead>
-                    <TableCellHead>Button</TableCellHead>
-                </TableRowHead>
-            </TableHead>
-            <TableBody>
-                <TableRow>
-                    <TableCell>Onyekachukwu</TableCell>
-                    <TableCell>Kariuki</TableCell>
-                    <TableCell>02/06/2007</TableCell>
-                    <TableCell>05/25/1972</TableCell>
-                    <TableCell>66</TableCell>
-                    <TableCell>Jawi</TableCell>
-                    <TableCell>Sofie Hubert</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Kwasi</TableCell>
-                    <TableCell>Okafor</TableCell>
-                    <TableCell>08/11/2010</TableCell>
-                    <TableCell>02/26/1991</TableCell>
-                    <TableCell>38</TableCell>
-                    <TableCell>Mokassie MCHP</TableCell>
-                    <TableCell>Dashonte Clarke</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Siyabonga</TableCell>
-                    <TableCell>Abiodun</TableCell>
-                    <TableCell>07/21/1981</TableCell>
-                    <TableCell>02/06/2007</TableCell>
-                    <TableCell>98</TableCell>
-                    <TableCell>Bathurst MCHP</TableCell>
-                    <TableCell>Unassigned</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Chiyembekezo</TableCell>
-                    <TableCell>Okeke</TableCell>
-                    <TableCell>01/23/1982</TableCell>
-                    <TableCell>07/15/2003</TableCell>
-                    <TableCell>2</TableCell>
-                    <TableCell>Mayolla MCHP</TableCell>
-                    <TableCell>Wan Gengxin</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Mtendere</TableCell>
-                    <TableCell>Afolayan</TableCell>
-                    <TableCell>08/12/1994</TableCell>
-                    <TableCell>05/12/1972</TableCell>
-                    <TableCell>37</TableCell>
-                    <TableCell>Gbangadu MCHP</TableCell>
-                    <TableCell>Gvozden Boskovsky</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Inyene</TableCell>
-                    <TableCell>Okonkwo</TableCell>
-                    <TableCell>04/01/1971</TableCell>
-                    <TableCell>03/16/2000</TableCell>
-                    <TableCell>70</TableCell>
-                    <TableCell>Kunike Barina</TableCell>
-                    <TableCell>Oscar de la Cavallería</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Amaka</TableCell>
-                    <TableCell>Pretorius</TableCell>
-                    <TableCell>01/25/1996</TableCell>
-                    <TableCell>09/15/1986</TableCell>
-                    <TableCell>32</TableCell>
-                    <TableCell>Bargbo</TableCell>
-                    <TableCell>Alberto Raya</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Meti</TableCell>
-                    <TableCell>Abiodun</TableCell>
-                    <TableCell>10/24/2010</TableCell>
-                    <TableCell>07/26/1989</TableCell>
-                    <TableCell>8</TableCell>
-                    <TableCell>Majihun MCHP</TableCell>
-                    <TableCell>Unassigned</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Eshe</TableCell>
-                    <TableCell>Okeke</TableCell>
-                    <TableCell>01/31/1995</TableCell>
-                    <TableCell>01/31/1995</TableCell>
-                    <TableCell>63</TableCell>
-                    <TableCell>Mambiama CHP</TableCell>
-                    <TableCell>Shadrias Pearson</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-                <TableRow>
-                    <TableCell>Obi</TableCell>
-                    <TableCell>Okafor</TableCell>
-                    <TableCell>06/07/1990</TableCell>
-                    <TableCell>01/03/2006</TableCell>
-                    <TableCell>28</TableCell>
-                    <TableCell>Dalakuru CHP</TableCell>
-                    <TableCell>Anatoliy Shcherbatykh</TableCell>
-                    <TableCell dense>
-                        <TableButton />
-                    </TableCell>
-                </TableRow>
-            </TableBody>
-            <TableFoot>
-                <TableRow>
-                    <TableCell colSpan="8">
-                        <TableFooterButton />
-                    </TableCell>
-                </TableRow>
-            </TableFoot>
-        </Table>
-    )
+export const OneDenseCell = () => (
+    <Table>
+        <TableHead>
+            <TableRowHead>
+                <TableCellHead>First name</TableCellHead>
+                <TableCellHead>Last name</TableCellHead>
+                <TableCellHead>Incident date</TableCellHead>
+                <TableCellHead>Last updated</TableCellHead>
+                <TableCellHead>Age</TableCellHead>
+                <TableCellHead>Registering unit</TableCellHead>
+                <TableCellHead>Assigned user</TableCellHead>
+                <TableCellHead>Button</TableCellHead>
+            </TableRowHead>
+        </TableHead>
+        <TableBody>
+            <TableRow>
+                <TableCell>Onyekachukwu</TableCell>
+                <TableCell>Kariuki</TableCell>
+                <TableCell>02/06/2007</TableCell>
+                <TableCell>05/25/1972</TableCell>
+                <TableCell>66</TableCell>
+                <TableCell>Jawi</TableCell>
+                <TableCell>Sofie Hubert</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Kwasi</TableCell>
+                <TableCell>Okafor</TableCell>
+                <TableCell>08/11/2010</TableCell>
+                <TableCell>02/26/1991</TableCell>
+                <TableCell>38</TableCell>
+                <TableCell>Mokassie MCHP</TableCell>
+                <TableCell>Dashonte Clarke</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Siyabonga</TableCell>
+                <TableCell>Abiodun</TableCell>
+                <TableCell>07/21/1981</TableCell>
+                <TableCell>02/06/2007</TableCell>
+                <TableCell>98</TableCell>
+                <TableCell>Bathurst MCHP</TableCell>
+                <TableCell>Unassigned</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Chiyembekezo</TableCell>
+                <TableCell>Okeke</TableCell>
+                <TableCell>01/23/1982</TableCell>
+                <TableCell>07/15/2003</TableCell>
+                <TableCell>2</TableCell>
+                <TableCell>Mayolla MCHP</TableCell>
+                <TableCell>Wan Gengxin</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Mtendere</TableCell>
+                <TableCell>Afolayan</TableCell>
+                <TableCell>08/12/1994</TableCell>
+                <TableCell>05/12/1972</TableCell>
+                <TableCell>37</TableCell>
+                <TableCell>Gbangadu MCHP</TableCell>
+                <TableCell>Gvozden Boskovsky</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Inyene</TableCell>
+                <TableCell>Okonkwo</TableCell>
+                <TableCell>04/01/1971</TableCell>
+                <TableCell>03/16/2000</TableCell>
+                <TableCell>70</TableCell>
+                <TableCell>Kunike Barina</TableCell>
+                <TableCell>Oscar de la Cavallería</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Amaka</TableCell>
+                <TableCell>Pretorius</TableCell>
+                <TableCell>01/25/1996</TableCell>
+                <TableCell>09/15/1986</TableCell>
+                <TableCell>32</TableCell>
+                <TableCell>Bargbo</TableCell>
+                <TableCell>Alberto Raya</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Meti</TableCell>
+                <TableCell>Abiodun</TableCell>
+                <TableCell>10/24/2010</TableCell>
+                <TableCell>07/26/1989</TableCell>
+                <TableCell>8</TableCell>
+                <TableCell>Majihun MCHP</TableCell>
+                <TableCell>Unassigned</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Eshe</TableCell>
+                <TableCell>Okeke</TableCell>
+                <TableCell>01/31/1995</TableCell>
+                <TableCell>01/31/1995</TableCell>
+                <TableCell>63</TableCell>
+                <TableCell>Mambiama CHP</TableCell>
+                <TableCell>Shadrias Pearson</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Obi</TableCell>
+                <TableCell>Okafor</TableCell>
+                <TableCell>06/07/1990</TableCell>
+                <TableCell>01/03/2006</TableCell>
+                <TableCell>28</TableCell>
+                <TableCell>Dalakuru CHP</TableCell>
+                <TableCell>Anatoliy Shcherbatykh</TableCell>
+                <TableCell dense>
+                    <TableButton />
+                </TableCell>
+            </TableRow>
+        </TableBody>
+        <TableFoot>
+            <TableRow>
+                <TableCell colSpan="8">
+                    <TableFooterButton />
+                </TableCell>
+            </TableRow>
+        </TableFoot>
+    </Table>
+)
+
+export const NoAlternatingBgColor = () => (
+    <Table suppressZebraStriping>
+        <TableHead>
+            <TableRowHead>
+                <TableCellHead>Name</TableCellHead>
+                <TableCellHead colSpan="7" />
+            </TableRowHead>
+            <TableRowHead>
+                <TableCellHead>First name</TableCellHead>
+                <TableCellHead>Last name</TableCellHead>
+                <TableCellHead>Incident date</TableCellHead>
+                <TableCellHead>Last updated</TableCellHead>
+                <TableCellHead>Age</TableCellHead>
+                <TableCellHead>Registering unit</TableCellHead>
+                <TableCellHead>Assigned user</TableCellHead>
+                <TableCellHead>Status</TableCellHead>
+            </TableRowHead>
+        </TableHead>
+        <TableBody>
+            <TableRow>
+                <TableCell>Onyekachukwu</TableCell>
+                <TableCell>Kariuki</TableCell>
+                <TableCell>02/06/2007</TableCell>
+                <TableCell>05/25/1972</TableCell>
+                <TableCell>66</TableCell>
+                <TableCell>Jawi</TableCell>
+                <TableCell>Sofie Hubert</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Kwasi</TableCell>
+                <TableCell>Okafor</TableCell>
+                <TableCell>08/11/2010</TableCell>
+                <TableCell>02/26/1991</TableCell>
+                <TableCell>38</TableCell>
+                <TableCell>Mokassie MCHP</TableCell>
+                <TableCell>Dashonte Clarke</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Siyabonga</TableCell>
+                <TableCell>Abiodun</TableCell>
+                <TableCell>07/21/1981</TableCell>
+                <TableCell>02/06/2007</TableCell>
+                <TableCell>98</TableCell>
+                <TableCell>Bathurst MCHP</TableCell>
+                <TableCell>Unassigned</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Chiyembekezo</TableCell>
+                <TableCell>Okeke</TableCell>
+                <TableCell>01/23/1982</TableCell>
+                <TableCell>07/15/2003</TableCell>
+                <TableCell>2</TableCell>
+                <TableCell>Mayolla MCHP</TableCell>
+                <TableCell>Wan Gengxin</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Mtendere</TableCell>
+                <TableCell>Afolayan</TableCell>
+                <TableCell>08/12/1994</TableCell>
+                <TableCell>05/12/1972</TableCell>
+                <TableCell>37</TableCell>
+                <TableCell>Gbangadu MCHP</TableCell>
+                <TableCell>Gvozden Boskovsky</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Inyene</TableCell>
+                <TableCell>Okonkwo</TableCell>
+                <TableCell>04/01/1971</TableCell>
+                <TableCell>03/16/2000</TableCell>
+                <TableCell>70</TableCell>
+                <TableCell>Kunike Barina</TableCell>
+                <TableCell>Oscar de la Cavallería</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Amaka</TableCell>
+                <TableCell>Pretorius</TableCell>
+                <TableCell>01/25/1996</TableCell>
+                <TableCell>09/15/1986</TableCell>
+                <TableCell>32</TableCell>
+                <TableCell>Bargbo</TableCell>
+                <TableCell>Alberto Raya</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Meti</TableCell>
+                <TableCell>Abiodun</TableCell>
+                <TableCell>10/24/2010</TableCell>
+                <TableCell>07/26/1989</TableCell>
+                <TableCell>8</TableCell>
+                <TableCell>Majihun MCHP</TableCell>
+                <TableCell>Unassigned</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Eshe</TableCell>
+                <TableCell>Okeke</TableCell>
+                <TableCell>01/31/1995</TableCell>
+                <TableCell>01/31/1995</TableCell>
+                <TableCell>63</TableCell>
+                <TableCell>Mambiama CHP</TableCell>
+                <TableCell>Shadrias Pearson</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Obi</TableCell>
+                <TableCell>Okafor</TableCell>
+                <TableCell>06/07/1990</TableCell>
+                <TableCell>01/03/2006</TableCell>
+                <TableCell>28</TableCell>
+                <TableCell>Dalakuru CHP</TableCell>
+                <TableCell>Anatoliy Shcherbatykh</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+        </TableBody>
+        <TableFoot>
+            <TableRow>
+                <TableCell colSpan="8">
+                    <TableFooterButton />
+                </TableCell>
+            </TableRow>
+        </TableFoot>
+    </Table>
+)
+
+export const CustomAlternatingBgColor = () => (
+    <Table>
+        <TableHead>
+            <TableRowHead>
+                <TableCellHead>Name</TableCellHead>
+                <TableCellHead colSpan="7" />
+            </TableRowHead>
+            <TableRowHead>
+                <TableCellHead>First name</TableCellHead>
+                <TableCellHead>Last name</TableCellHead>
+                <TableCellHead>Incident date</TableCellHead>
+                <TableCellHead>Last updated</TableCellHead>
+                <TableCellHead>Age</TableCellHead>
+                <TableCellHead>Registering unit</TableCellHead>
+                <TableCellHead>Assigned user</TableCellHead>
+                <TableCellHead>Status</TableCellHead>
+            </TableRowHead>
+        </TableHead>
+        <TableBody>
+            <TableRow>
+                <TableCell>Onyekachukwu</TableCell>
+                <TableCell>Kariuki</TableCell>
+                <TableCell>02/06/2007</TableCell>
+                <TableCell>05/25/1972</TableCell>
+                <TableCell>66</TableCell>
+                <TableCell>Jawi</TableCell>
+                <TableCell>Sofie Hubert</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow suppressZebraStriping>
+                <TableCell>Kwasi</TableCell>
+                <TableCell>Okafor</TableCell>
+                <TableCell>08/11/2010</TableCell>
+                <TableCell>02/26/1991</TableCell>
+                <TableCell>38</TableCell>
+                <TableCell>Mokassie MCHP</TableCell>
+                <TableCell>Dashonte Clarke</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Siyabonga</TableCell>
+                <TableCell>Abiodun</TableCell>
+                <TableCell>07/21/1981</TableCell>
+                <TableCell>02/06/2007</TableCell>
+                <TableCell>98</TableCell>
+                <TableCell>Bathurst MCHP</TableCell>
+                <TableCell>Unassigned</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Chiyembekezo</TableCell>
+                <TableCell>Okeke</TableCell>
+                <TableCell>01/23/1982</TableCell>
+                <TableCell>07/15/2003</TableCell>
+                <TableCell>2</TableCell>
+                <TableCell>Mayolla MCHP</TableCell>
+                <TableCell>Wan Gengxin</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Mtendere</TableCell>
+                <TableCell>Afolayan</TableCell>
+                <TableCell>08/12/1994</TableCell>
+                <TableCell>05/12/1972</TableCell>
+                <TableCell>37</TableCell>
+                <TableCell>Gbangadu MCHP</TableCell>
+                <TableCell>Gvozden Boskovsky</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Inyene</TableCell>
+                <TableCell>Okonkwo</TableCell>
+                <TableCell>04/01/1971</TableCell>
+                <TableCell>03/16/2000</TableCell>
+                <TableCell>70</TableCell>
+                <TableCell>Kunike Barina</TableCell>
+                <TableCell>Oscar de la Cavallería</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Amaka</TableCell>
+                <TableCell>Pretorius</TableCell>
+                <TableCell>01/25/1996</TableCell>
+                <TableCell>09/15/1986</TableCell>
+                <TableCell>32</TableCell>
+                <TableCell>Bargbo</TableCell>
+                <TableCell>Alberto Raya</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Meti</TableCell>
+                <TableCell>Abiodun</TableCell>
+                <TableCell>10/24/2010</TableCell>
+                <TableCell>07/26/1989</TableCell>
+                <TableCell>8</TableCell>
+                <TableCell>Majihun MCHP</TableCell>
+                <TableCell>Unassigned</TableCell>
+                <TableCell>Complete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Eshe</TableCell>
+                <TableCell>Okeke</TableCell>
+                <TableCell>01/31/1995</TableCell>
+                <TableCell>01/31/1995</TableCell>
+                <TableCell>63</TableCell>
+                <TableCell>Mambiama CHP</TableCell>
+                <TableCell>Shadrias Pearson</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+            <TableRow>
+                <TableCell>Obi</TableCell>
+                <TableCell>Okafor</TableCell>
+                <TableCell>06/07/1990</TableCell>
+                <TableCell>01/03/2006</TableCell>
+                <TableCell>28</TableCell>
+                <TableCell>Dalakuru CHP</TableCell>
+                <TableCell>Anatoliy Shcherbatykh</TableCell>
+                <TableCell>Incomplete</TableCell>
+            </TableRow>
+        </TableBody>
+        <TableFoot>
+            <TableRow>
+                <TableCell colSpan="8">
+                    <TableFooterButton />
+                </TableCell>
+            </TableRow>
+        </TableFoot>
+    </Table>
 )

--- a/packages/core/src/Table/TableContext.js
+++ b/packages/core/src/Table/TableContext.js
@@ -1,0 +1,7 @@
+import { createContext } from 'react'
+
+export const TableContext = createContext({
+    suppressZebraStriping: false,
+})
+
+export const { Consumer, Provider } = TableContext

--- a/packages/core/src/Table/TableRow.js
+++ b/packages/core/src/Table/TableRow.js
@@ -1,9 +1,11 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import css from 'styled-jsx/css'
 import propTypes from '@dhis2/prop-types'
+import cx from 'classnames'
+import { TableContext } from './TableContext'
 
 const tableRowStyles = css`
-    tr:nth-child(even) {
+    .zebraStriping:nth-child(even) {
         background: #fbfcfd;
     }
 `
@@ -15,13 +17,29 @@ const tableRowStyles = css`
  * @example import { TableRow } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableRow = ({ children, className, dataTest }) => (
-    <tr className={className} data-test={dataTest}>
-        {children}
+export const TableRow = ({
+    children,
+    className,
+    dataTest,
+    suppressZebraStriping,
+}) => {
+    const {
+        suppressZebraStriping: suppressZebraStripingFromContext,
+    } = useContext(TableContext)
 
-        <style jsx>{tableRowStyles}</style>
-    </tr>
-)
+    const zebraStriping =
+        typeof suppressZebraStriping !== 'undefined'
+            ? !suppressZebraStriping
+            : !suppressZebraStripingFromContext
+
+    return (
+        <tr className={cx(className, { zebraStriping })} data-test={dataTest}>
+            {children}
+
+            <style jsx>{tableRowStyles}</style>
+        </tr>
+    )
+}
 
 TableRow.defaultProps = {
     dataTest: 'dhis2-uicore-tablerow',
@@ -38,4 +56,5 @@ TableRow.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    suppressZebraStriping: propTypes.bool,
 }

--- a/packages/core/src/Table/TableRowHead.js
+++ b/packages/core/src/Table/TableRowHead.js
@@ -11,8 +11,17 @@ import { TableRow } from './TableRow.js'
  * @example import { TableRowHead } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableRowHead = ({ children, className, dataTest }) => (
-    <TableRow className={className} dataTest={dataTest}>
+export const TableRowHead = ({
+    children,
+    className,
+    dataTest,
+    suppressZebraStriping,
+}) => (
+    <TableRow
+        className={className}
+        dataTest={dataTest}
+        suppressZebraStriping={suppressZebraStriping}
+    >
         {children}
     </TableRow>
 )
@@ -32,4 +41,5 @@ TableRowHead.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    suppressZebraStriping: propTypes.bool,
 }


### PR DESCRIPTION
Fixes #207 
Fixes TECH-416

Adds the `alternateRowBgColor` prop that defaults to true.
Can be set globally on the `Table` component and/or individually on `TableRow` components.