### PR TITLE
feat(transfer): add prop selected to renderOption (TECH-393)

### DIFF
--- a/packages/widgets/src/Transfer/Transfer.js
+++ b/packages/widgets/src/Transfer/Transfer.js
@@ -218,6 +218,7 @@ export const Transfer = ({
                                         toggleHighlightedSourceOption
                                     ),
                                     highlighted,
+                                    selected: false,
                                 })}
                             </Fragment>
                         )
@@ -314,6 +315,7 @@ export const Transfer = ({
                                         toggleHighlightedPickedOption
                                     ),
                                     highlighted,
+                                    selected: true,
                                 })}
                             </Fragment>
                         )

--- a/packages/widgets/src/Transfer/Transfer.stories.js
+++ b/packages/widgets/src/Transfer/Transfer.stories.js
@@ -204,7 +204,9 @@ export const CustomListOptions = () => (
     </p>
 )`}</pre>
         </code>
-        <StatefulWrapper>
+        <StatefulWrapper
+            initialState={options.slice(0, 2).map(({ value }) => value)}
+        >
             <Transfer
                 onChange={() =>
                     console.log('Will be overriden by StatefulWrapper')

--- a/packages/widgets/src/Transfer/Transfer.stories.js
+++ b/packages/widgets/src/Transfer/Transfer.stories.js
@@ -176,10 +176,13 @@ export const Filtered = () => (
     </StatefulWrapper>
 )
 
-const renderOption = ({ label, value, onClick, highlighted }) => (
+const renderOption = ({ label, value, onClick, highlighted, selected }) => (
     <p
         onClick={event => onClick({ label, value }, event)}
-        style={{ background: highlighted ? 'green' : 'blue' }}
+        style={{
+            background: highlighted ? 'green' : 'blue',
+            color: selected ? 'orange' : 'white',
+        }}
     >
         Custom: {label} (label), {value} (value)
     </p>
@@ -189,10 +192,13 @@ export const CustomListOptions = () => (
     <>
         <strong>Custom option code:</strong>
         <code>
-            <pre>{`const renderOption = ({ label, value, onClick, highlighted }) => (
+            <pre>{`const renderOption = ({ label, value, onClick, highlighted, selected }) => (
     <p
         onClick={event => onClick({ label, value }, event)}
-        style={{ background: highlighted ? 'green' : 'blue' }}
+        style={{
+            background: highlighted ? 'green' : 'blue',
+            color: selected ? 'orange' : 'white',
+        }}
     >
         Custom: {label} (label), {value} (value)
     </p>


### PR DESCRIPTION
Fixes #105 
Fixes [TECH-393](https://jira.dhis2.org/browse/TECH-393)

Adds a `selected` prop (bool) to the `Transfer` component's `renderOption`. This enables consumers to use `selected` in the `renderOption` function to provide separate styles for the source options and picked options, in addition to the already existing `highlighted` prop.

-----------------

_Story example: Custom List Options_
![image](https://user-images.githubusercontent.com/12590483/87155567-6f49c580-c2bb-11ea-9c26-b1a04ae937fa.png)
