### PR TITLE
docs(getting-started): adds text for peer dependency installation 

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,12 @@
 yarn add @dhis2/ui
 ```
 
+In some cases you might need to install `styled-jsx` as peer dependency. To do so run
+
+```bash
+yarn add styled-jsx -P
+```
+
 ## Requirements
 
 ### React >= 16.3

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,10 +8,16 @@
 yarn add @dhis2/ui
 ```
 
-In some cases you might need to install `styled-jsx` as peer dependency. To do so run
+When not using the dhis2 app platform, then the ui library requires you to install some peer dependencies:
+
+-   `react`
+-   `react-dom`
+-   `styled-jsx`
+
+Using the dhis2 app platform you won't have to install them as they're bundled with the platform scripts.
 
 ```bash
-yarn add styled-jsx -P
+yarn add react react-dom styled-jsx -P
 ```
 
 ## Requirements


### PR DESCRIPTION
Hey 👋 

This PR adds a small section in the getting started section. This is because while we were updating the `capture-app` to use the `@dhis2/ui` we got into the scenario that we had to install as peer dep the `styled-jsx` 

Happy to hear your feedback on the text :) 