### PR TITLE
fix(radio): modal jumping when clicking radio

### DIFF
--- a/packages/core/src/Radio/Radio.js
+++ b/packages/core/src/Radio/Radio.js
@@ -110,6 +110,7 @@ class Radio extends Component {
                 <style jsx>{`
                     label {
                         display: flex;
+                        position: relative;
                         flex-direction: row;
                         align-items: center;
                         justify-content: flex-start;


### PR DESCRIPTION
See Jira issue with link to codesandbox: https://jira.dhis2.org/browse/DHIS2-9104

When clicking a radio in a modal that is scrollable, the modal will scroll and the content will be outside of the viewport. This is due to how the modal is scrolling the modal-content only, using `display: flex`. I believe the reason for using flex here is to keep the header above the content when scrolling. 

The Card rendered by the Modal will have a height of something like 2x of the modal-content. So when a Radio is clicked, the page is for some weird reason (see https://stackoverflow.com/questions/24299567/radio-button-causes-browser-to-jump-to-the-top/24323870)  scrolled to the position of the clicked Radio in the `Card-div`. As far as I understand this, it's due to the `position: absolute` on the Radios, and the Card being the closest relative-positioned element. 

This fix makes the label positioned relative, so when a Radio is clicked, it will not scroll to the position. However, this could potentially make absolutely position elements in the modal behave weirdly, so another solution would be to have a simple `display: block` on the Card ( instead of flex) - but that would mean we would scroll the header as well. 
Maybe the `ModalContent` should have `position: relative` as well, to play nice with absolutely positioned elements?

~~@Mohammer5 replied that position relative is not ideal. The inputs are already hidden with `opacity: 0`, and it looks like `visibility: hidden` works as well. Source for fix in above [stackoverflow](https://stackoverflow.com/questions/24299567/radio-button-causes-browser-to-jump-to-the-top/24323870).~~