### PR TITLE
fix(help): accessible colors for help text statuses

### DIFF
--- a/packages/core/src/Help/Help.js
+++ b/packages/core/src/Help/Help.js
@@ -2,7 +2,6 @@ import { spacers, theme, colors, sharedPropTypes } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**

--- a/packages/core/src/Help/Help.js
+++ b/packages/core/src/Help/Help.js
@@ -1,7 +1,8 @@
-import { spacers, theme, sharedPropTypes } from '@dhis2/ui-constants'
+import { spacers, theme, colors, sharedPropTypes } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -35,7 +36,7 @@ const Help = ({ children, valid, error, warning, className, dataTest }) => (
             }
 
             .valid {
-                color: ${theme.valid};
+                color: ${colors.blue700};
             }
 
             .error {
@@ -43,7 +44,7 @@ const Help = ({ children, valid, error, warning, className, dataTest }) => (
             }
 
             .warning {
-                color: ${theme.warning};
+                color: ${colors.yellow800};
             }
         `}</style>
     </p>


### PR DESCRIPTION
This PR changes the color of `warning` and `valid` variations of the `help` component. The previous colors were not [AA accessible](https://www.w3.org/TR/WCAG21/#contrast-minimum). 

I have replaced `theme.valid` and `theme.warning` with the color variables because the theme values are used elsewhere where the contrast requirements are not as strict. I contemplated adding `theme.warning-dark` and `theme.valid-dark`, but I thought that was over-engineering this. I am open to feedback if that would indeed be a better solution. Perhaps `theme.warning-text` might be a useful addition?