### PR TITLE
fix(menu-item): make sure onClick is undefined when disabled

### DIFF
--- a/packages/core/src/MenuItem/MenuItem.js
+++ b/packages/core/src/MenuItem/MenuItem.js
@@ -67,8 +67,13 @@ const MenuItem = ({
                     target={target}
                     href={!disabled && href ? href : undefined}
                     onClick={
-                        !disabled &&
-                        createOnClickHandler(onClick, toggleSubMenu, value)
+                        !disabled
+                            ? createOnClickHandler(
+                                  onClick,
+                                  toggleSubMenu,
+                                  value
+                              )
+                            : undefined
                     }
                 >
                     {icon && <span className="icon">{icon}</span>}


### PR DESCRIPTION
Before this fix, `onClick` could get a `false` value for disabled items, and that would trigger an error.
Now `onClick` can only be a function, or `undefined`, and that should take care of the error.