### PR TITLE
fix: add background to transfer option containers

### DIFF
--- a/packages/widgets/src/Transfer/LeftSide.js
+++ b/packages/widgets/src/Transfer/LeftSide.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
-import { borderColor, borderRadius } from './common/index.js'
+import { backgroundColor, borderColor, borderRadius } from './common/index.js'
 
 export const LeftSide = ({ children, dataTest, width }) => (
     <div data-test={dataTest}>
@@ -17,6 +17,7 @@ export const LeftSide = ({ children, dataTest, width }) => (
             div {
                 display: flex;
                 flex-direction: column;
+                background-color: ${backgroundColor};
                 border-radius: ${borderRadius};
                 border: 1px solid ${borderColor};
                 min-height: 240px;

--- a/packages/widgets/src/Transfer/RightSide.js
+++ b/packages/widgets/src/Transfer/RightSide.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import propTypes from '@dhis2/prop-types'
 
-import { borderColor, borderRadius } from './common/index.js'
+import { backgroundColor, borderColor, borderRadius } from './common/index.js'
 
 export const RightSide = ({ children, dataTest, width }) => (
     <div data-test={dataTest}>
@@ -15,6 +15,7 @@ export const RightSide = ({ children, dataTest, width }) => (
         }
         <style jsx>{`
             div {
+                background-color: ${backgroundColor};
                 border: 1px solid ${borderColor};
                 border-radius: ${borderRadius};
                 display: flex;

--- a/packages/widgets/src/Transfer/common/index.js
+++ b/packages/widgets/src/Transfer/common/index.js
@@ -1,5 +1,5 @@
 export { ADD_MODE, RANGE_MODE, REPLACE_MODE } from './modes.js'
-export { borderColor, borderRadius } from './styles.js'
+export { backgroundColor, borderColor, borderRadius } from './styles.js'
 export { findOptionIndex } from './findOptionIndex.js'
 export { getModeByModifierKey } from './getModeByModifierKey.js'
 export { isOption } from './isOption.js'

--- a/packages/widgets/src/Transfer/common/styles.js
+++ b/packages/widgets/src/Transfer/common/styles.js
@@ -1,4 +1,5 @@
 import { colors } from '@dhis2/ui-constants'
 
+export const backgroundColor = colors.white
 export const borderColor = colors.grey400
 export const borderRadius = '3px'


### PR DESCRIPTION
This PR adds background color properties to the transfer option containers. Previously they were transparent, which was incorrectly stated on the design spec.