### PR TITLE
fix(transfer): make inifinite loading work when selecting options (#257)

### DIFF
--- a/packages/core/src/IntersectionDetector/IntersectionDetector.js
+++ b/packages/core/src/IntersectionDetector/IntersectionDetector.js
@@ -13,6 +13,7 @@ export const IntersectionDetector = ({
     onChange,
     children,
     className,
+    dataTest,
     rootRef,
 }) => {
     // Use useRef instead of useState to prevent unnecessary re-render:
@@ -20,10 +21,6 @@ export const IntersectionDetector = ({
     //   so there's no need for re-rendering the (potentially computational
     //   heavy) children.  Also: If the parent re-renders (e. g. due to a state
     //   change), then this component will re-render as well.
-
-    // @var {Object}
-    // @prop {IntersectionObserver} current
-    const observer = useRef()
 
     // @var {Object}
     // @prop {bool} current
@@ -37,7 +34,7 @@ export const IntersectionDetector = ({
         const rootEl = rootRef.current
         const intersectionEl = intersectionRef.current
 
-        if (rootEl && intersectionEl && !observer.current) {
+        if (rootEl && intersectionEl) {
             const onIntersection = entries => {
                 // Currently there's no way to supply multiple thresholds,
                 // so a single entry can be assumed safely
@@ -63,7 +60,6 @@ export const IntersectionDetector = ({
             )
 
             intersectionObserver.observe(intersectionEl)
-            observer.current = intersectionObserver
 
             // Make sure to clean up everything when un-mounting.
             // Using an arrow function instead of just returning
@@ -73,7 +69,7 @@ export const IntersectionDetector = ({
     }, [rootRef.current, intersectionRef.current])
 
     return (
-        <div ref={intersectionRef} className={className}>
+        <div ref={intersectionRef} className={className} data-test={dataTest}>
             {children}
 
             <style jsx>{`
@@ -90,6 +86,7 @@ export const IntersectionDetector = ({
 
 IntersectionDetector.defaultProps = {
     threshold: 0,
+    dataTest: 'dhis2-uicore-intersectiondetector',
 }
 
 /**
@@ -112,5 +109,6 @@ IntersectionDetector.propTypes = {
 
     children: PropTypes.any,
     className: PropTypes.string,
+    dataTest: PropTypes.string,
     threshold: PropTypes.number,
 }

--- a/packages/widgets/src/Transfer/OptionsContainer.js
+++ b/packages/widgets/src/Transfer/OptionsContainer.js
@@ -1,9 +1,10 @@
 import { CircularLoader } from '@dhis2/ui-core'
 import { spacers } from '@dhis2/ui-constants'
-import React, { Fragment, useEffect, useRef, useState } from 'react'
+import React, { Fragment, useRef } from 'react'
 import propTypes from '@dhis2/prop-types'
 
 import { EndIntersectionDetector } from './EndIntersectionDetector.js'
+import { useResizeCounter } from './useResizeCounter'
 
 export const OptionsContainer = ({
     dataTest,
@@ -18,31 +19,10 @@ export const OptionsContainer = ({
     selectionHandler,
     toggleHighlightedOption,
 }) => {
-    const [remountCounter, setRemountCounter] = useState(0)
-    const [resizeObserver, setResizeObserver] = useState(null)
     const optionsRef = useRef(null)
     const wrapperRef = useRef(null)
 
-    useEffect(() => {
-        if (onEndReached && wrapperRef.current) {
-            // The initial call is irrelevant as there has been
-            // no resize yet that we want to react to
-            let firstCall = false
-
-            const observer = new ResizeObserver(() => {
-                if (!firstCall) {
-                    const newCounter = remountCounter + 1
-                    setRemountCounter(newCounter)
-                    firstCall = true
-                }
-            })
-
-            observer.observe(wrapperRef.current)
-            setResizeObserver(observer)
-
-            return () => observer.disconnect()
-        }
-    }, [onEndReached, wrapperRef.current, setRemountCounter])
+    const resizeCounter = useResizeCounter(wrapperRef.current)
 
     return (
         <div className="optionsContainer">
@@ -77,10 +57,10 @@ export const OptionsContainer = ({
                         )
                     })}
 
-                    {onEndReached && resizeObserver && (
+                    {onEndReached && (
                         <EndIntersectionDetector
                             dataTest={`${dataTest}-endintersectiondetector`}
-                            key={`key-${remountCounter}`}
+                            key={`key-${resizeCounter}`}
                             rootRef={optionsRef}
                             onEndReached={onEndReached}
                         />

--- a/packages/widgets/src/Transfer/OptionsContainer.js
+++ b/packages/widgets/src/Transfer/OptionsContainer.js
@@ -21,7 +21,6 @@ export const OptionsContainer = ({
 }) => {
     const optionsRef = useRef(null)
     const wrapperRef = useRef(null)
-
     const resizeCounter = useResizeCounter(wrapperRef.current)
 
     return (

--- a/packages/widgets/src/Transfer/useResizeCounter.js
+++ b/packages/widgets/src/Transfer/useResizeCounter.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+/*
+ * The initial call is irrelevant as there has been
+ * no resize yet that we want to react to
+ * So we start with -1 with will returned as 0 by this hook
+ *
+ * @param {Element} element
+ * @returns {number}
+ */
+export const useResizeCounter = element => {
+    const [counter, setCounter] = useState(-1)
+
+    useEffect(() => {
+        // using an internal counter as using the one from `useState`
+        // would cause an infinite loop as this `useEffect` would
+        // both depend on that value as well as change it every time
+        // it's executed as the callback passed to `ResizeObserver`
+        // will be executed on construction
+        let internalCounter = counter
+
+        if (element) {
+            const observer = new ResizeObserver(() => {
+                ++internalCounter
+                setCounter(internalCounter)
+            })
+
+            observer.observe(element)
+            return () => observer.disconnect()
+        }
+    }, [element, setCounter])
+
+    return counter < 1 ? 0 : counter
+}


### PR DESCRIPTION
Fixes #257 

* Removed the `observer` variable in the `IntersectionDetector` which caused buggy behavior
* Restructured the combination of resize + intersection to not call the `onEndReached` callback twice in the beginning