### PR TITLE
fix: use white background color for textarea instead of transparent

### DIFF
--- a/packages/core/src/TextArea/TextArea.styles.js
+++ b/packages/core/src/TextArea/TextArea.styles.js
@@ -10,7 +10,7 @@ export const styles = css`
         padding: 8px 12px;
 
         color: ${colors.grey900};
-        background-color: transparent;
+        background-color: white;
 
         border: 1px solid ${colors.grey500};
         border-radius: 3px;


### PR DESCRIPTION
Closes #274 

I'm using regular white, just like our Input.