### PR TITLE
fix: remove name property for select field labels

### DIFF
--- a/packages/widgets/src/MultiSelectField/MultiSelectField.js
+++ b/packages/widgets/src/MultiSelectField/MultiSelectField.js
@@ -57,7 +57,6 @@ class MultiSelectField extends React.Component {
             <Field
                 className={className}
                 dataTest={dataTest}
-                name={name}
                 disabled={disabled}
                 required={required}
                 label={label}

--- a/packages/widgets/src/SingleSelectField/SingleSelectField.js
+++ b/packages/widgets/src/SingleSelectField/SingleSelectField.js
@@ -57,7 +57,6 @@ class SingleSelectField extends React.Component {
             <Field
                 className={className}
                 dataTest={dataTest}
-                name={name}
                 disabled={disabled}
                 required={required}
                 label={label}


### PR DESCRIPTION
Closes #266 

Our SingleSelectFields and MultiSelectFields were emitting a warning in the console when hovering over their label. This is because of a faulty `name` that was being passed to the `Field` component. It's not present in the props, so the global `window.name` was passed (`""`). That's also why it didn't show up in linting (since window.name exists).

Our select is not a labelable component (https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Form_labelable), so I've removed the name line from the SingleSelectField and MultiSelectField.