### PR TITLE
fix: use > as ns separator for translation with :

### DIFF
--- a/packages/widgets/i18n/en.pot
+++ b/packages/widgets/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-05-14T13:50:41.269Z\n"
-"PO-Revision-Date: 2020-05-14T13:50:41.269Z\n"
+"POT-Creation-Date: 2020-09-17T12:14:04.736Z\n"
+"PO-Revision-Date: 2020-09-17T12:14:04.736Z\n"
 
 msgid "Upload a file"
 msgstr ""
@@ -54,4 +54,7 @@ msgid "No options found"
 msgstr ""
 
 msgid "Could not load children"
+msgstr ""
+
+msgid "Error: {{ ERRORMESSAGE }}"
 msgstr ""

--- a/packages/widgets/src/OrganisationUnitTree/RootError.js
+++ b/packages/widgets/src/OrganisationUnitTree/RootError.js
@@ -4,8 +4,10 @@ import propTypes from 'prop-types'
 
 export const RootError = ({ dataTest, error }) => (
     <div data-test={`${dataTest}-loading`}>
-        {i18n.t('Error: ')}
-        {error}
+        {i18n.t('Error: {{ ERRORMESSAGE }}', {
+            ERRORMESSAGE: error,
+            nsSeparator: '>',
+        })}
     </div>
 )
 


### PR DESCRIPTION
Closes #279 

I've also made the message part of the translation so that it can be positioned differently for languages that are rtl for example (though I assume they'd still have problems with the error message text itself).