### PR TITLE
fix: allow empty string as select option value

### DIFF
--- a/packages/core/src/SingleSelect/Input.js
+++ b/packages/core/src/SingleSelect/Input.js
@@ -20,7 +20,7 @@ const Input = ({
     disabled,
     inputMaxHeight,
 }) => {
-    const hasSelection = selected && typeof selected === 'string'
+    const hasSelection = typeof selected === 'string'
     const onClear = (_, e) => {
         const data = { selected: '' }
 

--- a/packages/core/src/SingleSelect/SingleSelect.js
+++ b/packages/core/src/SingleSelect/SingleSelect.js
@@ -118,7 +118,6 @@ const SingleSelect = ({
 }
 
 SingleSelect.defaultProps = {
-    selected: '',
     dataTest: 'dhis2-uicore-singleselect',
 }
 

--- a/packages/core/src/SingleSelect/features/accepts_blur_cb/index.js
+++ b/packages/core/src/SingleSelect/features/accepts_blur_cb/index.js
@@ -9,7 +9,7 @@ Then('the onBlur handler is called', () => {
     cy.window().should(win => {
         expect(win.onBlur).to.be.calledOnce
         expect(win.onBlur).to.be.calledWith({
-            selected: '',
+            selected: undefined,
         })
     })
 })

--- a/packages/core/src/SingleSelect/features/accepts_focus_cb/index.js
+++ b/packages/core/src/SingleSelect/features/accepts_focus_cb/index.js
@@ -9,7 +9,7 @@ Then('the onFocus handler is called', () => {
     cy.window().should(win => {
         expect(win.onFocus).to.be.calledOnce
         expect(win.onFocus).to.be.calledWith({
-            selected: '',
+            selected: undefined,
         })
     })
 })

--- a/packages/widgets/src/SingleSelectField/SingleSelectField.js
+++ b/packages/widgets/src/SingleSelectField/SingleSelectField.js
@@ -102,7 +102,6 @@ class SingleSelectField extends React.Component {
 
 SingleSelectField.defaultProps = {
     dataTest: 'dhis2-uiwidgets-singleselectfield',
-    selected: '',
 
     clearText: () => i18n.t('Clear'),
     empty: () => i18n.t('No data found'),


### PR DESCRIPTION
Closes #245

I wonder whether we can call this a fix. If a user has this kind of select:

```jsx
<SingleSelect selected={""} >
  <SingleSelectOption value="1" label="1" />
</SingleSelect>
```

which was valid code (though not very useful), then this update will break their code. Previously it would skip `""` since it's falsy, but since now `""` will be a valid value, the select will look for that value in the options. When it can't find an option with that value it'll throw an error.

So for this users this would be a breaking change.