### PR TITLE
fix(input field ff): forward type property of Field component

### DIFF
--- a/packages/forms/src/InputFieldFF/InputFieldFF.js
+++ b/packages/forms/src/InputFieldFF/InputFieldFF.js
@@ -29,6 +29,7 @@ export const InputFieldFF = ({
     <InputField
         {...rest}
         name={input.name}
+        type={input.type}
         error={hasError(meta, error)}
         valid={isValid(meta, valid, showValidStatus)}
         loading={isLoading(meta, loading, showLoadingStatus)}


### PR DESCRIPTION
The type property is only accessible through the `input` prop that's passed to the InputFieldFF component, so it needs to forward that property. The `input.type` property is undefined when no type is provided, so I just forwarded the prop and ignored the missing type case (which will default to `input` in the `Input` component)