### PR TITLE
feat(orgunittree): sort org units alphabetically

### DIFF
--- a/packages/widgets/src/OrganisationUnitTree/OrganisationUnitNode.js
+++ b/packages/widgets/src/OrganisationUnitTree/OrganisationUnitNode.js
@@ -46,6 +46,7 @@ export const OrganisationUnitNode = ({
     selected,
     singleSelection,
     filter,
+    suppressAlphabeticalSorting,
     onChange,
     onChildrenLoaded,
     onCollapse,
@@ -53,6 +54,7 @@ export const OrganisationUnitNode = ({
 }) => {
     const { loading, error, data } = useOrgData([id], {
         isUserDataViewFallback,
+        suppressAlphabeticalSorting,
     })
     const childNodes =
         !loading && !error ? computeChildNodes(data[id], filter) : []
@@ -142,6 +144,9 @@ export const OrganisationUnitNode = ({
                             highlighted={highlighted}
                             id={child.id}
                             isUserDataViewFallback={isUserDataViewFallback}
+                            suppressAlphabeticalSorting={
+                                suppressAlphabeticalSorting
+                            }
                             path={childPath}
                             selected={selected}
                             singleSelection={singleSelection}
@@ -171,6 +176,7 @@ OrganisationUnitNode.propTypes = {
     path: orgUnitPathPropType,
     selected: propTypes.arrayOf(orgUnitPathPropType),
     singleSelection: propTypes.bool,
+    suppressAlphabeticalSorting: propTypes.bool,
 
     onChildrenLoaded: propTypes.func,
     onCollapse: propTypes.func,

--- a/packages/widgets/src/OrganisationUnitTree/OrganisationUnitTree.js
+++ b/packages/widgets/src/OrganisationUnitTree/OrganisationUnitTree.js
@@ -46,6 +46,7 @@ const OrganisationUnitTree = ({
     filter,
     selected,
     singleSelection,
+    suppressAlphabeticalSorting,
 
     onExpand,
     onCollapse,
@@ -56,6 +57,7 @@ const OrganisationUnitTree = ({
     const { loading, error, data, refetch } = useOrgData(rootIds, {
         withChildren: false,
         isUserDataViewFallback,
+        suppressAlphabeticalSorting,
     })
     const { expanded, handleExpand, handleCollapse } = useExpanded(
         initiallyExpanded,
@@ -95,6 +97,9 @@ const OrganisationUnitTree = ({
                             path={rootPath}
                             selected={selected}
                             singleSelection={singleSelection}
+                            suppressAlphabeticalSorting={
+                                suppressAlphabeticalSorting
+                            }
                             onChange={onChange}
                             onChildrenLoaded={onChildrenLoaded}
                             onCollapse={handleCollapse}
@@ -190,6 +195,7 @@ OrganisationUnitTree.propTypes = {
     isUserDataViewFallback: propTypes.bool,
     selected: propTypes.arrayOf(orgUnitPathPropType),
     singleSelection: propTypes.bool,
+    suppressAlphabeticalSorting: propTypes.bool,
     onChildrenLoaded: propTypes.func,
     onCollapse: propTypes.func,
     onExpand: propTypes.func,

--- a/packages/widgets/src/OrganisationUnitTree/OrganisationUnitTree.stories.js
+++ b/packages/widgets/src/OrganisationUnitTree/OrganisationUnitTree.stories.js
@@ -447,6 +447,7 @@ storiesOf('OrganisationUnitTree', module)
             </div>
             <Wrapper
                 //initiallyExpanded={['/ImspTQPwCqd/eIQbndfxQMb']}
+                suppressAlphabeticalSorting
                 roots="ImspTQPwCqd"
             />
         </div>

--- a/packages/widgets/src/OrganisationUnitTree/__e2e__/tree_api.stories.e2e.js
+++ b/packages/widgets/src/OrganisationUnitTree/__e2e__/tree_api.stories.e2e.js
@@ -16,7 +16,7 @@ window.dataProviderData = {
         ],
     },
     'organisationUnits/A0000000001': {
-        ...dataProviderData['organisationUnits/A0000000000'],
+        ...dataProviderData['organisationUnits/A0000000001'],
         children: [],
     },
 }

--- a/packages/widgets/src/OrganisationUnitTree/__tests__/useOrgData.test.js
+++ b/packages/widgets/src/OrganisationUnitTree/__tests__/useOrgData.test.js
@@ -2,6 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 
 import {
     addMissingDisplayNameProps,
+    sortNodeChildrenAlphabetically,
     createQuery,
 } from '../useOrgData/helpers.js'
 import { useOrgData } from '../useOrgData.js'
@@ -12,7 +13,8 @@ jest.mock('@dhis2/app-runtime', () => ({
 
 jest.mock('../useOrgData/helpers', () => ({
     createQuery: jest.fn(() => 'createQuery'),
-    addMissingDisplayNameProps: jest.fn(() => 'addMissingDisplayNameProps'),
+    addMissingDisplayNameProps: jest.fn(() => ({})),
+    sortNodeChildrenAlphabetically: jest.fn(() => []),
 }))
 
 describe('OrganisationUnitTree - useOrgData', () => {
@@ -22,6 +24,7 @@ describe('OrganisationUnitTree - useOrgData', () => {
         createQuery.mockClear()
         useDataQuery.mockClear()
         addMissingDisplayNameProps.mockClear()
+        sortNodeChildrenAlphabetically.mockClear()
     })
 
     it('create the query from the ids', () => {
@@ -44,10 +47,22 @@ describe('OrganisationUnitTree - useOrgData', () => {
         expect(addMissingDisplayNameProps).toHaveBeenCalledWith(data)
     })
 
-    it('should return the data from addMissingDisplayNameProps as data when there are nodes', () => {
+    it('should return the data from addMissingDisplayNameProps as data when there are nodes and children are not being sorted', () => {
         const data = { id1: {} }
         useDataQuery.mockReturnValueOnce({ loading: false, error: null, data })
         addMissingDisplayNameProps.mockImplementationOnce(input => input)
+        const { data: actual } = useOrgData(ids, {
+            suppressAlphabeticalSorting: true,
+        })
+
+        expect(actual).toEqual(data)
+    })
+
+    it('should return the data from the sorting process as data when there are nodes and children are being sorted', () => {
+        const data = { id1: { id: 'id1' }, id2: { id: 'id2' } }
+        useDataQuery.mockReturnValueOnce({ loading: false, error: null, data })
+        addMissingDisplayNameProps.mockImplementationOnce(input => input)
+        sortNodeChildrenAlphabetically.mockImplementation(input => input)
         const { data: actual } = useOrgData(ids)
 
         expect(actual).toEqual(data)

--- a/packages/widgets/src/OrganisationUnitTree/useOrgData.js
+++ b/packages/widgets/src/OrganisationUnitTree/useOrgData.js
@@ -1,6 +1,9 @@
 import { useDataQuery } from '@dhis2/app-runtime'
-
-import { addMissingDisplayNameProps, createQuery } from './useOrgData/helpers'
+import {
+    addMissingDisplayNameProps,
+    createQuery,
+    sortNodeChildrenAlphabetically,
+} from './useOrgData/helpers'
 
 /**
  * @param {string[]} ids
@@ -11,12 +14,29 @@ import { addMissingDisplayNameProps, createQuery } from './useOrgData/helpers'
  */
 export const useOrgData = (
     ids,
-    { withChildren = true, isUserDataViewFallback } = {}
+    {
+        withChildren = true,
+        isUserDataViewFallback,
+        suppressAlphabeticalSorting,
+    } = {}
 ) => {
     const query = createQuery(ids)
     const variables = { withChildren, isUserDataViewFallback }
     const { loading, error, data, refetch } = useDataQuery(query, { variables })
     const nodes = data ? addMissingDisplayNameProps(data) : {}
 
-    return { loading, error, data: nodes, refetch }
+    let sorted = nodes
+    if (!suppressAlphabeticalSorting) {
+        sorted = Object.values(nodes)
+            .map(sortNodeChildrenAlphabetically)
+            .reduce(
+                (current, node) => ({
+                    ...current,
+                    [node.id]: node,
+                }),
+                {}
+            )
+    }
+
+    return { loading, error, data: sorted, refetch }
 }

--- a/packages/widgets/src/OrganisationUnitTree/useOrgData/helpers.js
+++ b/packages/widgets/src/OrganisationUnitTree/useOrgData/helpers.js
@@ -28,3 +28,18 @@ export const addMissingDisplayNameProps = nodes => {
 
     return fromEntries(nodesWithDisplayName)
 }
+
+export const sortNodeChildrenAlphabetically = node => {
+    if (!node.children) return node
+    const sortedChildren = [...node.children]
+
+    sortedChildren.sort((left, right) => {
+        if (left.displayName === right.displayName) return 0
+        return left.displayName > right.displayName ? 1 : -1
+    })
+
+    return {
+        ...node,
+        children: sortedChildren,
+    }
+}


### PR DESCRIPTION
Fixed DHIS2-9440

I've added a `suppressAlphabeticalSorting` in case this behavior is not wanted, sorting now happens by default.
It'll change the order of displayed items in apps that already use this, but as apps don't have any control over this process, this won't break anythings, so in my opinion this does not need to be a breaking change.