### PR TITLE
fix: adjust icon button sizes

### DIFF
--- a/packages/core/src/Button/Button.styles.js
+++ b/packages/core/src/Button/Button.styles.js
@@ -218,7 +218,7 @@ export default css`
     }
 
     .icon-only {
-        padding: 0 0 0 6px;
+        padding: 0 0 0 5px;
     }
 
     .button-icon {
@@ -230,12 +230,20 @@ export default css`
         pointer-events: none;
     }
 
+    .icon-only .button-icon {
+        margin-right: 5px;
+    }
+
     .small.icon-only {
-        padding: 0 0 0 2px;
+        padding: 0 0 0 1px;
     }
 
     .small .button-icon {
         margin-right: 2px;
+    }
+
+    .small.icon-only .button-icon {
+        margin-right: 1px;
     }
 
     .toggled {


### PR DESCRIPTION
This PR adjusts the padding on icon-only buttons for regular and dense sizes.

Previously the left/right padding was too large, causing icon-only buttons to be slightly-not-square at 38x36 and 30x28. The fix adjusts the css to make the icon-only buttons correctly sized at 36x36 and 28x28.