### PR TITLE
fix(alertbar): skip init on component update

### DIFF
--- a/packages/core/src/AlertBar/AlertBar.js
+++ b/packages/core/src/AlertBar/AlertBar.js
@@ -24,34 +24,19 @@ class AlertBar extends Component {
     // visible is used to control the show/hide animation
     // hidden is used to stop rendering entirely after hide animation
     state = {
-        visible: false,
+        visible: true,
         hidden: false,
     }
 
     componentDidMount() {
-        this.init()
-    }
-
-    componentDidUpdate(_prevProps, prevState) {
-        // Only re-init when props change, ignore state changes
-        if (
-            prevState.visible === this.state.visible &&
-            prevState.hidden === this.state.hidden
-        ) {
-            this.init()
-        }
+        this.startTime = Date.now()
+        this.timeRemaining = this.props.duration
+        this.startDisplayTimeout()
     }
 
     componentWillUnmount() {
         clearTimeout(this.displayTimeout)
         clearTimeout(this.onHiddenTimeout)
-    }
-
-    init() {
-        this.startTime = Date.now()
-        this.timeRemaining = this.props.duration
-        this.startDisplayTimeout()
-        this.show()
     }
 
     startDisplayTimeout = () => {
@@ -80,12 +65,6 @@ class AlertBar extends Component {
                 () => this.props.onHidden && this.props.onHidden({}, event)
             )
         }, ANIMATION_TIME)
-    }
-
-    show() {
-        requestAnimationFrame(() => {
-            this.setState({ visible: true })
-        })
     }
 
     shouldAutoHide() {

--- a/packages/core/src/AlertBar/AlertBar.styles.js
+++ b/packages/core/src/AlertBar/AlertBar.styles.js
@@ -8,28 +8,20 @@ export default css`
         display: flex;
         justify-content: space-between;
         align-items: center;
-
         border-radius: 4px;
         box-shadow: ${elevations.e300};
-
         padding-top: ${spacers.dp12};
         padding-right: ${spacers.dp16};
         padding-bottom: ${spacers.dp12};
         padding-left: ${spacers.dp24};
-
         margin-bottom: ${spacers.dp16};
-
         max-width: 600px;
-
         font-size: 14px;
-
-        transform: translateY(1000px);
-        transition: transform ${ANIMATION_TIME}ms cubic-bezier(0.4, 0, 0.6, 1);
-
         pointer-events: all;
     }
 
     /* States */
+
     div.info {
         background-color: ${colors.grey900};
         color: ${colors.white};
@@ -60,7 +52,41 @@ export default css`
     }
 
     /* Animation */
+
+    @keyframes slidein {
+        from {
+            transform: translateY(1000px);
+        }
+        to {
+            transform: translateY(0);
+        }
+    }
+
+    @keyframes slideout {
+        from {
+            transform: translateY(0);
+        }
+        to {
+            transform: translateY(1000px);
+        }
+    }
+
+    /**
+     * The AlertBar starts out visible. This triggers the slidein animation.
+     * Removing the .visible class triggers the slideout animation.
+     */
+
     div.visible {
-        transform: translateY(0px);
+        animation-duration: ${ANIMATION_TIME}ms;
+        animation-name: slidein;
+        animation-fill-mode: forwards;
+        animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+
+    div {
+        animation-duration: ${ANIMATION_TIME}ms;
+        animation-name: slideout;
+        animation-fill-mode: forwards;
+        animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
     }
 `


### PR DESCRIPTION
Fixes an infinite loop caused by an unconditional setstate on component updates. It doesn't seem necessary to re-run init when the props are updated anyway. The core problem was the setState in the `show()` method, which was called by `init()`, which was run on every update (or more precisely, when state was the same as the previous state).

* Since we're not reusing init, I've just moved what we were doing there to didMount
* Since show was called on didMount and just changing state, I'm now starting with that state on mount. That meant show could also be removed. This meant that the animation logic had to be changed, which I've done as well.

I've tried to stick to the existing code as much as possible. Starting out with the `.visible` class could maybe be refactored to starting out without a class, and then hiding when a `.hiding` class is added instead for example. But I figured that those kinds of more elaborate changes were out of scope for this PR.

Closes #299 