### PR TITLE
chore(dependencies): remove unused package

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
         "react-dev-utils": "^10.2.1",
         "react-docgen": "^5.3.0",
         "react-dom": "16.8",
-        "styled-jsx": "^3.3.0",
-        "typeface-roboto": "^0.0.75"
+        "styled-jsx": "^3.3.0"
     },
     "d2": {
         "docsite": {


### PR DESCRIPTION
Closes #312 

I don't see this package being imported anywhere. The build and storybook also still work after removing. Yarn why shows this:

<img width="645" alt="Screenshot 2020-10-13 at 15 15 55" src="https://user-images.githubusercontent.com/7355199/95866447-390f5c80-0d68-11eb-97de-a3465fe98063.png">

I think it's safe to remove it. Seems like it's bundled in the app-shell.