### PR TITLE
chore(dependencies): replace deprecated roboto package

### DIFF
--- a/storybook/.storybook/preview.js
+++ b/storybook/.storybook/preview.js
@@ -1,4 +1,4 @@
-import 'typeface-roboto'
+import 'fontsource-roboto/latin.css'
 import React, { Fragment } from 'react'
 import { jsxDecorator } from 'storybook-addon-jsx'
 import { addDecorator, addParameters } from '@storybook/react'
@@ -37,8 +37,8 @@ addDecorator(fn => (
 addParameters({
     options: {
         storySort: (a, b) =>
-            a[1].kind === b[1].kind 
-            ? 0 
+            a[1].kind === b[1].kind
+            ? 0
             : a[1].id.localeCompare(b[1].id, undefined, { numeric: true }),
     },
 })

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -17,9 +17,9 @@
         "@storybook/csf": "^0.0.1",
         "@storybook/preset-create-react-app": "^3.1.4",
         "@storybook/react": "^6.0.22",
+        "fontsource-roboto": "^3.0.3",
         "storybook-addon-jsx": "^7.3.4",
-        "storybook-addon-react-docgen": "^1.2.42",
-        "typeface-roboto": "^0.0.75"
+        "storybook-addon-react-docgen": "^1.2.42"
     },
     "dependencies": {
         "@dhis2/ui": "5.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9220,6 +9220,11 @@ follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.0.tgz#b42e8d93a2a7eea5ed88633676d6597bc8e384db"
   integrity sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA==
 
+fontsource-roboto@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fontsource-roboto/-/fontsource-roboto-3.0.3.tgz#99c312babeabce22b3e933b3edf2951d4508f4f7"
+  integrity sha512-kfsC9qAP6XhwnSDAhg2lhWeaUJfLGXZh7GcLxFiz/4lXdkV2pVhWv2Xp9ES3b3BHdc9UuPrWXXLOphzHIStcOw==
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"


### PR DESCRIPTION
Replaces deprecated https://www.npmjs.com/package/typeface-roboto with the recommended, maintained follow-up: https://www.npmjs.com/package/fontsource-roboto.