### PR TITLE
fix(headerbar): allow keyboard focus on apps drawer trigger

### DIFF
--- a/packages/widgets/src/HeaderBar/Apps.js
+++ b/packages/widgets/src/HeaderBar/Apps.js
@@ -243,16 +243,22 @@ export default class Apps extends React.Component {
         const apps = this.props.apps
         return (
             <div ref={c => (this.elContainer = c)} data-test="headerbar-apps">
-                <a onClick={this.onToggle} data-test="headerbar-apps-icon">
+                <button onClick={this.onToggle} data-test="headerbar-apps-icon">
                     <AppsIcon className={appIcon.className} />
-                </a>
+                </button>
 
                 {this.state.show && this.AppMenu(apps)}
 
                 {appIcon.styles}
                 <style jsx>{`
-                    a {
+                    button {
                         display: block;
+                        background: transparent;
+                        padding: 0;
+                        border: 0;
+                    }
+                    button:focus {
+                        outline: 1px dotted white;
                     }
 
                     div {

--- a/packages/widgets/src/HeaderBar/NotificationIcon.js
+++ b/packages/widgets/src/HeaderBar/NotificationIcon.js
@@ -53,6 +53,9 @@ export const NotificationIcon = ({ count, href, kind, dataTestId }) => (
                 margin: 8px 24px 0 0;
                 cursor: pointer;
             }
+            a:focus {
+                outline: 1px dotted white;
+            }
 
             span {
                 z-index: 1;


### PR DESCRIPTION
This PR will allow keyboard focus on the apps drawer trigger in the headerbar. It also changes the focus styles of headerbar items for contrast accessbility.

The current apps drawer trigger is a `<a>` without `href` and therefore cannot be focussed. This (naive) fix uses a `<button>` instead to allow focus, and styles the button to be invisible. I am unaware if there was a reason to use an `<a>` initially that would make `<button>` the wrong choice, but I found no issues when testing.

Fixes https://jira.dhis2.org/browse/LIBS-50