### PR TITLE
fix(tooltip): leverage layer context to ensure correct stacking of the tooltip

### DIFF
--- a/packages/core/src/Tooltip/Tooltip.js
+++ b/packages/core/src/Tooltip/Tooltip.js
@@ -5,6 +5,7 @@ import { resolve } from 'styled-jsx/css'
 import propTypes from '@dhis2/prop-types'
 import { colors, layers } from '@dhis2/ui-constants'
 
+import { useLayerContext } from '../Layer/Layer.js'
 import { Popper } from '../Popper/Popper.js'
 
 const TOOLTIP_OFFSET = 4
@@ -46,6 +47,7 @@ const Tooltip = ({
     const popperReference = useRef()
     const openTimerRef = useRef(null)
     const closeTimerRef = useRef(null)
+    const { node: portalRootNode } = useLayerContext()
 
     const onMouseOver = () => {
         clearTimeout(closeTimerRef.current)
@@ -97,7 +99,7 @@ const Tooltip = ({
                             {content}
                         </div>
                     </Popper>,
-                    document.body
+                    portalRootNode
                 )}
             {popperStyle.styles}
             <style jsx>{`

--- a/packages/core/src/Tooltip/Tooltip.stories.e2e.js
+++ b/packages/core/src/Tooltip/Tooltip.stories.e2e.js
@@ -2,6 +2,7 @@ import React from 'react'
 import css from 'styled-jsx/css'
 
 import { Tooltip } from './Tooltip.js'
+import { Modal } from '../Modal/Modal.js'
 
 const noPaddingStyles = css`
     :global(#root) {
@@ -72,4 +73,22 @@ export const ShiftingPosition = () => (
             }
         `}</style>
     </p>
+)
+
+export const ModalWithTooltip = () => (
+    <Modal>
+        <p>
+            I am a <Tooltip content="Short content">paragraph</Tooltip> that
+            contains a tooltip.
+        </p>
+        {/* 
+            Added pointer-events: all to the popper element to circumvent
+            a cypress bug: https://github.com/cypress-io/cypress/issues/9227
+         */}
+        <style jsx>{`
+            :global([data-test='dhis2-uicore-popper']) {
+                pointer-events: all;
+            }
+        `}</style>
+    </Modal>
 )

--- a/packages/core/src/Tooltip/features/layering.feature
+++ b/packages/core/src/Tooltip/features/layering.feature
@@ -1,0 +1,8 @@
+Feature: Tooltip layering
+
+    Scenario: Tooltip is rendered from a Modal
+        Given a Modal contains a tooltip
+        When the mouse cursor enters the anchor
+        Then the Tooltip is rendered above the anchor
+        And the Tooltip has attached itself to the modal layer root node
+        And the Tooltip is fully visible

--- a/packages/core/src/Tooltip/features/layering/index.js
+++ b/packages/core/src/Tooltip/features/layering/index.js
@@ -1,0 +1,19 @@
+import '../common'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a Modal contains a tooltip', () => {
+    cy.visitStory('Tooltip', 'Modal With Tooltip')
+})
+
+Then('the Tooltip has attached itself to the modal layer root node', () => {
+    cy.all(
+        () => cy.get('[data-test="dhis2-uicore-layer"]'),
+        () => cy.get('[data-test="dhis2-uicore-popper"]')
+    ).should(([$layer, $popper]) => {
+        expect($popper.get(0).parentNode).to.equal($layer.get(0))
+    })
+})
+
+Then('the Tooltip is fully visible', () => {
+    cy.get('[data-test="dhis2-uicore-popper"]').should('be.visible')
+})


### PR DESCRIPTION
This fixes bug [TECH-473](https://jira.dhis2.org/browse/TECH-473) which @turban reported. I'll provide some info:
- Our layering mechanism can be leveraged in two ways:
    1. Adding new layers via the `Layer` component. This will result in a blocking UI because it actually renders a div that covers the underlying content. For a `Tooltip` this isn't good.
    2. Using the `useLayerContext` hook to get the closest parent layer root node. You can pass this node as the second arg in a call to `React.createPortal` so that the new portal becomes a direct descendant of the parent layer node and the normal CSS z-index stacking context Just Works ™️ . I hadn't used this approach before but the Tooltip seemed to be the right candidate for it.
- Since the Tooltip was initially a class component it could not use the `useLayerContext` hook. So I refactored it as a function component.
- When adding tests I ran into a cypress bug reg. visibility assertions and `pointer-events: none;`. I filed a bug report https://github.com/cypress-io/cypress/issues/9227 and have implemented a small hack in the e2e story to make the test run as expected.