### PR TITLE
fix(IntersectionDetector): use mixed export prop-types style

### DIFF
--- a/packages/core/src/IntersectionDetector/IntersectionDetector.js
+++ b/packages/core/src/IntersectionDetector/IntersectionDetector.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { PropTypes } from '@dhis2/prop-types'
+import propTypes from '@dhis2/prop-types'
 ;('') // TODO: https://github.com/jsdoc/jsdoc/issues/1718
 
 /**
@@ -101,14 +101,14 @@ IntersectionDetector.defaultProps = {
  * @prop {number} [threshold]
  */
 IntersectionDetector.propTypes = {
-    rootRef: PropTypes.shape({
+    rootRef: propTypes.shape({
         // not required so `current` can be `null`
-        current: PropTypes.instanceOf(HTMLElement),
+        current: propTypes.instanceOf(HTMLElement),
     }).isRequired,
-    onChange: PropTypes.func.isRequired,
+    onChange: propTypes.func.isRequired,
 
-    children: PropTypes.any,
-    className: PropTypes.string,
-    dataTest: PropTypes.string,
-    threshold: PropTypes.number,
+    children: propTypes.any,
+    className: propTypes.string,
+    dataTest: propTypes.string,
+    threshold: propTypes.number,
 }


### PR DESCRIPTION
`ui-core` has a [dependency](https://github.com/dhis2/ui/blob/master/packages/core/package.json#L29) on `@dhis2/prop-types@^1.6.4`. The re-export style was changed in `@dhis2/prop-types@2.0.0`.  All other components in `ui-core` use the pre-2.0 import style for `@dhis2/prop-types`, but for some reason this one doesn't.

I'm not sure how this component could ever have worked... and curious how we didn't catch this in tests.  The storybook appears to be broken, perhaps related - https://ui.dhis2.nu/demo/?path=/story/intersectionobserver--absolute-bottom-area

We should probably upgrade the dependency and move to the new `@dhis2/prop-types` import style here (codeMod?), or revert the prop-types export change if we're not going to use it.