### PR TITLE
chore(release): fix entrypoint configuration

### DIFF
--- a/packages/constants/d2.config.js
+++ b/packages/constants/d2.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: 'lib',
-    entryPoint: {
+    entryPoints: {
         lib: 'src/index.js',
     },
 }

--- a/packages/core/d2.config.js
+++ b/packages/core/d2.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: 'lib',
-    entryPoint: {
+    entryPoints: {
         lib: 'src/index.js',
     },
 }

--- a/packages/forms/d2.config.js
+++ b/packages/forms/d2.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: 'lib',
-    entryPoint: {
+    entryPoints: {
         lib: 'src/index.js',
     },
 }

--- a/packages/icons/d2.config.js
+++ b/packages/icons/d2.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: 'lib',
-    entryPoint: {
+    entryPoints: {
         lib: 'src/index.js',
     },
 }

--- a/packages/ui/d2.config.js
+++ b/packages/ui/d2.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: 'lib',
-    entryPoint: {
+    entryPoints: {
         lib: 'src/index.js',
     },
 }

--- a/packages/widgets/d2.config.js
+++ b/packages/widgets/d2.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     type: 'lib',
-    entryPoint: {
+    entryPoints: {
         lib: 'src/index.js',
     },
 }


### PR DESCRIPTION
This fixes our d2-app-scripts entrypoint configuration. We were using `entryPoint`, when the docs reference `entryPoints`: https://platform.dhis2.nu/#/config/d2-config-js-reference?id=supported-properties.

It worked because we were using the default entryPoint (`src/index.js`), which d2-app-scripts falls back to.