### PR TITLE
chore(yarn): lock yarn version to 1.19.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
-.yarn
+# We use the newer format, .yarnrc.yml
 .yarnrc
 
 # Editor settings

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.19.1.js

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
   command = "yarn install --frozen-lockfile && yarn build && yarn docs && yarn demo"
   publish = "dist/"
+  environment = { YARN_VERSION = "1.19.1" }


### PR DESCRIPTION
This locks the yarn version that will be used when installing dependencies for this monorepo to 1.19.1.