### PR TITLE
build(eslint): add more import restrictions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,23 +6,16 @@ const config = {
         cy: 'readonly',
         Cypress: 'readonly',
     },
-    rules: {
-        'no-restricted-imports': [
-            'error',
-            {
-                paths: ['@dhis2/ui'],
-                patterns: ['@dhis2/ui/*'],
-            },
-        ],
-    },
 }
 
 // Run cpu intensive checks only on CI
 const isCI = !!process.env.CI
 
 if (isCI) {
-    config.rules['import/no-cycle'] = 'error'
-    config.rules['import/no-self-import'] = 'error'
+    config.rules = {
+        'import/no-cycle': 'error',
+        'import/no-self-import': 'error',
+    }
 }
 
 module.exports = config

--- a/packages/constants/.eslintrc.js
+++ b/packages/constants/.eslintrc.js
@@ -3,8 +3,22 @@ module.exports = {
         'no-restricted-imports': [
             'error',
             {
-                paths: ['@dhis2/ui-constants'],
-                patterns: ['@dhis2/ui-constants/*'],
+                paths: [
+                    '@dhis2/ui-constants',
+                    '@dhis2/ui-core',
+                    '@dhis2/ui-forms',
+                    '@dhis2/ui-icons',
+                    '@dhis2/ui',
+                    '@dhis2/ui-widgets',
+                ],
+                patterns: [
+                    '@dhis2/ui-constants/*',
+                    '@dhis2/ui-core/*',
+                    '@dhis2/ui-forms/*',
+                    '@dhis2/ui-icons/*',
+                    '@dhis2/ui/*',
+                    '@dhis2/ui-widgets/*',
+                ],
             },
         ],
     },

--- a/packages/core/.eslintrc.js
+++ b/packages/core/.eslintrc.js
@@ -3,8 +3,18 @@ module.exports = {
         'no-restricted-imports': [
             'error',
             {
-                paths: ['@dhis2/ui-core'],
-                patterns: ['@dhis2/ui-core/*'],
+                paths: [
+                    '@dhis2/ui-core',
+                    '@dhis2/ui-forms',
+                    '@dhis2/ui',
+                    '@dhis2/ui-widgets',
+                ],
+                patterns: [
+                    '@dhis2/ui-core/*',
+                    '@dhis2/ui-forms/*',
+                    '@dhis2/ui/*',
+                    '@dhis2/ui-widgets/*',
+                ],
             },
         ],
     },

--- a/packages/icons/.eslintrc.js
+++ b/packages/icons/.eslintrc.js
@@ -3,8 +3,22 @@ module.exports = {
         'no-restricted-imports': [
             'error',
             {
-                paths: ['@dhis2/ui-icons'],
-                patterns: ['@dhis2/ui-icons/*'],
+                paths: [
+                    '@dhis2/ui-constants',
+                    '@dhis2/ui-core',
+                    '@dhis2/ui-forms',
+                    '@dhis2/ui-icons',
+                    '@dhis2/ui',
+                    '@dhis2/ui-widgets',
+                ],
+                patterns: [
+                    '@dhis2/ui-constants/*',
+                    '@dhis2/ui-core/*',
+                    '@dhis2/ui-forms/*',
+                    '@dhis2/ui-icons/*',
+                    '@dhis2/ui/*',
+                    '@dhis2/ui-widgets/*',
+                ],
             },
         ],
     },

--- a/packages/ui/.eslintrc.js
+++ b/packages/ui/.eslintrc.js
@@ -3,8 +3,8 @@ module.exports = {
         'no-restricted-imports': [
             'error',
             {
-                paths: ['@dhis2/ui-forms', '@dhis2/ui'],
-                patterns: ['@dhis2/ui-forms/*', '@dhis2/ui/*'],
+                paths: ['@dhis2/ui'],
+                patterns: ['@dhis2/ui/*'],
             },
         ],
     },

--- a/packages/widgets/.eslintrc.js
+++ b/packages/widgets/.eslintrc.js
@@ -3,8 +3,12 @@ module.exports = {
         'no-restricted-imports': [
             'error',
             {
-                paths: ['@dhis2/ui-widgets'],
-                patterns: ['@dhis2/ui-widgets/*'],
+                paths: ['@dhis2/ui-forms', '@dhis2/ui', '@dhis2/ui-widgets'],
+                patterns: [
+                    '@dhis2/ui-forms/*',
+                    '@dhis2/ui/*',
+                    '@dhis2/ui-widgets/*',
+                ],
             },
         ],
     },


### PR DESCRIPTION
- The import restriction that prevented imports of `@dhis2/ui` in the root eslint has been moved to the eslint config of the individual packages, so that it doesn't get overwritten.
- Let me know if you think the restrictions are too strict anywhere. Currently this is the hierarchy:

  - constants and icons can't import from any other ui packages
  - core can only import from icons and constants
  - widgets can only import from core, icons and constants
  - forms can import from widgets, core, icons and constants