### PR TITLE
ci(eslint): only run circular dependency check on CI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,12 @@
-const { config } = require('@dhis2/cli-style')
+const cliStyle = require('@dhis2/cli-style')
 
-module.exports = {
-    extends: [config.eslintReact],
+const config = {
+    extends: [cliStyle.config.eslintReact],
     globals: {
         cy: 'readonly',
         Cypress: 'readonly',
     },
     rules: {
-        'import/no-cycle': 'error',
-        'import/no-self-import': 'error',
         'no-restricted-imports': [
             'error',
             {
@@ -18,3 +16,13 @@ module.exports = {
         ],
     },
 }
+
+// Run cpu intensive checks only on CI
+const isCI = !!process.env.CI
+
+if (isCI) {
+    config.rules['import/no-cycle'] = 'error'
+    config.rules['import/no-self-import'] = 'error'
+}
+
+module.exports = config


### PR DESCRIPTION
This runs our circular dependency checks only on CI, to not slow down editors, as the checks can be very cpu intensive.

See the GH docs for the `CI` env var I'm using: [GH actions docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables). Besides GH actions, `CI` is a pretty common env var for indicating that code is running on CI so it should even work with most other providers. See also here: https://github.com/watson/ci-info/blob/master/index.js#L52.

### Follow up

Also, as a follow up and if this works out, we can move this and related rules to cli-style and make it a rule we check for all our codebases: https://jira.dhis2.org/browse/CLI-19