### PR TITLE
docs(readme): add link to design system

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ We recommend that you use `@dhis2/ui` as the entrypoint for all imports of our f
 
 ## Documentation
 
+`@dhis2/ui` is based on the specifications in our design-system: https://github.com/dhis2/design-system. See the documentation there for more information.
+
 -   Docs: [ui.dhis2.nu](https://ui.dhis2.nu)
 -   Live demo: [ui.dhis2.nu/demo](https://ui.dhis2.nu/demo)
 -   API reference: [ui.dhis2.nu/api](https://ui.dhis2.nu/#/api)


### PR DESCRIPTION
This adds a link to the design system, just so it's clear what principles and specs this lib is based on. Noticed during the presentation that we didn't have that yet.