### PR TITLE
fix(button): pass name prop to button element

### DIFF
--- a/packages/core/src/Button/Button.js
+++ b/packages/core/src/Button/Button.js
@@ -59,6 +59,7 @@ export const Button = ({
     return (
         <button
             ref={ref}
+            name={name}
             className={buttonClassName}
             data-test={dataTest}
             disabled={disabled}


### PR DESCRIPTION
It seems like during a refactor of the button component the name attribute was unintentionally omitted. This fixes that and passes the name prop to the button element.