### PR TITLE
fix(icons): add missing prop-types dependency

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -26,6 +26,10 @@
     "files": [
         "build"
     ],
+    "peerDependencies": {
+        "react": "^16.8",
+        "react-dom": "^16.8"
+    },
     "devDependencies": {
         "@svgr/cli": "^5.5.0",
         "execa": "^4.1.0",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -30,5 +30,8 @@
         "@svgr/cli": "^5.5.0",
         "execa": "^4.1.0",
         "rimraf": "^3.0.2"
+    },
+    "dependencies": {
+        "@dhis2/prop-types": "^1.6.4"
     }
 }


### PR DESCRIPTION
The prop-types library is used in the generated react components: https://github.com/dhis2/ui/blob/d7949dad5397c1fe5d1568892c715ded233ec29c/packages/icons/templates/icon-template.js#L16

Also added react and react-dom peer dependencies.