### PR TITLE
fix(headerbar): translate search bar placeholder text

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -82,6 +82,9 @@ jobs:
               with:
                   name: lib-build
 
+            - name: Build
+              run: yarn build
+
             - name: Lint
               run: yarn lint
 

--- a/packages/widgets/src/HeaderBar/Apps.js
+++ b/packages/widgets/src/HeaderBar/Apps.js
@@ -1,5 +1,5 @@
 import { useConfig } from '@dhis2/app-runtime'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales'
 import propTypes from '@dhis2/prop-types'
 import { colors, theme } from '@dhis2/ui-constants'
 import { Card } from '@dhis2/ui-core'

--- a/packages/widgets/src/HeaderBar/Apps.js
+++ b/packages/widgets/src/HeaderBar/Apps.js
@@ -1,5 +1,4 @@
 import { useConfig } from '@dhis2/app-runtime'
-import i18n from '../locales'
 import propTypes from '@dhis2/prop-types'
 import { colors, theme } from '@dhis2/ui-constants'
 import { Card } from '@dhis2/ui-core'
@@ -7,6 +6,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react'
 import css from 'styled-jsx/css'
 import { Settings, Apps as AppsIcon } from '../Icons/index.js'
 import { InputField } from '../InputField/InputField.js'
+import i18n from '../locales'
 import { joinPath } from './joinPath.js'
 
 const appIcon = css.resolve`

--- a/packages/widgets/src/HeaderBar/Apps.js
+++ b/packages/widgets/src/HeaderBar/Apps.js
@@ -1,4 +1,4 @@
-import { useDataMutation, useConfig } from '@dhis2/app-runtime'
+import { useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import propTypes from '@dhis2/prop-types'
 import { colors, theme } from '@dhis2/ui-constants'
@@ -216,28 +216,12 @@ AppMenu.propTypes = {
     filter: propTypes.string,
 }
 
-const mutation = {
-    resource: 'i18n',
-    type: 'create',
-    data: ({ items }) => items,
-}
-
 const Apps = ({ apps }) => {
-    const [translations, setTranslations] = useState({})
     const [show, setShow] = useState(false)
     const [filter, setFilter] = useState('')
 
     const handleVisibilityToggle = useCallback(() => setShow(!show), [show])
     const handleFilterChange = useCallback(({ value }) => setFilter(value), [])
-
-    const [mutate] = useDataMutation(mutation, {
-        onComplete: translations => setTranslations(translations),
-    })
-    useEffect(() => {
-        mutate({
-            items: apps.map(({ name }) => name),
-        })
-    }, [apps])
 
     const containerEl = useRef(null)
     const onDocClick = useCallback(evt => {
@@ -261,10 +245,7 @@ const Apps = ({ apps }) => {
 
             {show ? (
                 <AppMenu
-                    apps={apps.map(app => ({
-                        ...app,
-                        displayName: translations[app.name] || app.displayName,
-                    }))}
+                    apps={apps}
                     filter={filter}
                     onFilterChange={handleFilterChange}
                 />

--- a/packages/widgets/src/HeaderBar/Apps.js
+++ b/packages/widgets/src/HeaderBar/Apps.js
@@ -1,4 +1,5 @@
 import { useDataMutation, useConfig } from '@dhis2/app-runtime'
+import i18n from '@dhis2/d2-i18n'
 import propTypes from '@dhis2/prop-types'
 import { colors, theme } from '@dhis2/ui-constants'
 import { Card } from '@dhis2/ui-core'
@@ -6,7 +7,6 @@ import React, { useState, useEffect, useCallback, useRef } from 'react'
 import css from 'styled-jsx/css'
 import { Settings, Apps as AppsIcon } from '../Icons/index.js'
 import { InputField } from '../InputField/InputField.js'
-import i18n from '../locales'
 import { joinPath } from './joinPath.js'
 
 const appIcon = css.resolve`

--- a/packages/widgets/src/HeaderBar/Apps.js
+++ b/packages/widgets/src/HeaderBar/Apps.js
@@ -3,7 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import propTypes from '@dhis2/prop-types'
 import { colors, theme } from '@dhis2/ui-constants'
 import { Card } from '@dhis2/ui-core'
-import React from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import css from 'styled-jsx/css'
 import { Settings, Apps as AppsIcon } from '../Icons/index.js'
 import { InputField } from '../InputField/InputField.js'
@@ -195,83 +195,91 @@ List.propTypes = {
     filter: propTypes.string,
 }
 
-export default class Apps extends React.Component {
-    state = {
-        show: false,
-        filter: '',
-    }
+const AppMenu = ({ apps, filter, onFilterChange }) => (
+    <div data-test="headerbar-apps-menu">
+        <Card>
+            <Search value={filter} onChange={onFilterChange} />
+            <List apps={apps} filter={filter} />
+        </Card>
 
-    componentDidMount() {
-        document.addEventListener('click', this.onDocClick)
-    }
+        <style jsx>{`
+            div {
+                z-index: 10000;
+                position: absolute;
+                top: 28px;
+                right: -6px;
+                border-top: 4px solid transparent;
+            }
+        `}</style>
+    </div>
+)
 
-    componentWillUnmount() {
-        document.removeEventListener('click', this.onDocClick)
-    }
+AppMenu.propTypes = {
+    apps: propTypes.array.isRequired,
+    onFilterChange: propTypes.func.isRequired,
+    filter: propTypes.string,
+}
 
-    onDocClick = evt => {
-        if (this.elContainer && !this.elContainer.contains(evt.target)) {
-            this.setState({ show: false })
+const Apps = ({ apps }) => {
+    const [show, setShow] = useState(false)
+    const [filter, setFilter] = useState('')
+
+    const handleVisibilityToggle = useCallback(() => setShow(!show), [show])
+    const handleFilterChange = useCallback(({ value }) => setFilter(value), [])
+
+    const containerEl = useRef(null)
+    const onDocClick = useCallback(evt => {
+        if (containerEl.current && !containerEl.current.contains(evt.target)) {
+            setShow(false)
         }
-    }
+    }, [])
+    useEffect(() => {
+        document.addEventListener('click', onDocClick)
+        return () => document.removeEventListener('click', onDocClick)
+    }, [])
 
-    onToggle = () => this.setState({ show: !this.state.show })
+    return (
+        <div ref={containerEl} data-test="headerbar-apps">
+            <button
+                onClick={handleVisibilityToggle}
+                data-test="headerbar-apps-icon"
+            >
+                <AppsIcon className={appIcon.className} />
+            </button>
 
-    onChange = ({ value }) => this.setState({ filter: value })
+            {show ? (
+                <AppMenu
+                    apps={apps}
+                    filter={filter}
+                    onFilterChange={handleFilterChange}
+                />
+            ) : null}
 
-    AppMenu = apps => (
-        <div data-test="headerbar-apps-menu">
-            <Card>
-                <Search value={this.state.filter} onChange={this.onChange} />
-                <List apps={apps} filter={this.state.filter} />
-            </Card>
-
+            {appIcon.styles}
             <style jsx>{`
+                button {
+                    display: block;
+                    background: transparent;
+                    padding: 0;
+                    border: 0;
+                }
+                button:focus {
+                    outline: 1px dotted white;
+                }
+
                 div {
-                    z-index: 10000;
-                    position: absolute;
-                    top: 28px;
-                    right: -6px;
-                    border-top: 4px solid transparent;
+                    position: relative;
+                    width: 24px;
+                    height: 30px;
+                    margin: 8px 0 0 0;
                 }
             `}</style>
         </div>
     )
-
-    render() {
-        const apps = this.props.apps
-        return (
-            <div ref={c => (this.elContainer = c)} data-test="headerbar-apps">
-                <button onClick={this.onToggle} data-test="headerbar-apps-icon">
-                    <AppsIcon className={appIcon.className} />
-                </button>
-
-                {this.state.show && this.AppMenu(apps)}
-
-                {appIcon.styles}
-                <style jsx>{`
-                    button {
-                        display: block;
-                        background: transparent;
-                        padding: 0;
-                        border: 0;
-                    }
-                    button:focus {
-                        outline: 1px dotted white;
-                    }
-
-                    div {
-                        position: relative;
-                        width: 24px;
-                        height: 30px;
-                        margin: 8px 0 0 0;
-                    }
-                `}</style>
-            </div>
-        )
-    }
 }
 
 Apps.propTypes = {
     apps: propTypes.array.isRequired,
 }
+
+export default Apps

--- a/packages/widgets/src/HeaderBar/Apps.js
+++ b/packages/widgets/src/HeaderBar/Apps.js
@@ -1,5 +1,4 @@
-import { useConfig } from '@dhis2/app-runtime'
-import i18n from '@dhis2/d2-i18n'
+import { useDataMutation, useConfig } from '@dhis2/app-runtime'
 import propTypes from '@dhis2/prop-types'
 import { colors, theme } from '@dhis2/ui-constants'
 import { Card } from '@dhis2/ui-core'
@@ -7,6 +6,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react'
 import css from 'styled-jsx/css'
 import { Settings, Apps as AppsIcon } from '../Icons/index.js'
 import { InputField } from '../InputField/InputField.js'
+import i18n from '../locales'
 import { joinPath } from './joinPath.js'
 
 const appIcon = css.resolve`
@@ -32,11 +32,10 @@ const settingsIcon = css.resolve`
  * Copied from here:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
  */
-function escapeRegExpCharacters(text) {
-    return text.replace(/[/.*+?^${}()|[\]\\]/g, '\\$&')
-}
+const escapeRegExpCharacters = text =>
+    text.replace(/[/.*+?^${}()|[\]\\]/g, '\\$&')
 
-function Search({ value, onChange }) {
+const Search = ({ value, onChange }) => {
     const { baseUrl } = useConfig()
 
     return (
@@ -84,58 +83,56 @@ Search.propTypes = {
     onChange: propTypes.func.isRequired,
 }
 
-function Item({ name, path, img }) {
-    return (
-        <a href={path}>
-            <img src={img} alt="app logo" />
+const Item = ({ name, path, img }) => (
+    <a href={path}>
+        <img src={img} alt="app logo" />
 
-            <div>{name}</div>
+        <div>{name}</div>
 
-            <style jsx>{`
-                a {
-                    display: inline-block;
-                    display: flex;
-                    flex-direction: column;
-                    align-items: center;
-                    justify-content: center;
-                    width: 96px;
-                    margin: 8px;
-                    padding: 8px;
-                    border-radius: 12px;
-                    text-decoration: none;
-                    cursor: pointer;
-                }
+        <style jsx>{`
+            a {
+                display: inline-block;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                width: 96px;
+                margin: 8px;
+                padding: 8px;
+                border-radius: 12px;
+                text-decoration: none;
+                cursor: pointer;
+            }
 
-                a:hover,
-                a:focus {
-                    background-color: ${theme.primary050};
-                    cursor: pointer;
-                }
+            a:hover,
+            a:focus {
+                background-color: ${theme.primary050};
+                cursor: pointer;
+            }
 
-                a:hover > div {
-                    font-weight: 500;
-                    cursor: pointer;
-                }
+            a:hover > div {
+                font-weight: 500;
+                cursor: pointer;
+            }
 
-                img {
-                    width: 48px;
-                    height: 48px;
-                    cursor: pointer;
-                }
+            img {
+                width: 48px;
+                height: 48px;
+                cursor: pointer;
+            }
 
-                div {
-                    margin-top: 14px;
-                    color: rgba(0, 0, 0, 0.87);
-                    font-size: 12px;
-                    letter-spacing: 0.01em;
-                    line-height: 14px;
-                    text-align: center;
-                    cursor: pointer;
-                }
-            `}</style>
-        </a>
-    )
-}
+            div {
+                margin-top: 14px;
+                color: rgba(0, 0, 0, 0.87);
+                font-size: 12px;
+                letter-spacing: 0.01em;
+                line-height: 14px;
+                text-align: center;
+                cursor: pointer;
+            }
+        `}</style>
+    </a>
+)
 
 Item.propTypes = {
     img: propTypes.string,
@@ -143,53 +140,52 @@ Item.propTypes = {
     path: propTypes.string,
 }
 
-function List({ apps, filter }) {
-    return (
-        <div data-test="headerbar-apps-menu-list">
-            {apps
-                .filter(({ displayName, name }) => {
-                    const appName = displayName || name
-                    const formattedAppName = appName.toLowerCase()
-                    const formattedFilter = escapeRegExpCharacters(
-                        filter
-                    ).toLowerCase()
+const List = ({ apps, filter }) => (
+    <div data-test="headerbar-apps-menu-list">
+        {apps
+            .filter(({ displayName, name }) => {
+                const appName = displayName || name
+                const formattedAppName = appName.toLowerCase()
+                const formattedFilter = escapeRegExpCharacters(
+                    filter
+                ).toLowerCase()
 
-                    return filter.length > 0
-                        ? formattedAppName.match(formattedFilter)
-                        : true
-                })
-                .map(({ displayName, name, defaultAction, icon }, idx) => (
-                    <Item
-                        key={`app-${name}-${idx}`}
-                        name={displayName || name}
-                        path={defaultAction}
-                        img={icon}
-                    />
-                ))}
+                return filter.length > 0
+                    ? formattedAppName.match(formattedFilter)
+                    : true
+            })
+            .map(({ displayName, name, defaultAction, icon }, idx) => (
+                <Item
+                    key={`app-${name}-${idx}`}
+                    name={displayName || name}
+                    path={defaultAction}
+                    img={icon}
+                />
+            ))}
 
-            <style jsx>{`
-                div {
-                    display: flex;
-                    flex-direction: row;
-                    flex-wrap: wrap;
-                    align-content: flex-start;
-                    align-items: flex-start;
-                    justify-content: flex-start;
-                    width: 30vw;
-                    min-width: 300px;
-                    max-width: 560px;
+        <style jsx>{`
+            div {
+                display: flex;
+                flex-direction: row;
+                flex-wrap: wrap;
+                align-content: flex-start;
+                align-items: flex-start;
+                justify-content: flex-start;
+                width: 30vw;
+                min-width: 300px;
+                max-width: 560px;
 
-                    min-height: 200px;
-                    max-height: 465px;
-                    margin: 0 8px 8px 8px;
+                min-height: 200px;
+                max-height: 465px;
+                margin: 0 8px 8px 8px;
 
-                    overflow: auto;
-                    overflow-x: hidden;
-                }
-            `}</style>
-        </div>
-    )
-}
+                overflow: auto;
+                overflow-x: hidden;
+            }
+        `}</style>
+    </div>
+)
+
 List.propTypes = {
     apps: propTypes.array,
     filter: propTypes.string,
@@ -220,12 +216,28 @@ AppMenu.propTypes = {
     filter: propTypes.string,
 }
 
+const mutation = {
+    resource: 'i18n',
+    type: 'create',
+    data: ({ items }) => items,
+}
+
 const Apps = ({ apps }) => {
+    const [translations, setTranslations] = useState({})
     const [show, setShow] = useState(false)
     const [filter, setFilter] = useState('')
 
     const handleVisibilityToggle = useCallback(() => setShow(!show), [show])
     const handleFilterChange = useCallback(({ value }) => setFilter(value), [])
+
+    const [mutate] = useDataMutation(mutation, {
+        onComplete: translations => setTranslations(translations),
+    })
+    useEffect(() => {
+        mutate({
+            items: apps.map(({ name }) => name),
+        })
+    }, [apps])
 
     const containerEl = useRef(null)
     const onDocClick = useCallback(evt => {
@@ -249,7 +261,10 @@ const Apps = ({ apps }) => {
 
             {show ? (
                 <AppMenu
-                    apps={apps}
+                    apps={apps.map(app => ({
+                        ...app,
+                        displayName: translations[app.name] || app.displayName,
+                    }))}
                     filter={filter}
                     onFilterChange={handleFilterChange}
                 />

--- a/packages/widgets/src/HeaderBar/HeaderBar.js
+++ b/packages/widgets/src/HeaderBar/HeaderBar.js
@@ -2,7 +2,7 @@ import { useDataQuery, useConfig } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import propTypes from '@dhis2/prop-types'
 import { colors } from '@dhis2/ui-constants'
-import React, { useMemo } from 'react'
+import React, { useMemo, useEffect } from 'react'
 import Apps from './Apps.js'
 import { joinPath } from './joinPath.js'
 import { Logo } from './Logo.js'
@@ -48,12 +48,14 @@ export const HeaderBar = ({ appName, className }) => {
         }))
     }, [data])
 
-    if (!loading && !error) {
-        // TODO: This will run every render which is probably wrong!  Also, setting the global locale shouldn't be done in the headerbar
-        const locale = data.user.settings.keyUiLocale || 'en'
-        i18n.setDefaultNamespace('default')
-        i18n.changeLanguage(locale)
-    }
+    // TODO: Setting the global locale shouldn't be done in the headerbar
+    useEffect(() => {
+        if (!loading && !error) {
+            const locale = data.user.settings.keyUiLocale || 'en'
+            i18n.setDefaultNamespace('default')
+            i18n.changeLanguage(locale)
+        }
+    }, [loading, error])
 
     return (
         <header className={className}>


### PR DESCRIPTION
The original intent of this PR was to fix https://jira.dhis2.org/browse/DHIS2-8875, but after discussing with @amcgee we decided that it would make more for the backend to be responsible for translating application names - which it would do by translating the `displayName` property of the data returned by the `getModules` API.

Moving translation to the backend reduces the number of network requests and reduces the amount of effort needed across frontend apps.

However, the translation of the placeholder text of the search bar ('Search apps') is the responsibility of the frontend and this PR fixes a regression in its translation.