### PR TITLE
fix: hide tooltips when reference is hidden

### DIFF
--- a/packages/core/src/Tooltip/Tooltip.js
+++ b/packages/core/src/Tooltip/Tooltip.js
@@ -11,6 +11,11 @@ const TOOLTIP_OFFSET = 4
 const popperStyle = resolve`
     z-index: ${layers.applicationTop};
     pointer-events: none;
+
+    // Hide popper when reference component is obscured (https://popper.js.org/docs/v2/modifiers/hide/)
+    div[data-popper-escaped="true"] {
+        visibility: hidden;
+    }
 `
 
 const offsetModifier = {
@@ -18,6 +23,10 @@ const offsetModifier = {
     options: {
         offset: [0, TOOLTIP_OFFSET],
     },
+}
+
+const hideModifier = {
+    name: 'hide',
 }
 
 const OPEN_DELAY = 200
@@ -88,7 +97,7 @@ const Tooltip = ({
                         className={popperStyle.className}
                         placement={placement}
                         reference={popperReference}
-                        modifiers={[offsetModifier]}
+                        modifiers={[offsetModifier, hideModifier]}
                     >
                         <div
                             className={className}

--- a/packages/core/src/Tooltip/Tooltip.stories.js
+++ b/packages/core/src/Tooltip/Tooltip.stories.js
@@ -120,3 +120,40 @@ export const CustomComponent = () => {
         </p>
     )
 }
+
+export const HidesWhenOutOfFrame = args => (
+    <div
+        style={{
+            height: '250px',
+            padding: '1rem',
+            overflow: 'scroll',
+            border: '1px solid #43cbcb',
+        }}
+    >
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <Tooltip {...args}>
+            <div style={{ height: '80px', border: '1px solid grey' }}>
+                {
+                    "I am a rectangle that contains a tooltip that hides when I'm obscured from view"
+                }
+            </div>
+        </Tooltip>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+        <p>{"I'm an extra paragraph"}</p>
+    </div>
+)
+HidesWhenOutOfFrame.args = { content: 'Some extra info' }


### PR DESCRIPTION
This addresses the issue in [this thread](https://github.com/dhis2/notes/discussions/205)

The 'hide' modifier from popper is used to hide tooltips when their reference component is obscured

Some questions:
1. Should the popper hide when the reference component is partially covered (as in the demo above), or only when fully covered? Check out the demo at the bottom of the popper docs page to see the difference between 'escaped' and 'reference-hidden'
2. I think this behavior should be the default for all tooltips, but should it be configurable with props? E.g. set the tooltip to hide on partial cover/full cover/not at all
