### PR TITLE
fix(select): update menu width when opening

### DIFF
--- a/packages/core/src/MultiSelect/MultiSelect.stories.e2e.js
+++ b/packages/core/src/MultiSelect/MultiSelect.stories.e2e.js
@@ -1,7 +1,13 @@
 import propTypes from '@dhis2/prop-types'
 import { storiesOf } from '@storybook/react'
-import React from 'react'
-import { MultiSelectOption } from '../index.js'
+import React, { useState } from 'react'
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    MultiSelectOption,
+    Button,
+} from '../index.js'
 import { MultiSelect } from './MultiSelect.js'
 
 window.onChange = window.Cypress && window.Cypress.cy.stub()
@@ -16,6 +22,13 @@ CustomMultiSelectOption.propTypes = {
     label: propTypes.string,
     onClick: propTypes.func,
 }
+
+const options = [
+    { name: 'Hello', id: '1' },
+    { name: 'world', id: '2' },
+    { name: 'foo', id: '3' },
+    { name: 'bar', id: '4' },
+]
 
 storiesOf('MultiSelect', module)
     .add('With options', () => (
@@ -347,5 +360,61 @@ storiesOf('MultiSelect', module)
                     }
                 `}</style>
             </>
+        )
+    })
+    .add('Menu width changing', () => {
+        const [toggle, setToggle] = useState(false)
+        return (
+            <div className="App">
+                <Modal dataTest={'myModal'}>
+                    <ModalTitle>Modal</ModalTitle>
+                    <ModalContent>
+                        <div style={{ display: 'flex' }}>
+                            {toggle && (
+                                <div
+                                    style={{
+                                        padding: '30px',
+                                        border: '1px solid green',
+                                    }}
+                                    className="toggler"
+                                >
+                                    Stuff
+                                </div>
+                            )}
+                            <div style={{ flexGrow: 1 }}>
+                                <MultiSelect
+                                    onChange={({ selected }) =>
+                                        console.log(
+                                            'size changed to ' + selected
+                                        )
+                                    }
+                                >
+                                    {options.map(({ name, id }) => (
+                                        <MultiSelectOption
+                                            key={id}
+                                            value={id}
+                                            label={name}
+                                        />
+                                    ))}
+                                </MultiSelect>
+                            </div>
+                            {toggle && (
+                                <div
+                                    style={{
+                                        padding: '30px',
+                                        border: '1px solid green',
+                                    }}
+                                    className="toggler"
+                                >
+                                    Stuff
+                                </div>
+                            )}
+                        </div>
+                        <Button onClick={() => setToggle(!toggle)}>
+                            Toggle
+                        </Button>
+                    </ModalContent>
+                </Modal>
+            </div>
         )
     })

--- a/packages/core/src/MultiSelect/features/menu_width_matches_input.feature
+++ b/packages/core/src/MultiSelect/features/menu_width_matches_input.feature
@@ -1,0 +1,11 @@
+Feature: The menu always has the same size as the input
+
+    Scenario: The MultiSelect input changes width while the menu is closed
+        Given a MultiSelect with hidden sibling elements
+        When the button is clicked
+        Then the siblings are displayed
+        And the menu width has decreased
+        When the MultiSelect input is clicked
+        Then the MultiSelect menu is open
+        And the MultiSelect input is left aligned with the menu
+        And the MultiSelect input and menu have the same width

--- a/packages/core/src/MultiSelect/features/menu_width_matches_input/index.js
+++ b/packages/core/src/MultiSelect/features/menu_width_matches_input/index.js
@@ -28,17 +28,17 @@ Then('the MultiSelect input is left aligned with the menu', () => {
     const selectDataTest = '[data-test="dhis2-uicore-multiselect"]'
     const menuDataTest = '[data-test="dhis2-uicore-select-menu-menuwrapper"]'
 
-    cy.getAll(selectDataTest, menuDataTest).should(([selects, menus]) => {
-        expect(selects.length).to.equal(1)
+    cy.getAll(selectDataTest, menuDataTest).should(([inputs, menus]) => {
+        expect(inputs.length).to.equal(1)
         expect(menus.length).to.equal(1)
 
-        const $select = selects[0]
+        const $input = inputs[0]
         const $menu = menus[0]
 
-        const selectRect = $select.getBoundingClientRect()
+        const inputRect = $input.getBoundingClientRect()
         const menuRect = $menu.getBoundingClientRect()
 
-        expect(Math.round(selectRect.left)).to.equal(Math.round(menuRect.left))
+        expect(Math.round(inputRect.left)).to.equal(Math.round(menuRect.left))
     })
 })
 When('the MultiSelect input and menu have the same width', () => {
@@ -46,6 +46,9 @@ When('the MultiSelect input and menu have the same width', () => {
     const menuSelector = '[data-test="dhis2-uicore-select-menu-menuwrapper"]'
 
     cy.getAll(inputSelector, menuSelector).should(([$input, $menu]) => {
-        expect($input.outerWidth()).to.equal($menu.outerWidth())
+        const inputWidth = Math.round($input.outerWidth())
+        const menuWidth = Math.round($menu.outerWidth())
+
+        expect(inputWidth).to.equal(menuWidth)
     })
 })

--- a/packages/core/src/MultiSelect/features/menu_width_matches_input/index.js
+++ b/packages/core/src/MultiSelect/features/menu_width_matches_input/index.js
@@ -1,0 +1,51 @@
+import '../common'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a MultiSelect with hidden sibling elements', () => {
+    cy.visitStory('MultiSelect', 'Menu width changing')
+    cy.get('[data-test="dhis2-uicore-multiselect"]').then($el => {
+        cy.wrap($el.outerWidth()).as('originalWidth')
+    })
+})
+When('the button is clicked', () => {
+    cy.get('button').click()
+})
+Then('the siblings are displayed', () => {
+    cy.get('.toggler').should('exist').and('have.length', 2)
+})
+Then('the menu width has decreased', () => {
+    cy.get('[data-test="dhis2-uicore-multiselect"]').then($el => {
+        const newWidth = $el.outerWidth()
+        cy.get('@originalWidth').should('be.greaterThan', newWidth)
+    })
+})
+When('the MultiSelect menu is open', () => {
+    cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]').should(
+        'be.visible'
+    )
+})
+Then('the MultiSelect input is left aligned with the menu', () => {
+    const selectDataTest = '[data-test="dhis2-uicore-multiselect"]'
+    const menuDataTest = '[data-test="dhis2-uicore-select-menu-menuwrapper"]'
+
+    cy.getAll(selectDataTest, menuDataTest).should(([selects, menus]) => {
+        expect(selects.length).to.equal(1)
+        expect(menus.length).to.equal(1)
+
+        const $select = selects[0]
+        const $menu = menus[0]
+
+        const selectRect = $select.getBoundingClientRect()
+        const menuRect = $menu.getBoundingClientRect()
+
+        expect(Math.round(selectRect.left)).to.equal(Math.round(menuRect.left))
+    })
+})
+When('the MultiSelect input and menu have the same width', () => {
+    const inputSelector = '[data-test="dhis2-uicore-select"]'
+    const menuSelector = '[data-test="dhis2-uicore-select-menu-menuwrapper"]'
+
+    cy.getAll(inputSelector, menuSelector).should(([$input, $menu]) => {
+        expect($input.outerWidth()).to.equal($menu.outerWidth())
+    })
+})

--- a/packages/core/src/Select/Select.js
+++ b/packages/core/src/Select/Select.js
@@ -25,12 +25,12 @@ export class Select extends Component {
             this.inputRef.current.focus()
         }
 
-        this.setMenuWidth()
-        window.addEventListener('resize', this.setMenuWidth)
+        this.setState({ menuWidth: this.getMenuWidth() })
+        window.addEventListener('resize', this.onResize)
     }
 
     componentWillUnmount() {
-        window.removeEventListener('resize', this.setMenuWidth)
+        window.removeEventListener('resize', this.onResize)
     }
 
     /**
@@ -42,20 +42,23 @@ export class Select extends Component {
      *
      * See: https://nolanlawson.com/2018/09/25/accurately-measuring-layout-on-the-web
      */
-    setMenuWidth = debounce(() => {
-        const hasOffsetWidth =
-            this.inputRef.current && this.inputRef.current.offsetWidth
+    onResize = debounce(() => {
+        const menuWidth = this.getMenuWidth()
 
-        if (hasOffsetWidth) {
-            const inputWidth = `${this.inputRef.current.offsetWidth}px`
-
-            if (this.state.menuWidth !== inputWidth) {
-                this.setState({
-                    menuWidth: inputWidth,
-                })
-            }
+        if (this.state.menuWidth !== menuWidth) {
+            this.setState({ menuWidth })
         }
     }, 50)
+
+    getMenuWidth() {
+        const { offsetWidth } = this.inputRef.current
+        const { menuWidth } = this.state
+
+        if (offsetWidth && `${offsetWidth}px` !== menuWidth) {
+            return `${offsetWidth}px`
+        }
+        return menuWidth
+    }
 
     handleFocusInput = () => {
         this.inputRef.current.focus()
@@ -72,7 +75,10 @@ export class Select extends Component {
     }
 
     handleOpen = () => {
-        this.setState({ open: true })
+        this.setState({
+            open: true,
+            menuWidth: this.getMenuWidth(),
+        })
     }
 
     handleClose = () => {

--- a/packages/core/src/SingleSelect/SingleSelect.stories.e2e.js
+++ b/packages/core/src/SingleSelect/SingleSelect.stories.e2e.js
@@ -1,7 +1,14 @@
 import propTypes from '@dhis2/prop-types'
 import { storiesOf } from '@storybook/react'
-import React from 'react'
-import { SingleSelect, SingleSelectOption } from '../index.js'
+import React, { useState } from 'react'
+import {
+    Modal,
+    ModalTitle,
+    ModalContent,
+    SingleSelect,
+    SingleSelectOption,
+    Button,
+} from '../index.js'
 
 window.onChange = window.Cypress && window.Cypress.cy.stub()
 window.onFocus = window.Cypress && window.Cypress.cy.stub()
@@ -15,6 +22,13 @@ CustomSingleSelectOption.propTypes = {
     label: propTypes.string,
     onClick: propTypes.func,
 }
+
+const options = [
+    { name: 'Hello', id: '1' },
+    { name: 'world', id: '2' },
+    { name: 'foo', id: '3' },
+    { name: 'bar', id: '4' },
+]
 
 storiesOf('SingleSelect', module)
     .add('With options', () => (
@@ -321,3 +335,59 @@ storiesOf('SingleSelect', module)
             <SingleSelectOption value="3" label="option three" />
         </SingleSelect>
     ))
+    .add('Menu width changing', () => {
+        const [toggle, setToggle] = useState(false)
+        return (
+            <div className="App">
+                <Modal dataTest={'myModal'}>
+                    <ModalTitle>Modal</ModalTitle>
+                    <ModalContent>
+                        <div style={{ display: 'flex' }}>
+                            {toggle && (
+                                <div
+                                    style={{
+                                        padding: '30px',
+                                        border: '1px solid green',
+                                    }}
+                                    className="toggler"
+                                >
+                                    Stuff
+                                </div>
+                            )}
+                            <div style={{ flexGrow: 1 }}>
+                                <SingleSelect
+                                    onChange={({ selected }) =>
+                                        console.log(
+                                            'size changed to ' + selected
+                                        )
+                                    }
+                                >
+                                    {options.map(({ name, id }) => (
+                                        <SingleSelectOption
+                                            key={id}
+                                            value={id}
+                                            label={name}
+                                        />
+                                    ))}
+                                </SingleSelect>
+                            </div>
+                            {toggle && (
+                                <div
+                                    style={{
+                                        padding: '30px',
+                                        border: '1px solid green',
+                                    }}
+                                    className="toggler"
+                                >
+                                    Stuff
+                                </div>
+                            )}
+                        </div>
+                        <Button onClick={() => setToggle(!toggle)}>
+                            Toggle
+                        </Button>
+                    </ModalContent>
+                </Modal>
+            </div>
+        )
+    })

--- a/packages/core/src/SingleSelect/features/menu_width_matches_input.feature
+++ b/packages/core/src/SingleSelect/features/menu_width_matches_input.feature
@@ -1,0 +1,11 @@
+Feature: The menu always has the same size as the input
+
+    Scenario: The SingleSelect input changes width while the menu is closed
+        Given a SingleSelect with hidden sibling elements
+        When the button is clicked
+        Then the siblings are displayed
+        And the menu width has decreased
+        When the SingleSelect input is clicked
+        Then the SingleSelect menu is open
+        And the SingleSelect input is left aligned with the menu
+        And the SingleSelect input and menu have the same width

--- a/packages/core/src/SingleSelect/features/menu_width_matches_input/index.js
+++ b/packages/core/src/SingleSelect/features/menu_width_matches_input/index.js
@@ -1,0 +1,54 @@
+import '../common'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a SingleSelect with hidden sibling elements', () => {
+    cy.visitStory('SingleSelect', 'Menu width changing')
+    cy.get('[data-test="dhis2-uicore-singleselect"]').then($el => {
+        cy.wrap($el.outerWidth()).as('originalWidth')
+    })
+})
+When('the button is clicked', () => {
+    cy.get('button').click()
+})
+Then('the siblings are displayed', () => {
+    cy.get('.toggler').should('exist').and('have.length', 2)
+})
+Then('the menu width has decreased', () => {
+    cy.get('[data-test="dhis2-uicore-singleselect"]').then($el => {
+        const newWidth = $el.outerWidth()
+        cy.get('@originalWidth').should('be.greaterThan', newWidth)
+    })
+})
+When('the SingleSelect menu is open', () => {
+    cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]').should(
+        'be.visible'
+    )
+})
+Then('the SingleSelect input is left aligned with the menu', () => {
+    const selectDataTest = '[data-test="dhis2-uicore-singleselect"]'
+    const menuDataTest = '[data-test="dhis2-uicore-select-menu-menuwrapper"]'
+
+    cy.getAll(selectDataTest, menuDataTest).should(([inputs, menus]) => {
+        expect(inputs.length).to.equal(1)
+        expect(menus.length).to.equal(1)
+
+        const $input = inputs[0]
+        const $menu = menus[0]
+
+        const inputRect = $input.getBoundingClientRect()
+        const menuRect = $menu.getBoundingClientRect()
+
+        expect(Math.round(inputRect.left)).to.equal(Math.round(menuRect.left))
+    })
+})
+When('the SingleSelect input and menu have the same width', () => {
+    const inputSelector = '[data-test="dhis2-uicore-select"]'
+    const menuSelector = '[data-test="dhis2-uicore-select-menu-menuwrapper"]'
+
+    cy.getAll(inputSelector, menuSelector).should(([$input, $menu]) => {
+        const inputWidth = Math.round($input.outerWidth())
+        const menuWidth = Math.round($menu.outerWidth())
+
+        expect(inputWidth).to.equal(menuWidth)
+    })
+})


### PR DESCRIPTION
See https://github.com/dhis2/notes/discussions/221 for context. I created a story based on the code sandbox @martinkrulltott provided, a feature that reproduced the issue, and a fix that solved it. The solution was actually in the `Select`, which is being used by both the `SingleSelect` and the `MultiSelect`. However, since the `Select` doesn't have any stories, we ended up with a single fix and two (almost identical) stories/e2e-tests.