### PR TITLE
fix(tooltip): configure open and close delays via prop (LIBS-126)

### DIFF
--- a/packages/core/src/Tooltip/Tooltip.js
+++ b/packages/core/src/Tooltip/Tooltip.js
@@ -1,5 +1,6 @@
 import propTypes from '@dhis2/prop-types'
 import { colors, layers } from '@dhis2/ui-constants'
+import PropTypes from 'prop-types'
 import React, { useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { resolve } from 'styled-jsx/css'
@@ -36,9 +37,6 @@ const flipModifier = {
     options: { altBoundary: true },
 }
 
-const OPEN_DELAY = 200
-const CLOSE_DELAY = 400
-
 /**
  * @module
  * @param {Tooltip.PropTypes} props
@@ -52,9 +50,11 @@ const CLOSE_DELAY = 400
 const Tooltip = ({
     children,
     className,
+    closeDelay,
     content,
     dataTest,
     maxWidth,
+    openDelay,
     placement,
 }) => {
     const [open, setOpen] = useState(false)
@@ -68,7 +68,7 @@ const Tooltip = ({
 
         openTimerRef.current = setTimeout(() => {
             setOpen(true)
-        }, OPEN_DELAY)
+        }, openDelay)
     }
 
     const onMouseOut = () => {
@@ -76,7 +76,7 @@ const Tooltip = ({
 
         closeTimerRef.current = setTimeout(() => {
             setOpen(false)
-        }, CLOSE_DELAY)
+        }, closeDelay)
     }
 
     return (
@@ -134,8 +134,10 @@ const Tooltip = ({
 }
 
 Tooltip.defaultProps = {
+    closeDelay: 400,
     dataTest: 'dhis2-uicore-tooltip',
     maxWidth: 300,
+    openDelay: 200,
     placement: 'top',
     tag: 'span',
 }
@@ -145,17 +147,23 @@ Tooltip.defaultProps = {
  * @static
  * @prop {Node|function} [children]
  * @prop {string} [className]
+ * @prop {number} [closeDelay=400] Time (in ms) until tooltip closes after mouse out
  * @prop {Node} [content]
  * @prop {string} [dataTest=dhis2-uicore-tooltip]
  * @prop {number} [maxWidth=300]
+ * @prop {number} [openDelay=200] Time (in ms) until tooltip opens after mouse over
  * @prop {('top'|'bottom'|'right'|'left')} [placement=top]
  */
 Tooltip.propTypes = {
     children: propTypes.oneOfType([propTypes.node, propTypes.func]),
     className: propTypes.string,
+    /** Time (in ms) until tooltip closes after mouse out */
+    closeDelay: PropTypes.number,
     content: propTypes.node,
     dataTest: propTypes.string,
     maxWidth: propTypes.number,
+    /** Time (in ms) until tooltip open after mouse over */
+    openDelay: PropTypes.number,
     placement: propTypes.oneOf(['top', 'right', 'bottom', 'left']),
 }
 

--- a/packages/core/src/Tooltip/Tooltip.stories.js
+++ b/packages/core/src/Tooltip/Tooltip.stories.js
@@ -58,6 +58,20 @@ export const PlacementLeft = () => (
     </p>
 )
 
+export const ConfigurableOpenAndCloseDelays = args => (
+    <p>
+        <Tooltip {...args}>
+            The tooltip that opens when this content is moused over opens with 0
+            open or close delay
+        </Tooltip>
+    </p>
+)
+ConfigurableOpenAndCloseDelays.args = {
+    content: 'Some extra info',
+    openDelay: 0,
+    closeDelay: 0,
+}
+
 export const CustomElementViaTagProp = () => {
     return (
         <p>

--- a/packages/core/src/Tooltip/__tests__/Tooltip.test.js
+++ b/packages/core/src/Tooltip/__tests__/Tooltip.test.js
@@ -1,0 +1,174 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import { act } from 'react-dom/test-utils'
+import { Tooltip } from '../Tooltip.js'
+
+// Due to its global nature, tooltip & popper need to be unmounted after each test
+let wrapper
+const tooltipContent = 'tooltip content'
+const tooltipContentSelector = '[data-test="dhis2-uicore-tooltip-content"]'
+
+beforeEach(() => {
+    // note that 'setTimeout' becomes a mocked function to spy
+    jest.useFakeTimers()
+    wrapper = mount(<div />)
+})
+
+afterEach(() => {
+    // clean up any tooltips that are still open
+    wrapper.unmount()
+})
+
+describe('default delay behavior', () => {
+    it('opens after a delay of 200ms', () => {
+        wrapper = mount(<Tooltip content={tooltipContent}>Hi hi!</Tooltip>)
+
+        wrapper.simulate('mouseover')
+
+        // 'open delay' function has been called with default delay = 200ms
+        expect(setTimeout).toHaveBeenCalledTimes(1)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 200)
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+
+        // wait for 'open delay' to elapse to open tooltip
+        act(() => {
+            jest.advanceTimersByTime(205)
+        })
+
+        // expect tooltip to be open after delay
+        const res = document.querySelector(tooltipContentSelector)
+        expect(res).not.toBe(null)
+        expect(res.textContent).toBe(tooltipContent)
+
+        // this last part clears a warning about "code should be wrapped in `act(...)`"
+        // and clears the tooltip
+        wrapper.simulate('mouseout')
+        act(() => {
+            jest.runAllTimers()
+        })
+    })
+
+    it('closes after a delay of 400ms', () => {
+        wrapper = mount(<Tooltip content={tooltipContent}>Hi hi!</Tooltip>)
+
+        // open tooltip
+        wrapper.simulate('mouseover')
+        expect(setTimeout).toHaveBeenCalledTimes(1)
+
+        act(() => {
+            jest.runAllTimers()
+        })
+        // verify tooltip is open
+        expect(document.querySelector(tooltipContentSelector)).not.toBe(null)
+
+        // close tooltip
+        wrapper.simulate('mouseout')
+
+        // delay function has been called; tooltip is still open
+        expect(setTimeout).toHaveBeenCalledTimes(2)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 400)
+        expect(document.querySelector(tooltipContentSelector)).not.toBe(null)
+
+        // wait for close delay
+        act(() => {
+            jest.advanceTimersByTime(405)
+        })
+
+        // expect tooltip to be closed
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+    })
+})
+
+it("doesn't leave a rendered node open", () => {
+    // makes sure 'unmount' is working
+    const res = document.querySelector('[data-test="dhis2-uicore-popper"]')
+    expect(res).toBe(null)
+})
+
+describe('it handles custom open and close delays', () => {
+    it('handles open delay = close delay = 0', () => {
+        wrapper = mount(
+            <Tooltip openDelay={0} closeDelay={0} content={tooltipContent}>
+                Hi hi!
+            </Tooltip>
+        )
+
+        // open tooltip
+        wrapper.simulate('mouseover')
+        expect(setTimeout).toHaveBeenCalledTimes(1)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 0)
+
+        // wait for open delay (necessary b/c timeout is still used)
+        act(() => {
+            jest.advanceTimersByTime(0)
+        })
+        // verify tooltip is open
+        expect(document.querySelector(tooltipContentSelector)).not.toBe(null)
+
+        // close tooltip
+        wrapper.simulate('mouseout')
+
+        // delay function has been called
+        expect(setTimeout).toHaveBeenCalledTimes(2)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 0)
+
+        // wait for close delay (necessary b/c timeout is used)
+        act(() => {
+            jest.advanceTimersByTime(0)
+        })
+
+        // expect tooltip to be closed
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+    })
+
+    it('handles open delay = close delay = 1000', () => {
+        wrapper = mount(
+            <Tooltip
+                openDelay={1000}
+                closeDelay={1000}
+                content={tooltipContent}
+            >
+                Hi hi!
+            </Tooltip>
+        )
+
+        // open tooltip
+        wrapper.simulate('mouseover')
+        expect(setTimeout).toHaveBeenCalledTimes(1)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000)
+
+        // expect tooltip is not open after 950ms
+        act(() => {
+            jest.advanceTimersByTime(950)
+        })
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+
+        // finish wait for open delay
+        act(() => {
+            jest.advanceTimersByTime(55)
+        })
+        // verify tooltip is open
+        expect(document.querySelector(tooltipContentSelector)).not.toBe(null)
+
+        // close tooltip
+        wrapper.simulate('mouseout')
+
+        // delay function has been called
+        expect(setTimeout).toHaveBeenCalledTimes(2)
+        expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000)
+
+        // expect tooltip to still be open after 950ms
+        act(() => {
+            jest.advanceTimersByTime(950)
+        })
+        expect(document.querySelector(tooltipContentSelector)).not.toBe(null)
+
+        // Finisih waiting for close delay
+        act(() => {
+            jest.advanceTimersByTime(55)
+        })
+
+        // expect tooltip to be closed
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+    })
+})


### PR DESCRIPTION
Allows configuring tooltip open and close delays via `openDelay` and `closeDelay` props to cater to a wider variety of use cases.

Relates to [this question in notes](https://github.com/dhis2/notes/discussions/230)