### PR TITLE
feat(table): add role attributes for table components

### DIFF
--- a/packages/core/src/Table/Table.js
+++ b/packages/core/src/Table/Table.js
@@ -22,13 +22,14 @@ const tableStyles = css`
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
 export const Table = ({
+    role,
     children,
     className,
     dataTest,
     suppressZebraStriping,
 }) => (
     <Provider value={{ suppressZebraStriping }}>
-        <table className={className} data-test={dataTest}>
+        <table className={className} data-test={dataTest} role={role}>
             {children}
 
             <style jsx>{tableStyles}</style>
@@ -45,6 +46,7 @@ Table.defaultProps = {
  * @static
  * @prop {TableHead|TableBody|TableFoot|Array.<TableHead|TableBody|TableFoot>} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  * @prop {bool} [suppressZebraStriping]
  */
@@ -52,5 +54,6 @@ Table.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    role: propTypes.string,
     suppressZebraStriping: propTypes.bool,
 }

--- a/packages/core/src/Table/TableBody.js
+++ b/packages/core/src/Table/TableBody.js
@@ -8,8 +8,8 @@ import React from 'react'
  * @example import { TableBody } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableBody = ({ children, className, dataTest }) => (
-    <tbody className={className} data-test={dataTest}>
+export const TableBody = ({ children, className, dataTest, role }) => (
+    <tbody className={className} data-test={dataTest} role={role}>
         {children}
     </tbody>
 )
@@ -23,10 +23,12 @@ TableBody.defaultProps = {
  * @static
  * @prop {TableRow|Array.<TableRow>} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  */
 TableBody.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    role: propTypes.string,
 }

--- a/packages/core/src/Table/TableCell.js
+++ b/packages/core/src/Table/TableCell.js
@@ -26,6 +26,7 @@ const tableCellStyles = css`
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableCell = ({
+    role,
     className,
     children,
     colSpan,
@@ -38,6 +39,7 @@ export const TableCell = ({
         rowSpan={rowSpan}
         className={cx({ dense }, className)}
         data-test={dataTest}
+        role={role}
     >
         {children}
 
@@ -57,6 +59,7 @@ TableCell.defaultProps = {
  * @prop {bool} [dense]
  * @prop {Node} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  */
 TableCell.propTypes = {
@@ -65,5 +68,6 @@ TableCell.propTypes = {
     colSpan: propTypes.string,
     dataTest: propTypes.string,
     dense: propTypes.bool,
+    role: propTypes.string,
     rowSpan: propTypes.string,
 }

--- a/packages/core/src/Table/TableCellHead.js
+++ b/packages/core/src/Table/TableCellHead.js
@@ -26,6 +26,7 @@ const tableCellHeadStyles = css`
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableCellHead = ({
+    role,
     colSpan,
     rowSpan,
     dense,
@@ -38,6 +39,7 @@ export const TableCellHead = ({
         rowSpan={rowSpan}
         className={cx({ dense }, className)}
         data-test={dataTest}
+        role={role}
     >
         {children}
 
@@ -57,6 +59,7 @@ TableCellHead.defaultProps = {
  * @prop {bool} [dense]
  * @prop {Node} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  */
 TableCellHead.propTypes = {
@@ -65,5 +68,6 @@ TableCellHead.propTypes = {
     colSpan: propTypes.string,
     dataTest: propTypes.string,
     dense: propTypes.bool,
+    role: propTypes.string,
     rowSpan: propTypes.string,
 }

--- a/packages/core/src/Table/TableFoot.js
+++ b/packages/core/src/Table/TableFoot.js
@@ -8,8 +8,8 @@ import React from 'react'
  * @example import { TableFoot } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableFoot = ({ children, className, dataTest }) => (
-    <tfoot className={className} data-test={dataTest}>
+export const TableFoot = ({ children, className, dataTest, role }) => (
+    <tfoot className={className} data-test={dataTest} role={role}>
         {children}
     </tfoot>
 )
@@ -23,10 +23,12 @@ TableFoot.defaultProps = {
  * @static
  * @prop {TableRow|Array.<TableRow>} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  */
 TableFoot.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    role: propTypes.string,
 }

--- a/packages/core/src/Table/TableHead.js
+++ b/packages/core/src/Table/TableHead.js
@@ -8,8 +8,8 @@ import React from 'react'
  * @example import { TableHead } from '@dhis2/ui-core'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
-export const TableHead = ({ children, className, dataTest }) => (
-    <thead className={className} data-test={dataTest}>
+export const TableHead = ({ children, className, dataTest, role }) => (
+    <thead className={className} data-test={dataTest} role={role}>
         {children}
     </thead>
 )
@@ -23,10 +23,12 @@ TableHead.defaultProps = {
  * @static
  * @prop {TableRowHead|Array.<TableRowHead>} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  */
 TableHead.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    role: propTypes.string,
 }

--- a/packages/core/src/Table/TableRow.js
+++ b/packages/core/src/Table/TableRow.js
@@ -18,6 +18,7 @@ const tableRowStyles = css`
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableRow = ({
+    role,
     children,
     className,
     dataTest,
@@ -33,7 +34,11 @@ export const TableRow = ({
             : !suppressZebraStripingFromContext
 
     return (
-        <tr className={cx(className, { zebraStriping })} data-test={dataTest}>
+        <tr
+            className={cx(className, { zebraStriping })}
+            data-test={dataTest}
+            role={role}
+        >
             {children}
 
             <style jsx>{tableRowStyles}</style>
@@ -50,11 +55,13 @@ TableRow.defaultProps = {
  * @static
  * @prop {TableCell|TableCellHead|Array.<TableCell|TableCellHead>} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  */
 TableRow.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    role: propTypes.string,
     suppressZebraStriping: propTypes.bool,
 }

--- a/packages/core/src/Table/TableRowHead.js
+++ b/packages/core/src/Table/TableRowHead.js
@@ -11,6 +11,7 @@ import { TableRow } from './TableRow.js'
  * @see Live demo: {@link /demo/?path=/story/table--static-layout|Storybook}
  */
 export const TableRowHead = ({
+    role,
     children,
     className,
     dataTest,
@@ -20,6 +21,7 @@ export const TableRowHead = ({
         className={className}
         dataTest={dataTest}
         suppressZebraStriping={suppressZebraStriping}
+        role={role}
     >
         {children}
     </TableRow>
@@ -34,11 +36,13 @@ TableRowHead.defaultProps = {
  * @static
  * @prop {TableCellHead|Array.<TableCellHead>} [children]
  * @prop {string} [className]
+ * @prop {string} [role]
  * @prop {string} [dataTest]
  */
 TableRowHead.propTypes = {
     children: propTypes.node,
     className: propTypes.string,
     dataTest: propTypes.string,
+    role: propTypes.string,
     suppressZebraStriping: propTypes.bool,
 }


### PR DESCRIPTION
This adds role props to all Table components, so that users can manually set the ARIA role if necessary.