### PR TITLE
fix(checkbox): make checkbox accessible

### DIFF
--- a/packages/core/src/Checkbox/Checkbox.js
+++ b/packages/core/src/Checkbox/Checkbox.js
@@ -65,8 +65,8 @@ class Checkbox extends Component {
 
     render() {
         const {
-            checked = false,
-            indeterminate = false,
+            checked,
+            indeterminate,
             className,
             disabled,
             error,
@@ -128,8 +128,6 @@ class Checkbox extends Component {
                         align-items: center;
                         justify-content: flex-start;
                         cursor: pointer;
-                        pointer-events: all;
-                        user-select: none;
                         color: ${colors.grey900};
                         font-size: 16px;
                         line-height: 20px;
@@ -147,12 +145,21 @@ class Checkbox extends Component {
 
                     input {
                         opacity: 0;
-                        pointer-events: none;
                         position: absolute;
+                        /* The same size as the icon */
+                        height: 18px;
+                        width: 18px;
+                        /* The same offset as the icon, 2px border, 1px padding */
+                        left: 3px;
+                    }
+
+                    label.dense input {
+                        /* The same size as the dense icon */
+                        height: 14px;
+                        width: 14px;
                     }
 
                     .icon {
-                        pointer-events: none;
                         user-select: none;
                         margin-right: 5px;
                         border: 2px solid transparent;
@@ -175,6 +182,8 @@ class Checkbox extends Component {
 }
 
 Checkbox.defaultProps = {
+    checked: false,
+    indeterminate: false,
     dataTest: 'dhis2-uicore-checkbox',
 }
 


### PR DESCRIPTION
The disabling of pointer events on the input interfered with the accessibility of our checkbox. I've followed the recommendations in this article https://www.sarasoueidan.com/blog/inclusively-hiding-and-styling-checkboxes-and-radio-buttons. The strategy is basically to leverage the behaviour of the native checkbox as much as possible, by positioning it on top of the svg, and just using the svg for display purposes. Instead of depending on the label to capture the clicks, we're now allowing the input to behave as it normally does, and just using the svg to replace the look of the checkbox.

It could be improved a lot more btw, but for now I've just fixed the most immediate accessibility issue. Later on we should apply the recommendations from the article in full for both our checkboxes and our radio buttons in my opinion.

Other than that I've:

- Moved the defaults to the defaultprops
- ~~Removed `cursor: pointer` on the label as that's not the browser default (pointer indicates a link according to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor))~~
- I've removed `user-select: none` on the label as well as that's also not a browser default (see [jsfiddle](https://jsfiddle.net/m650y3vd/))

The above three changes could be seen as extraneous to this PR, though I think they're useful. So let me know if you think they should be omitted.

Closes https://jira.dhis2.org/browse/LIBS-136
