### PR TITLE
fix(modal): close modal by clicking above (LIBS-127)

### DIFF
--- a/packages/core/src/Modal/Modal.js
+++ b/packages/core/src/Modal/Modal.js
@@ -18,6 +18,15 @@ const scrollBoxCard = resolve`
     }
 `
 
+const centeredContent = resolve`
+    .top {
+        padding-top: ${spacers.dp64};
+    }
+    .bottom {
+        padding-bottom: ${spacers.dp64};
+    }
+`
+
 /**
  * @module
  * @param {Modal.PropTypes} props
@@ -57,14 +66,18 @@ export const Modal = ({
     dataTest,
 }) => (
     <Layer onClick={onClose} level={layers.blocking} translucent>
-        <CenteredContent position={position}>
+        <CenteredContent
+            position={position}
+            className={centeredContent.className}
+        >
             <aside
                 data-test={dataTest}
-                className={cx(className, position, { small, large })}
+                className={cx(className, { small, large })}
             >
                 <Card className={scrollBoxCard.className}>{children}</Card>
             </aside>
             {scrollBoxCard.styles}
+            {centeredContent.styles}
         </CenteredContent>
 
         <style jsx>{`
@@ -74,14 +87,6 @@ export const Modal = ({
                 max-height: calc(100vh - ${2 * spacersNum.dp64}px);
                 max-width: calc(100vw - ${2 * spacersNum.dp64}px);
                 width: 600px;
-            }
-
-            aside.top {
-                margin-top: ${spacers.dp64};
-            }
-
-            aside.bottom {
-                margin-bottom: ${spacers.dp64};
             }
 
             aside.small {

--- a/packages/core/src/Modal/Modal.stories.e2e.js
+++ b/packages/core/src/Modal/Modal.stories.e2e.js
@@ -24,4 +24,16 @@ storiesOf('Modal', module)
             </ModalActions>
         </Modal>
     ))
+    .add('Bottom-aligned, with onClose', () => (
+        <Modal small onClose={window.onClose} position="bottom">
+            <ModalTitle>Title</ModalTitle>
+            <ModalContent>Content</ModalContent>
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button secondary>Secondary action</Button>
+                    <Button primary>Primary action</Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Modal>
+    ))
     .add('With children', () => <Modal>I am a child</Modal>)

--- a/packages/core/src/Modal/features/can_be_closed.feature
+++ b/packages/core/src/Modal/features/can_be_closed.feature
@@ -1,6 +1,11 @@
-Feature: The Modal has an onClose api
+Feature: The Modal has an onClose api that triggers when clicking anywhere outside the modal
 
-    Scenario: The user clicks on the Screencover
-        Given a Modal with onClose handler is rendered
-        When the Screencover is clicked
+    Scenario: The user clicks on the Screencover above a top-aligned modal
+        Given a top-aligned Modal with onClose handler is rendered
+        When the Screencover is clicked above the modal
+        Then the onClose handler is called
+
+    Scenario: The user clicks on the Screencover below a bottom-aligned modal
+        Given a bottom-aligned Modal with onClose handler is rendered
+        When the Screencover is clicked below the modal
         Then the onClose handler is called

--- a/packages/core/src/Modal/features/can_be_closed/index.js
+++ b/packages/core/src/Modal/features/can_be_closed/index.js
@@ -1,15 +1,23 @@
 import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
-Given('a Modal with onClose handler is rendered', () => {
+Given('a top-aligned Modal with onClose handler is rendered', () => {
     cy.visitStory('Modal', 'With onClose')
 })
 
-When('the Screencover is clicked', () => {
-    cy.get('[data-test="dhis2-uicore-layer"]').click('topLeft')
+When('the Screencover is clicked above the modal', () => {
+    cy.get('[data-test="dhis2-uicore-layer"]').click('top')
 })
 
 Then('the onClose handler is called', () => {
     cy.window().should(win => {
         expect(win.onClose).to.be.calledWith({})
     })
+})
+
+Given('a bottom-aligned Modal with onClose handler is rendered', () => {
+    cy.visitStory('Modal', 'Bottom-aligned, with onClose')
+})
+
+When('the Screencover is clicked below the modal', () => {
+    cy.get('[data-test="dhis2-uicore-layer"]').click('bottom')
 })


### PR DESCRIPTION
Fixes an issue where modals don't register onClose events when clicked above (or below, for bottom-aligned modals), as seen in this discussion: https://github.com/dhis2/notes/discussions/232

### Diagnosis
CenteredContent attempts to enable 'clicking through' the container component that applies the positioning rules by disabling pointer events on that container, then re-enabling pointer events on the `centered-inner-content` div that will hold the children.  The issue is that any margins or other space around children in that div will have pointer events enabled, and thus will not click through to content behind the CenteredContent as desired (as seen in the modal example in the discussion above)

### Proposed solution

~~Adding an `innerContentStyles` prop to CenteredContent that adds styles to `div.centered-inner-content`, which preserves CenteredContent functionality everywhere it’s currently used.~~

~~I moved margins from the `<aside>` in Modal to the `innerContentStyles` to fix the issue. Note that for the modal, passing ‘pointer-events: none’ to `innerContentStyles` and then using ‘pointer-events: auto’ on the `aside`'s styles would also fix this issue, but I chose to use margins because it’s more intuitive.~~

~~I chose to use a styles object over styled-jsx for `innerContentStyles` because I figured it would be a bit more straightforward for a consumer using a CenteredContent in their project to configure the styles this way, but I'm open to feedback about that choice.~~

### Better solution

Use styled-jsx `resolve` to add padding to the CenteredContent, as suggested below