### PR TITLE
docs: adjust storybook design

### DIFF
--- a/.storybook/static/manager.css
+++ b/.storybook/static/manager.css
@@ -1,5 +1,10 @@
 /* Styles to customize storybook manager UI (search, sidebar, etc) go here */
 
 .sidebar-subheading {
-    color: #4a5768 !important;
+    color: #404b5a !important;
+    text-transform: none !important;
+    font-size: 13px !important;
+    font-weight: 700 !important;
+    letter-spacing: normal !important;
+    margin: 16px 20px 0px 20px !important;
 }

--- a/.storybook/static/preview.css
+++ b/.storybook/static/preview.css
@@ -1,9 +1,12 @@
 /* Styles for storybook docs or anything else in the 'preview' frame go here */
 
-.sbdocs.sbdocs-a:hover {
-    text-decoration: underline;
+.sbdocs-a {
+    color: #0d47a1 !important;
+    text-decoration: underline !important;
 }
-
+a.sbdocs-a:visited {
+    color: #551a8b !important;
+}
 .sbdocs-expandable {
-    color: #004D40 !important; /* teal800 */
+    color: #004d40 !important; /* teal800 */
 }


### PR DESCRIPTION
This PR adjusts the design of some elements of the storybook documentation:
- adjusts document link color to meet WCAG AAA
- adds visibly different `:visited` state for document links
- adjusts sidebar headings for readability

Note: I followed the directions for using the [storybook CSS escape hatches](https://storybook.js.org/docs/react/configure/theming#css-escape-hatches), but this still required using `!important` on all rules.