### PR TITLE
docs: add stories for input [LIBS-138]

### DIFF
--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -1,6 +1,6 @@
-import propTypes from '@dhis2/prop-types'
 import { theme, colors, spacers, sharedPropTypes } from '@dhis2/ui-constants'
 import cx from 'classnames'
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import css from 'styled-jsx/css'
 import { StatusIcon } from '../Icons/index.js'
@@ -219,24 +219,33 @@ Input.defaultProps = {
  * @prop {string} [dataTest]
  */
 Input.propTypes = {
-    className: propTypes.string,
-    dataTest: propTypes.string,
-    dense: propTypes.bool,
-    disabled: propTypes.bool,
+    className: PropTypes.string,
+    dataTest: PropTypes.string,
+    /** Makes the input smaller */
+    dense: PropTypes.bool,
+    /** Disables the input */
+    disabled: PropTypes.bool,
+    /** Applies 'error' appearance for validation feedback. Mutually exclusive with `valid` and `warning` props */
     error: sharedPropTypes.statusPropType,
-    initialFocus: propTypes.bool,
-    loading: propTypes.bool,
+    /** The input grabs initial focus on the page */
+    initialFocus: PropTypes.bool,
+    /** Adds a loading indicator beside the input */
+    loading: PropTypes.bool,
     /** The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmax), for use when `type` is `'number'` */
-    max: propTypes.string,
+    max: PropTypes.string,
     /** The [native `min` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmin), for use when `type` is `'number'` */
-    min: propTypes.string,
-    name: propTypes.string,
-    placeholder: propTypes.string,
-    readOnly: propTypes.bool,
+    min: PropTypes.string,
+    /** Name associated with the input. Passed to event handler callbacks in object */
+    name: PropTypes.string,
+    /** Placeholder text for the input */
+    placeholder: PropTypes.string,
+    /** Makes the input read-only */
+    readOnly: PropTypes.bool,
     /** The [native `step` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefstep), for use when `type` is `'number'` */
-    step: propTypes.string,
-    tabIndex: propTypes.string,
-    type: propTypes.oneOf([
+    step: PropTypes.string,
+    tabIndex: PropTypes.string,
+    /** The native input `type` attribute */
+    type: PropTypes.oneOf([
         'text',
         'number',
         'password',
@@ -251,10 +260,16 @@ Input.propTypes = {
         'time',
         'search',
     ]),
+    /** Applies 'valid' appearance for validation feedback. Mutually exclusive with `error` and `warning` props */
     valid: sharedPropTypes.statusPropType,
-    value: propTypes.string,
+    /** Value in the input. Can be used to control the component (recommended). Passed to event handler callbacks in object */
+    value: PropTypes.string,
+    /** Applies 'warning' appearance for validation feedback. Mutually exclusive with `valid` and `error` props */
     warning: sharedPropTypes.statusPropType,
-    onBlur: propTypes.func,
-    onChange: propTypes.func,
-    onFocus: propTypes.func,
+    /** Called with signature `({ name: string, value: string }, event)` */
+    onBlur: PropTypes.func,
+    /** Called with signature `({ name: string, value: string }, event)` */
+    onChange: PropTypes.func,
+    /** Called with signature `({ name: string, value: string }, event)` */
+    onFocus: PropTypes.func,
 }

--- a/packages/core/src/Input/Input.stories.js
+++ b/packages/core/src/Input/Input.stories.js
@@ -1,0 +1,126 @@
+import { sharedPropTypes } from '@dhis2/ui-constants'
+import React from 'react'
+import { Input } from './Input.js'
+
+const description = `
+An input allows a user to enter data, usually text.
+
+Inputs are used wherever a user needs to input standard text information. Inputs are often used as part of forms. An input can also be used to capture information outside of a form, perhaps as a 'Filter' or 'Search' field.
+
+To use a label and validation text, consider the \`InputField\` component.
+
+Read more about Inputs and InputFields at [Design System: Inputs](https://github.com/dhis2/design-system/blob/master/atoms/inputfield.md).
+
+\`\`\`js
+import { Input } from '@dhis/ui'
+\`\`\`
+`
+
+const inputTypeArgType = {
+    table: { type: { summary: 'string' } },
+    control: {
+        type: 'select',
+        options: [
+            'text',
+            'number',
+            'password',
+            'email',
+            'url',
+            'tel',
+            'date',
+            'datetime',
+            'datetime-local',
+            'month',
+            'week',
+            'time',
+            'search',
+        ],
+    },
+}
+
+const logger = ({ name, value }) =>
+    console.log(`Name: ${name}, value: ${value}`)
+
+export default {
+    title: 'Forms/Input/Input',
+    component: Input,
+    parameters: {
+        docs: { description: { component: description } },
+    },
+    args: {
+        name: 'defaultName',
+        onChange: logger,
+    },
+    argTypes: {
+        type: { ...inputTypeArgType },
+        valid: { ...sharedPropTypes.statusArgType },
+        warning: { ...sharedPropTypes.statusArgType },
+        error: { ...sharedPropTypes.statusArgType },
+    },
+}
+
+const Template = args => <Input {...args} />
+
+export const Default = Template.bind({})
+
+export const NoPlaceholderNoValue = Template.bind({})
+NoPlaceholderNoValue.storyName = 'No placeholder, no value'
+
+export const PlaceholderNoValue = Template.bind({})
+PlaceholderNoValue.args = { placeholder: 'Hold the place' }
+PlaceholderNoValue.storyName = 'Placeholder, no value'
+
+export const WithValue = Template.bind({})
+WithValue.args = {
+    value:
+        'This is set through the value prop, which means the component is controlled.',
+}
+
+export const NumberMaxMinStep = Template.bind({})
+NumberMaxMinStep.args = {
+    type: 'number',
+    max: '3',
+    min: '0',
+    step: '0.5',
+}
+
+export const Focus = Template.bind({})
+Focus.args = { initialFocus: true }
+// Disabled initial focus stories on docs page
+Focus.parameters = { docs: { disable: true } }
+
+export const StatusValid = Template.bind({})
+StatusValid.args = { valid: true, value: 'This value is valid' }
+StatusValid.storyName = 'Status: Valid'
+
+export const StatusWarning = Template.bind({})
+StatusWarning.args = { warning: true, value: 'This value produces a warning' }
+StatusWarning.storyName = 'Status: Warning'
+
+export const StatusError = Template.bind({})
+StatusError.args = { error: true, value: 'This value produces an error' }
+StatusError.storyName = 'Status: Error'
+
+export const StatusLoading = Template.bind({})
+StatusLoading.args = {
+    loading: true,
+    value: 'This value produces a loading state',
+}
+StatusLoading.storyName = 'Status: Loading'
+
+export const Disabled = Template.bind({})
+Disabled.args = { disabled: true, value: 'This field is disabled' }
+
+export const ReadOnly = Template.bind({})
+ReadOnly.args = { readOnly: true, value: 'This field is read-only' }
+
+export const Dense = Template.bind({})
+Dense.args = { dense: true, value: 'This field is dense' }
+
+export const ValueTextOverflow = Template.bind({})
+ValueTextOverflow.args = {
+    value:
+        "This value is too long in order to show on a single line of the input field. It should stay on one line, not in an extra line and which wouldn't look like a standard input",
+    dense: true,
+    warning: true,
+}


### PR DESCRIPTION
Stories were missing for the `Input` component.

Stories in the new format were added, and some descriptions for the component and its props were added as well.