### PR TITLE
chore: differentiate react and dhis2 prop types when in same file

### DIFF
--- a/packages/core/src/AlertBar/AlertBar.js
+++ b/packages/core/src/AlertBar/AlertBar.js
@@ -1,4 +1,4 @@
-import propTypes from '@dhis2/prop-types'
+import { mutuallyExclusive } from '@dhis2/prop-types'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -126,7 +126,7 @@ class AlertBar extends Component {
     }
 }
 
-const alertTypePropType = propTypes.mutuallyExclusive(
+const alertTypePropType = mutuallyExclusive(
     ['success', 'warning', 'critical'],
     PropTypes.bool
 )

--- a/packages/core/src/ButtonStrip/ButtonStrip.js
+++ b/packages/core/src/ButtonStrip/ButtonStrip.js
@@ -1,4 +1,4 @@
-import propTypes from '@dhis2/prop-types'
+import { mutuallyExclusive } from '@dhis2/prop-types'
 import { spacers } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -45,10 +45,7 @@ const ButtonStrip = ({ className, children, middle, end, dataTest }) => (
     </div>
 )
 
-const alignmentPropType = propTypes.mutuallyExclusive(
-    ['middle', 'end'],
-    PropTypes.bool
-)
+const alignmentPropType = mutuallyExclusive(['middle', 'end'], PropTypes.bool)
 
 ButtonStrip.defaultProps = {
     dataTest: 'dhis2-uicore-buttonstrip',

--- a/packages/core/src/Checkbox/Checkbox.js
+++ b/packages/core/src/Checkbox/Checkbox.js
@@ -1,4 +1,4 @@
-import propTypes from '@dhis2/prop-types'
+import { mutuallyExclusive } from '@dhis2/prop-types'
 import { colors, theme, sharedPropTypes } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -206,7 +206,7 @@ Checkbox.defaultProps = {
  * @prop {string} [dataTest]
  */
 
-const uniqueOnStatePropType = propTypes.mutuallyExclusive(
+const uniqueOnStatePropType = mutuallyExclusive(
     ['checked', 'indeterminate'],
     PropTypes.bool
 )

--- a/packages/core/src/MultiSelect/MultiSelect.js
+++ b/packages/core/src/MultiSelect/MultiSelect.js
@@ -1,4 +1,4 @@
-import propTypes from '@dhis2/prop-types'
+import { requiredIf } from '@dhis2/prop-types'
 import { spacers, sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -155,7 +155,7 @@ MultiSelect.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     /** Required if `clearable` prop is `true` */
-    clearText: propTypes.requiredIf(props => props.clearable, PropTypes.string),
+    clearText: requiredIf(props => props.clearable, PropTypes.string),
     /** Adds a 'clear' option to the menu */
     clearable: PropTypes.bool,
     dataTest: PropTypes.string,
@@ -172,13 +172,10 @@ MultiSelect.propTypes = {
     loadingText: PropTypes.string,
     maxHeight: PropTypes.string,
     /** Required if `filterable` prop is `true` */
-    noMatchText: propTypes.requiredIf(
-        props => props.filterable,
-        PropTypes.string
-    ),
+    noMatchText: requiredIf(props => props.filterable, PropTypes.string),
     placeholder: PropTypes.string,
     prefix: PropTypes.string,
-    selected: PropTypes.arrayOf(propTypes.string),
+    selected: PropTypes.arrayOf(PropTypes.string),
     tabIndex: PropTypes.string,
     valid: sharedPropTypes.statusPropType,
     warning: sharedPropTypes.statusPropType,

--- a/packages/core/src/NoticeBox/NoticeBox.js
+++ b/packages/core/src/NoticeBox/NoticeBox.js
@@ -1,4 +1,4 @@
-import propTypes from '@dhis2/prop-types'
+import { mutuallyExclusive } from '@dhis2/prop-types'
 import { spacers, colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -83,8 +83,8 @@ NoticeBox.propTypes = {
     className: PropTypes.string,
     dataTest: PropTypes.string,
     /** Applies 'error' message styles. Mutually exclusive with the `warning` prop */
-    error: propTypes.mutuallyExclusive(['error', 'warning'], PropTypes.bool),
+    error: mutuallyExclusive(['error', 'warning'], PropTypes.bool),
     title: PropTypes.string,
     /** Applies 'warning' message styles. Mutually exclusive with the `error` prop */
-    warning: propTypes.mutuallyExclusive(['error', 'warning'], PropTypes.bool),
+    warning: mutuallyExclusive(['error', 'warning'], PropTypes.bool),
 }

--- a/packages/core/src/SingleSelect/SingleSelect.js
+++ b/packages/core/src/SingleSelect/SingleSelect.js
@@ -1,4 +1,4 @@
-import propTypes from '@dhis2/prop-types'
+import { requiredIf } from '@dhis2/prop-types'
 import { spacers, sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -155,7 +155,7 @@ SingleSelect.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     /** Text on button that clears selection. Required if `clearable` prop is true */
-    clearText: propTypes.requiredIf(props => props.clearable, PropTypes.string),
+    clearText: requiredIf(props => props.clearable, PropTypes.string),
     /** Adds a button to clear selection */
     clearable: PropTypes.bool,
     dataTest: PropTypes.string,
@@ -174,10 +174,7 @@ SingleSelect.propTypes = {
     loadingText: PropTypes.string,
     maxHeight: PropTypes.string,
     /** Text to show when filter returns no results. Required if `filterable` prop is true */
-    noMatchText: propTypes.requiredIf(
-        props => props.filterable,
-        PropTypes.string
-    ),
+    noMatchText: requiredIf(props => props.filterable, PropTypes.string),
     placeholder: PropTypes.string,
     prefix: PropTypes.string,
     selected: PropTypes.string,

--- a/packages/core/src/Tag/Tag.js
+++ b/packages/core/src/Tag/Tag.js
@@ -1,4 +1,4 @@
-import propTypes from '@dhis2/prop-types'
+import { mutuallyExclusive } from '@dhis2/prop-types'
 import { colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -97,7 +97,7 @@ export const Tag = ({
     </div>
 )
 
-const tagVariantPropType = propTypes.mutuallyExclusive(
+const tagVariantPropType = mutuallyExclusive(
     ['neutral', 'positive', 'negative'],
     PropTypes.bool
 )


### PR DESCRIPTION
Files with user-facing stories now mainly use React `prop-types` to work best with storybook doc generation, but a few components still use prop-types from the `@dhis2/prop-types` library.

To differentiate between the two prop type objects in these files (`PropTypes` from React and `propTypes` from dhis2), named imports are used for the dhis2 validators.