### PR TITLE
fix: enforce min w and h on UserIcon to keep circle shape on small screens [LIBS-151]

### DIFF
--- a/packages/widgets/src/HeaderBar/Profile.js
+++ b/packages/widgets/src/HeaderBar/Profile.js
@@ -58,6 +58,8 @@ export default class Profile extends React.Component {
                         position: relative;
                         width: 36px;
                         height: 36px;
+                        min-width: 36px;
+                        min-height: 36px;
                         margin: 2px 12px 0 24px;
                     }
 


### PR DESCRIPTION
One of the main analytics features for 2.36 is the responsive dashboard app. The goal is that the app should look good and have a subset of functionality on phone portrait orientation.  This PR is to make the UserIcon also look correct on phone portrait, since it is part of the overall impression of the responsive dashboard app.

Before:
![image](https://user-images.githubusercontent.com/6113918/110793355-cfdb3900-8274-11eb-968b-987498c0c0ed.png)


After: 
![image](https://user-images.githubusercontent.com/6113918/110793405-dd90be80-8274-11eb-8f16-7e6e9995fff6.png)
