### PR TITLE
docs: add Migrating page

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,0 +1,9 @@
+# Migrating from previous UI versions
+
+## < v5
+
+A number of important changes were introduced in UI version 5.0.0. To see more about these changes and how to migrate from older versions, see [this blog post](https://developers.dhis2.org/blog/ui-5-release) at the developer portal.
+
+## < v6
+
+A number of icons (intended for internal use) were deprecated. See the full [changelog here](https://ui.dhis2.nu/#/CHANGELOG?id=_600-2020-12-10).

--- a/docs/migrating.stories.mdx
+++ b/docs/migrating.stories.mdx
@@ -1,0 +1,6 @@
+import { Meta, Description } from '@storybook/addon-docs/blocks'
+import Migrating from './migrating.md'
+
+<Meta title="Using UI/Migrating from previous versions" />
+
+<Description>{Migrating}</Description>


### PR DESCRIPTION
Adds a page to both the docsite and the storybook that links to information about migrating from previous UI versions