### PR TITLE
fix(modal): add ARIA dialog role to modals

### DIFF
--- a/packages/core/src/Modal/Modal.js
+++ b/packages/core/src/Modal/Modal.js
@@ -75,6 +75,8 @@ export const Modal = ({
             className={centeredContent.className}
         >
             <aside
+                role="dialog"
+                aria-modal="true"
                 data-test={dataTest}
                 className={cx(className, { small, large })}
             >


### PR DESCRIPTION
Add the ARIA `dialog` role and `aria-modal` attribute (see [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) and [here](https://www.w3.org/TR/wai-aria-practices-1.1/examples/dialog-modal/dialog.html#rps_label)) to modals to improve accessibility.