### PR TITLE
fix(select): set z-index to 1 on FilterInput used by selects

### DIFF
--- a/packages/core/src/Select/FilterInput.js
+++ b/packages/core/src/Select/FilterInput.js
@@ -23,6 +23,7 @@ const FilterInput = ({ value, onChange, placeholder, className, dataTest }) => (
                 background: ${colors.white};
                 padding: ${spacers.dp8} ${spacers.dp8} ${spacers.dp4}
                     ${spacers.dp8};
+                z-index: 1;
             }
         `}</style>
     </div>


### PR DESCRIPTION
This PR fixes the issue shown in the screenshot below where the select options (for both single and multiselects) appear above the filter input.

![image](https://user-images.githubusercontent.com/4295266/111784360-3e427b80-88b3-11eb-968b-8ef320fcf092.png)
