### PR TITLE
feat: introduce ui-elements package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ All components can be imported directly from `@dhis2/ui` like so:
 import { Button } from '@dhis2/ui'
 ```
 
-We recommend that you use `@dhis2/ui` as the entrypoint for all imports of our frontend components (as in the example above). That way your imports won't break if any of the underlying packages change.
+We recommend that you use `@dhis2/ui` as the entrypoint for all imports
+of our frontend components (as in the example above). That way your
+imports won't break if any of the underlying packages change.
 
 ## Documentation
 
-`@dhis2/ui` is based on the specifications in our design-system: https://github.com/dhis2/design-system. See the documentation there for more information.
+`@dhis2/ui` is based on the specifications in our design-system:
+https://github.com/dhis2/design-system. See the documentation there for
+more information.
 
 -   Docs: [ui.dhis2.nu](https://ui.dhis2.nu)
 -   Live demo: [ui.dhis2.nu/demo](https://ui.dhis2.nu/demo)
@@ -41,25 +45,53 @@ We recommend that you use `@dhis2/ui` as the entrypoint for all imports of our f
 
 ### `@dhis2/ui-constants`
 
-This package provides access to shared constants, such as colors, spacers and elevation values. They are used across our frontend components and can be used directly in applications as well. Our constants can be imported like so:
+This package provides access to shared constants, such as colors,
+spacers and elevation values. They are used across our frontend
+components and can be used directly in applications as well. Our
+constants can be imported like so:
 
 ```js
 import { colors } from '@dhis2/ui'
 ```
 
-See our [api docs](https://ui.dhis2.nu/#/api) for a full list of the available constants.
+See our [api docs](https://ui.dhis2.nu/#/api) for a full list of the
+available constants.
+
+### `@dhis2/ui-elements`
+
+Think of these components as styled HTML elements. These are the
+elements that are used to compose other UI components.
+
+-   Elements MUST NOT import other elements.
+-   Elements SHOULD NOT provide behavior.
+-   Elements MUST provide relevant styles for the design system.
+-   Elements MUST forward the `ref`.
+-   Elements MAY provide props for specific variants.
+-   Elements SHOULD spread props to the underlying HTML element.
+
+Since UI Elements are useful in other contexts to compose new components
+with specific behavior, they provide a stable base to build on with a
+flexible API.
 
 ### `@dhis2/ui-icons`
 
-This package provides a collection of icons as react components. For tree shaking purposes the icon name, variant and size are all expressed in the component name. Our icons can be imported like so:
+This package provides a collection of icons as react components. For
+tree shaking purposes the icon name, variant and size are all expressed
+in the component name. Our icons can be imported like so:
 
 ```js
 import { IconApps16 } from '@dhis2/ui'
 ```
 
-For a list of all the available icons see [the ui-icons package](https://github.com/dhis2/ui/tree/master/packages/icons/src). Note that during their transformation to React components the svg filenames are PascalCased and prefixed with `Icon`. So `apps-16.svg` becomes `IconApps16` and can then be imported as in the example above.
+For a list of all the available icons see [the ui-icons
+package](https://github.com/dhis2/ui/tree/master/packages/icons/src).
+Note that during their transformation to React components the svg
+filenames are PascalCased and prefixed with `Icon`. So `apps-16.svg`
+becomes `IconApps16` and can then be imported as in the example above.
 
-The default fill of our icons is inherited from `color` with `currentColor`. To set a custom icon color you can use the `color` prop like so:
+The default fill of our icons is inherited from `color` with
+`currentColor`. To set a custom icon color you can use the `color` prop
+like so:
 
 ```jsx
 <IconApps16 color="#DE683D" />
@@ -67,33 +99,55 @@ The default fill of our icons is inherited from `color` with `currentColor`. To 
 
 ### `@dhis2/ui-core`
 
-This package provides the low level building blocks for all our components. We use them as building blocks for our more elaborate components and they can be used in applications for the same purpose. Any of our core components can be imported in the following manner:
+> :warning: DEPRECATED:
+
+This package provides the low level building blocks for all our
+components. We use them as building blocks for our more elaborate
+components and they can be used in applications for the same purpose.
+Any of our core components can be imported in the following manner:
 
 ```js
 import { Button } from '@dhis2/ui'
 ```
 
-See our [api docs](https://ui.dhis2.nu/#/api) or the [live docs](https://ui.dhis2.nu/demo) for a full list of the available core components.
+See our [api docs](https://ui.dhis2.nu/#/api) or the [live
+docs](https://ui.dhis2.nu/demo) for a full list of the available core
+components.
 
 ### `@dhis2/ui-widgets`
 
-This package provides widgets, more elaborate components that are often composed of multiple core components. Components in this package can include translations, interact with an API or address a DHIS 2 specific usecase. An example of a widget import:
+> :warning: DEPRECATED:
+
+This package provides widgets, more elaborate components that are often
+composed of multiple core components. Components in this package can
+include translations, interact with an API or address a DHIS 2 specific
+usecase. An example of a widget import:
 
 ```js
 import { Transfer } from '@dhis2/ui'
 ```
 
-See our [api docs](https://ui.dhis2.nu/#/api) or the [live docs](https://ui.dhis2.nu/demo) for a full list of the available widgets.
+See our [api docs](https://ui.dhis2.nu/#/api) or the [live
+docs](https://ui.dhis2.nu/demo) for a full list of the available
+widgets.
 
 ### `@dhis2/ui-forms`
 
-This package provides several components that allow for easy integration of our form components with [react-final-form](https://github.com/final-form/react-final-form). Besides form components, we also export several validator functions for common usecases. Components from this library can be imported like so:
+This package provides several components that allow for easy integration
+of our form components with
+[react-final-form](https://github.com/final-form/react-final-form).
+Besides form components, we also export several validator functions for
+common usecases. Components from this library can be imported like so:
 
 ```js
 import { TextAreaFieldFF } from '@dhis2/ui'
 ```
 
-The `FF` suffix ensures that these components don't clash with our regular field components from the widgets package and is an abbreviation of `final-form`. See our [api docs](https://ui.dhis2.nu/#/api) or the [live docs](https://ui.dhis2.nu/demo) for a full list of the available components and validators.
+The `FF` suffix ensures that these components don't clash with our
+regular field components from the widgets package and is an abbreviation
+of `final-form`. See our [api docs](https://ui.dhis2.nu/#/api) or the
+[live docs](https://ui.dhis2.nu/demo) for a full list of the available
+components and validators.
 
 ## Reporting an issue or opening a PR
 

--- a/packages/elements/.eslintrc.js
+++ b/packages/elements/.eslintrc.js
@@ -1,0 +1,23 @@
+module.exports = {
+    rules: {
+        'no-restricted-imports': [
+            'error',
+            {
+                paths: [
+                    '@dhis2/ui-elements',
+                    '@dhis2/ui-core',
+                    '@dhis2/ui-forms',
+                    '@dhis2/ui',
+                    '@dhis2/ui-widgets',
+                ],
+                patterns: [
+                    '@dhis2/ui-elements/*',
+                    '@dhis2/ui-core/*',
+                    '@dhis2/ui-forms/*',
+                    '@dhis2/ui/*',
+                    '@dhis2/ui-widgets/*',
+                ],
+            },
+        ],
+    },
+}

--- a/packages/elements/d2.config.js
+++ b/packages/elements/d2.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    type: 'lib',
+    entryPoints: {
+        lib: 'src/index.js',
+    },
+}

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@dhis2/ui-elements",
+    "description": "Element components for DHIS2 user interfaces",
+    "version": "6.5.6",
+    "main": "./build/cjs/index.js",
+    "module": "./build/es/index.js",
+    "exports": {
+        "import": "./build/es/index.js",
+        "require": "./build/cjs/index.js"
+    },
+    "sideEffects": false,
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/dhis2/ui.git",
+        "directory": "packages/elements"
+    },
+    "homepage": "https://github.com/dhis2/ui#readme",
+    "author": "Viktor Varland <viktor@dhis2.org>",
+    "license": "BSD-3-Clause",
+    "private": false,
+    "publishConfig": {
+        "access": "public"
+    },
+    "scripts": {
+        "build": "d2-app-scripts build"
+    },
+    "peerDependencies": {
+        "@dhis2/ui-constants": "6.5.6",
+        "react": "^16.8",
+        "react-dom": "^16.8",
+        "styled-jsx": "^3.2"
+    },
+    "dependencies": {
+        "classnames": "^2.2.6",
+        "prop-types": "^15.7.2"
+    },
+    "files": [
+        "build"
+    ]
+}

--- a/packages/elements/src/button/button.component.js
+++ b/packages/elements/src/button/button.component.js
@@ -1,0 +1,89 @@
+import cx from 'classnames'
+
+import PropTypes from 'prop-types'
+
+import styles from './button.styles.js'
+
+/**
+ * Buttons are used for triggering actions. There are different types
+ * of buttons in the design system which are intended for different
+ * types of actions.
+ *
+ * ```js
+ * import { Button } from '@dhis2/ui'
+ * ```
+ */
+export const Button = React.forwardRef(
+    (
+        {
+            children,
+            className,
+            dataTest,
+            primary,
+            secondary,
+            destructive,
+            small,
+            large,
+            toggled,
+            ...props
+        },
+        ref
+    ) => (
+        <button
+            {...props}
+            data-test={dataTest}
+            className={cx(className, {
+                primary,
+                secondary,
+                destructive,
+                small,
+                large,
+                toggled,
+            })}
+            ref={ref}
+        >
+            {children}
+            <style jsx>{styles}</style>
+        </button>
+    )
+)
+
+Button.defaultProps = {
+    dataTest: 'dhis2-uielements-button',
+}
+
+Button.displayName = 'Button'
+
+Button.propTypes = {
+    /**
+     * A string that will be applied as a `data-test` attribute on the button element
+     * for identification during testing
+     */
+    dataTest: PropTypes.string,
+    /** Component to render inside the button */
+    children: PropTypes.node,
+    /** A className that will be passed to the `<button>` element */
+    className: PropTypes.string,
+    /**
+     * Indicates that the button makes potentially dangerous
+     * deletions or data changes.
+     * Mutually exclusive with `primary` and `secondary` props
+     */
+    destructive: PropTypes.bool,
+    /** Makes the button large. Mutually exclusive with `small` */
+    large: PropTypes.bool,
+    /**
+     * Applies 'primary' button appearance.
+     * Mutually exclusive with `destructive` and `secondary` props
+     */
+    primary: PropTypes.bool,
+    /**
+     * Applies 'secondary' button appearance.
+     * Mutually exclusive with `primary` and `destructive` props
+     */
+    secondary: PropTypes.bool,
+    /** Makes the button small. Mutually exclusive with `large` prop */
+    small: PropTypes.bool,
+    /** Changes appearance of button to an on/off state */
+    toggled: PropTypes.bool,
+}

--- a/packages/elements/src/button/button.spec.js
+++ b/packages/elements/src/button/button.spec.js
@@ -1,0 +1,27 @@
+import { mount } from 'enzyme'
+import { Button } from './button.component.js'
+
+describe('<Button>', () => {
+    test('has class "toggled" if toggled is true', () => {
+        const wrapper = mount(<Button toggled />)
+
+        const actual = wrapper.find('button')
+        expect(actual.hasClass('toggled')).toBe(true)
+    })
+
+    test('no class "toggled" if toggled is false', () => {
+        const wrapper = mount(<Button />)
+
+        const actual = wrapper.find('button')
+        expect(actual.hasClass('toggled')).toBe(false)
+    })
+
+    test('the built-in classes are in addition to the custom one', () => {
+        const wrapper = mount(<Button primary large className="foobar" />)
+
+        const actual = wrapper.find('button')
+        expect(actual.hasClass('foobar')).toBe(true)
+        expect(actual.hasClass('primary')).toBe(true)
+        expect(actual.hasClass('large')).toBe(true)
+    })
+})

--- a/packages/elements/src/button/button.stories.js
+++ b/packages/elements/src/button/button.stories.js
@@ -1,0 +1,226 @@
+import { sharedPropTypes } from '@dhis2/ui-constants'
+
+import { Button } from './button.component.js'
+
+const { buttonVariantArgType, sizeArgType } = sharedPropTypes
+
+const logger = ({ name, value }) => console.log(`${name}: ${value}`)
+
+export default {
+    title: 'Actions/Buttons/Button',
+    component: Button,
+    parameters: {
+        componentSubtitle: 'Initiates an action',
+        docs: {
+            description: {
+                component: description,
+            },
+        },
+    },
+    args: {
+        children: 'Label me!',
+        value: 'default',
+        onClick: logger,
+    },
+    argTypes: {
+        primary: { ...buttonVariantArgType },
+        secondary: { ...buttonVariantArgType },
+        destructive: { ...buttonVariantArgType },
+        small: { ...sizeArgType },
+        large: { ...sizeArgType },
+    },
+}
+
+const DemoIcon = (
+    <svg
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="m10.7071068 13.2928932c.3604839.360484.3882135.927715.0831886 1.3200062l-.0831886.0942074-5.2921068 5.2918932 2.585.001c.51283584 0 .93550716.3860402.99327227.8833789l.00672773.1166211c0 .5128358-.38604019.9355072-.88337887.9932723l-.11662113.0067277h-5l-.0193545-.0001861c-.02332655-.0004488-.04664039-.0017089-.06989557-.0037803l.08925007.0039664c-.05062028 0-.10036209-.0037612-.14896122-.0110193-.01698779-.0026088-.03441404-.0056829-.05176454-.0092208-.02202032-.0043997-.04371072-.0095935-.06511385-.0154809-.01562367-.0043767-.03101173-.0090077-.04630291-.0140171-.01965516-.0063844-.03943668-.0135776-.058916-.0213659-.01773713-.0070924-.03503998-.014575-.05216303-.0225694-.02066985-.0097032-.0410724-.0201205-.0610554-.0312024-.01211749-.006623-.02433616-.0137311-.0364318-.0211197-.0255662-.0157232-.05042194-.0324946-.07445055-.050318-.00744374-.0054399-.01468311-.010971-.02186305-.0166142-.0631594-.049624-.12042594-.1068905-.17019169-.1703222l.08010726.0903567c-.03539405-.0353941-.06758027-.0727812-.09655864-.1118002-.01784449-.0241759-.03461588-.0490316-.05026715-.0746464-.00746051-.0120471-.0145686-.0242658-.02139626-.0365981-.01087725-.0197682-.02129453-.0401707-.03101739-.060963-.00797473-.0170006-.01545736-.0343035-.02242829-.0517631-.00790975-.0197568-.015103-.0395383-.02167881-.0595996-.00481796-.0148851-.00944895-.0302731-.01370154-.0457434-.00601151-.0215565-.01120534-.0432469-.01567999-.0651989-.00346298-.0174188-.00653707-.0348451-.00914735-.0523272-.00160026-.010231-.00303174-.021012-.00429007-.0318458l-.00276132-.027371c-.00207143-.0232552-.00333152-.0465691-.00378026-.0698956l-.00018615-.0193545v-5c0-.5522847.44771525-1 1-1 .51283584 0 .93550716.3860402.99327227.8833789l.00672773.1166211v2.584l5.29289322-5.2911068c.39052429-.3905243 1.02368928-.3905243 1.41421358 0zm9.2928932-3.2928932v10h-10v-2h8v-8zm-6-6v2h-8v7h-2v-9zm7-2 .0193545.00018615c.0233265.00044874.0466404.00170883.0698956.00378026l-.0892501-.00396641c.0506203 0 .1003621.00376119.1489612.01101934.0169878.00260874.0344141.00568283.0517646.00922073.0220203.00439973.0437107.00959356.0651138.0154809.0156237.00437676.0310117.00900775.0463029.01401712.0196552.0063844.0394367.01357765.058916.02136587.0177371.00709246.03504.01457509.052163.0225694.0206699.00970328.0410724.02012056.0610555.03120241.0121174.00662306.0243361.01373115.0364318.02111968.0255662.01572325.0504219.03249464.0744505.05031806.0074437.00543993.0146831.01097097.021863.01661418.0631595.04962402.120426.10689056.1701917.17032223l-.0801072-.0903567c.035394.03539405.0675802.0727812.0965586.11180017.0178445.02417592.0346159.04903166.0502672.07464642.0074605.01204708.0145686.02426575.0213962.03659809.0108773.01976815.0212946.0401707.0310174.06096295.0079748.01700065.0154574.0343035.0224283.05176313.0079098.01975682.015103.03953834.0216788.05959961.004818.01488507.009449.03027313.0137016.04574344.0060115.02155649.0112053.04324689.0156799.06519887.003463.01741884.0065371.03484509.0091474.05232723.0016003.01023098.0030317.02101195.0042901.03184574l.0030256.03039033c.0015457.01796531.0026074.03596443.003185.05397618l.0005171.03225462v5c0 .55228475-.4477153 1-1 1-.5128358 0-.9355072-.38604019-.9932723-.88337887l-.0067277-.11662113v-2.586l-5.2928932 5.2931068c-.3905243.3905243-1.0236893.3905243-1.4142136 0-.3604839-.360484-.3882135-.92771504-.0831886-1.32000624l.0831886-.09420734 5.2911068-5.29289322h-2.584c-.5128358 0-.9355072-.38604019-.9932723-.88337887l-.0067277-.11662113c0-.51283584.3860402-.93550716.8833789-.99327227l.1166211-.00672773z"
+            fill="#inherit"
+        />
+    </svg>
+)
+
+const Template = args => <Button {...args} />
+
+export const Basic = Template.bind({})
+Basic.args = {
+    name: 'Basic button',
+}
+
+export const Primary = Template.bind({})
+Primary.args = {
+    primary: true,
+    name: 'Primary button',
+}
+Primary.parameters = {
+    docs: {
+        description: {
+            story:
+                'Used to highlight the most important/main action on a page. \
+                A "Save" button for a form page should be primary, for example. \
+                Use sparingly, rarely should there be more than a single primary \
+                button per page.',
+        },
+    },
+}
+
+export const Secondary = Template.bind({})
+Secondary.args = {
+    secondary: true,
+    name: 'Secondary button',
+}
+Secondary.parameters = {
+    docs: {
+        description: {
+            story:
+                'Used for passive actions, often as an alternative to the primary \
+                action. If "Save" is primary, "Cancel" could be secondary. \
+                Not intended to draw user attention. Do not use for the only \
+                action on a page.',
+        },
+    },
+}
+
+export const Destructive = Template.bind({})
+Destructive.args = {
+    destructive: true,
+    name: 'Destructive button',
+}
+Destructive.parameters = {
+    docs: {
+        description: {
+            story:
+                'Used instead of a primary button when the main action is \
+                destructive in nature. Used to highlight to the user the \
+                seriousness of the action. \
+                **Destructive buttons must only be used for destructive actions.**',
+        },
+    },
+}
+
+export const Disabled = args => (
+    <>
+        <Button name="Disabled button" {...args} />
+        <Button primary name="Disabled primary button" {...args} />
+        <Button secondary name="Disabled button" {...args} />
+        <Button destructive name="Disabled button" {...args} />
+    </>
+)
+Disabled.args = {
+    disabled: true,
+}
+Disabled.parameters = {
+    docs: {
+        description: {
+            story:
+                "Use disabled buttons when an action is being prevented for some reason. \
+                Always communicate to the user why the button can't be clicked. This can \
+                be done through a tooltip on hover, or with supplementary text underneath \
+                the button. Do not change the button label between disabled/enabled states.",
+        },
+    },
+}
+
+export const Small = Template.bind({})
+Small.args = {
+    small: true,
+    name: 'Small button',
+}
+Small.parameters = {
+    docs: {
+        description: {
+            story:
+                'Buttons are available in three sizes: `small`, `medium`, and `large`. \
+                Medium is usually the correct choice.  Use small buttons in an information-\
+                dense ui.',
+        },
+    },
+}
+
+export const Large = Template.bind({})
+Large.args = {
+    large: true,
+    name: 'Large button',
+}
+Large.parameters = {
+    docs: {
+        description: {
+            story:
+                'Buttons are available in three sizes: `small`, `medium`, and `large`. \
+                Medium is usually the correct choice.  Large buttons can be used on very simple, \
+                single-action pages.',
+        },
+    },
+}
+
+export const InitialFocus = Template.bind({})
+InitialFocus.args = {
+    initialFocus: true,
+    name: 'Focused button',
+}
+// When enabled, this story grabs focus every time a control is changed
+// in the docs page. Disabled for better UX
+InitialFocus.parameters = { docs: { disable: true } }
+
+export const Icon = Template.bind({})
+Icon.args = {
+    icon: DemoIcon,
+    name: 'Icon button',
+    children: null,
+}
+Icon.parameters = {
+    docs: {
+        description: {
+            story:
+                'Icons can be included in Basic, Primary, Secondary and Destructive buttons. \
+                Use an icon to supplement the text label. Remember that the user may not be \
+                fluent in the working language, so an accompanying icon on an important action \
+                can be a welcome addition. Buttons with icons only should be used for \
+                supplementary actions and should include a text tooltip on hover.',
+        },
+    },
+}
+
+export const IconSmall = Template.bind({})
+IconSmall.args = {
+    icon: DemoIcon,
+    small: true,
+    name: 'Icon small button',
+    children: null,
+}
+
+export const Toggled = Template.bind({})
+Toggled.args = {
+    toggled: true,
+    icon: DemoIcon,
+    name: 'Toggled button',
+    children: null,
+}
+Toggled.parameters = {
+    docs: {
+        description: {
+            story:
+                'A button can represent an on/off state using the toggle option. \
+                Use a toggle button when the user can enable or disable an option and \
+                a checkbox or switch is not suitable. This will most often be in the case of \
+                a toolbar, such as bold or italic options in a text editing toolbar. \
+                A toggle button in this example uses an icon and does not need text. \
+                A text label should be provided in a tooltip on hover. The toggle option \
+                is available for basic and secondary type buttons.',
+        },
+    },
+}
+
+export const ToggledDisabled = Template.bind({})
+ToggledDisabled.args = {
+    toggled: true,
+    disabled: true,
+    icon: DemoIcon,
+    name: 'Toggled button',
+    children: null,
+}

--- a/packages/elements/src/button/button.styles.js
+++ b/packages/elements/src/button/button.styles.js
@@ -1,0 +1,252 @@
+import { colors, theme, spacers } from '@dhis2/ui-constants'
+import css from 'styled-jsx/css'
+
+export default css`
+    button {
+        display: inline-flex;
+        position: relative;
+        align-items: center;
+        justify-content: center;
+        border-radius: 4px;
+        font-weight: 400;
+        letter-spacing: 0.5px;
+        text-decoration: none;
+        cursor: pointer;
+        transition: all 0.15s cubic-bezier(0.4, 0, 0.6, 1);
+        user-select: none;
+        color: ${colors.grey900};
+
+        /*medium*/
+        height: 36px;
+        padding: 0 ${spacers.dp12};
+        font-size: 14px;
+        line-height: 16px;
+
+        /*basic*/
+        border: 1px solid ${colors.grey500};
+        background-color: #f9fafb;
+    }
+
+    button:disabled {
+        cursor: not-allowed;
+    }
+
+    button:focus {
+        /* Prevent default browser behavior which adds an outline */
+        outline: none;
+    }
+
+    /* Use the ::after pseudo-element for focus styles */
+    button::after {
+        content: ' ';
+        pointer-events: none;
+
+        position: absolute;
+        top: -2px;
+        right: -2px;
+        bottom: -2px;
+        left: -2px;
+        z-index: 1;
+
+        border: 2px solid transparent;
+        border-radius: inherit;
+
+        transition: border-color 0.15s cubic-bezier(0.4, 0, 0.6, 1);
+    }
+
+    /* Prevent focus styles on active and disabled buttons */
+    button:active:focus::after,
+    button:disabled:focus::after {
+        border-color: transparent;
+    }
+
+    button:hover {
+        border-color: ${colors.grey500};
+        background-color: ${colors.grey200};
+    }
+
+    button:active,
+    button:active:focus {
+        border-color: ${colors.grey500};
+        background-color: ${colors.grey200};
+        box-shadow: 0 0 0 1px rgb(0, 0, 0, 0.1) inset;
+    }
+
+    button:focus {
+        background-color: #f9fafb;
+    }
+
+    button:focus::after {
+        border-color: ${theme.primary600};
+    }
+
+    button:disabled {
+        border-color: ${colors.grey400};
+        background-color: #f9fafb;
+        box-shadow: none;
+        color: ${theme.disabled};
+        fill: ${theme.disabled};
+    }
+
+    .small {
+        height: 28px;
+        padding: 0 8px;
+        font-size: 14px;
+        line-height: 16px;
+    }
+
+    .large {
+        height: 43px;
+        padding: 0 ${spacers.dp24};
+        font-size: 16px;
+        letter-spacing: 0.57px;
+        line-height: 19px;
+    }
+
+    .primary {
+        border-color: ${theme.primary800};
+        background: linear-gradient(180deg, #1565c0 0%, #0650a3 100%);
+        background-color: #2b61b3;
+        color: ${colors.white};
+        fill: ${colors.white};
+        font-weight: 500;
+    }
+
+    .primary:hover {
+        border-color: ${theme.primary800};
+        background: linear-gradient(180deg, #054fa3 0%, #034793 100%);
+        background-color: #21539f;
+    }
+
+    .primary:active,
+    .primary:active:focus {
+        border-color: ${theme.primary800};
+        background: linear-gradient(180deg, #054fa3 0%, #034793 100%);
+        background-color: #1c4a90;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18) inset;
+    }
+
+    .primary:focus {
+        background: linear-gradient(180deg, #1565c0 0%, #0650a3 100%);
+        background-color: #285dac;
+    }
+
+    .primary:focus::after {
+        border-color: ${colors.yellow300};
+    }
+
+    .primary:disabled {
+        border-color: #93a6bd;
+        background: #b3c6de;
+        box-shadow: none;
+        color: ${colors.white};
+        fill: ${colors.white};
+    }
+
+    .secondary {
+        border-color: ${colors.grey400};
+        background-color: transparent;
+    }
+
+    .secondary:hover {
+        border-color: ${colors.grey400};
+        background-color: rgba(160, 173, 186, 0.08);
+    }
+
+    .secondary:active,
+    .secondary:active:focus {
+        border-color: ${colors.grey400};
+        background-color: rgba(160, 173, 186, 0.2);
+        box-shadow: none;
+    }
+
+    .secondary:focus {
+        background-color: transparent;
+    }
+
+    .secondary:focus::after {
+        border-color: ${theme.primary600};
+    }
+
+    .secondary:disabled {
+        border-color: ${colors.grey400};
+        background-color: transparent;
+        box-shadow: none;
+        color: ${theme.disabled};
+        fill: ${theme.disabled};
+    }
+
+    .destructive {
+        border-color: #a10b0b;
+        background: linear-gradient(180deg, #d32f2f 0%, #b71c1c 100%);
+        background-color: #b9242b;
+        color: ${colors.white};
+        fill: ${colors.white};
+        font-weight: 500;
+    }
+
+    .destructive:hover {
+        border-color: #a10b0b;
+        background: linear-gradient(180deg, #b81c1c 0%, #b80c0b 100%);
+        background-color: #ac0f1a;
+    }
+
+    .destructive:active,
+    .destructive:active:focus {
+        border-color: #a10b0b;
+        background: linear-gradient(180deg, #b81c1c 0%, #b80c0b 100%);
+        background-color: #ac101b;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18) inset;
+    }
+
+    .destructive:focus {
+        background: linear-gradient(180deg, #d32f2f 0%, #b71c1c 100%);
+        background-color: #b72229;
+    }
+
+    .destructive:focus:after {
+        border-color: #5e0303;
+    }
+
+    .destructive:disabled {
+        border-color: #c59898;
+        background: #d6a8a8;
+        box-shadow: none;
+        color: ${colors.white};
+        fill: ${colors.white};
+    }
+
+    .toggled {
+        background: ${colors.grey700};
+        border: 1px solid ${colors.grey900};
+        color: ${colors.grey050};
+        fill: ${colors.grey050};
+    }
+
+    .toggled:focus {
+        background: ${colors.grey800};
+        border: 1px solid ${colors.yellow300};
+    }
+
+    .toggled:hover {
+        background: ${colors.grey800};
+        border-color: ${colors.grey900};
+    }
+
+    .toggled:focus::after {
+        border-color: ${colors.yellow300};
+    }
+
+    .toggled:active,
+    .toggled:active:focus {
+        background: ${colors.grey900};
+        border-color: ${colors.grey900};
+    }
+
+    .toggled:disabled {
+        background: ${colors.grey500};
+        border-color: ${colors.grey600};
+        color: ${colors.grey050};
+        fill: ${colors.grey050};
+    }
+`

--- a/packages/elements/src/index.js
+++ b/packages/elements/src/index.js
@@ -1,0 +1,1 @@
+export { Button } from './button/button.component.js'

--- a/packages/elements/src/index.spec.js
+++ b/packages/elements/src/index.spec.js
@@ -1,0 +1,50 @@
+import { mount } from 'enzyme'
+
+import * as elements from './index.js'
+
+/**
+ * These tests must pass for all UI Elements.
+ */
+describe('UI Elements API consistency', () => {
+    for (const element in elements) {
+        const Component = elements[element]
+
+        describe(Component.displayName, () => {
+            test('default dataTest attribute', () => {
+                const wrapper = mount(<Component />)
+                const dataTest = wrapper.prop('dataTest')
+
+                expect(dataTest.startsWith('dhis2-uielements-')).toBe(true)
+            })
+
+            test('custom dataTest attribute', () => {
+                const dataTest = 'custom-data-test'
+                const wrapper = mount(<Component dataTest={dataTest} />)
+
+                expect(wrapper.prop('dataTest')).toEqual(dataTest)
+            })
+
+            test('custom props', () => {
+                const button = mount(<Component foo="bar" fuz={{buz: 'yikes'}} />)
+
+                expect(button.props().foo).toEqual('bar')
+                expect(button.props().fuz.buz).toEqual('yikes')
+            })
+
+            test('custom class', () => {
+                const wrapper = mount(<Component className="foobar" />)
+                const actual = wrapper.find('button')
+
+                expect(actual.hasClass('foobar')).toBe(true)
+            })
+
+            test('forwarded ref', () => {
+                const ref = React.createRef()
+                const wrapper = mount(<Component ref={ref}>foobar</Component>)
+
+                expect(wrapper.first().getElement().ref).toEqual(ref)
+            })
+        })
+    }
+})
+


### PR DESCRIPTION
Important: note that this deprecates ui-core but does not remove it. UI
Elements are also not included in the @dhis2/ui package nor in
Storybook.

## `@dhis2/ui-elements`

Worth exploring: https://github.com/dhis2/ui/tree/platonic-components/packages/elements/src

Adds the UI Elements package with an incomplete set of tests that are
intended to ensure that all the Element components comply to the
requirements.

Implements the Button using the UI Elements principles from the README.
This is the proposal of how an UI Element should be structured.

UI Elements will contain more components than exist in the Design
System, as we will need to divide each component into a set of UI
Elements.

We expect to have many UI Elements as we need to ensure that all our
higher level components (and more) can be composed using the UI
Elements.

Supersedes `@dhis2/ui-core`.

## Additional packages

```
src/packages
├── composes
├── constants
├── elements
├── forms
├── hooks
├── icons
├── layouts
└── ui
```

Among these, `composes`, `layouts`, `hooks` are new.

-   `@dhis2/ui-composes` supersedes widgets, as it covers all components that are composed. The antonym package for `elements`. The idea is that these components should be re-composable from another context, meaning that everything that is used to build these components should be available from e.g. `elements`, and `hooks`.
-    `@dhis2/ui-layouts` has been a long time coming (#27), but not completed yet.
-   `@dhis2/ui-hooks` to gather up the hooks we use for our composed components to build behavior.

## `@dhis2/ui` export structure

It is getting crowded so we may want to do something about the way we re-export everything, while still ensuring that consumers has one dependency in their project. The way we have it now, we cannot have multiple components with the same name. A blessing and a curse. This PR does nothing with this point; I figured it was worth writing down.

## Name conventions

To provide better support for automated tools, wider arrange of
developer environments, and be predictable, the name conventions
changes.

PascalCasing and camelCasing are reserved for source code use. The file
system should be kebab-case.

In the future, conventions will be enforced through linting.

These are the conventions applied:

-   directories should always be kebab-case

-   a component is organized into a subfolder with it's name:
    src/{component}

-   component files should be kebab-case with the suffix:
    src/{component}/{component}.component.js

-   component styles should have the suffix:
    src/{component}/{component}.styles.js

-   components stories should have the suffix:
    src/{component}/{component}.stories.js

-   component test files should have the suffix:
    src/{component}/{component}.spec.js

-   in case of multiple specs, they can be in subdirectory for the
    component named:
    src/{component}/tests

    -   test files under tests/ do not need the component as prefix

-   component feature files go in a subdirectory of the component:
    src/{component}/features

## TODO

-   [ ] Get Storybook working again.
-   [ ] Make an example `ui-composes` component.