### PR TITLE
fix: address accessibility issues in core components

### DIFF
--- a/packages/core/src/Radio/Radio.js
+++ b/packages/core/src/Radio/Radio.js
@@ -113,9 +113,6 @@ class Radio extends Component {
                         flex-direction: row;
                         align-items: center;
                         justify-content: flex-start;
-                        cursor: pointer;
-                        pointer-events: all;
-                        user-select: none;
                         color: ${colors.grey900};
                         font-size: 16px;
                         line-height: 20px;
@@ -133,12 +130,23 @@ class Radio extends Component {
 
                     input {
                         opacity: 0;
-                        pointer-events: none;
                         position: absolute;
+
+                        /* The same size as the icon */
+                        height: 18px;
+                        width: 18px;
+
+                        /* The same offset as the icon, 2px border, 1px padding */
+                        left: 3px;
+                    }
+
+                    label.dense input {
+                        /* The same size as the dense icon */
+                        height: 14px;
+                        width: 14px;
                     }
 
                     .icon {
-                        pointer-events: none;
                         user-select: none;
                         margin-right: ${label ? '5px' : 0};
                         border: 2px solid transparent;

--- a/packages/core/src/Switch/Switch.js
+++ b/packages/core/src/Switch/Switch.js
@@ -53,7 +53,8 @@ class Switch extends Component {
 
     render() {
         const {
-            checked = false,
+            ariaLabel,
+            checked,
             className,
             disabled,
             error,
@@ -65,6 +66,7 @@ class Switch extends Component {
             warning,
             dense,
             dataTest,
+            role,
         } = this.props
 
         const classes = cx({
@@ -85,7 +87,9 @@ class Switch extends Component {
                 data-test={dataTest}
             >
                 <input
+                    aria-label={ariaLabel}
                     type="checkbox"
+                    role={role}
                     ref={this.ref}
                     name={name}
                     value={value}
@@ -109,9 +113,6 @@ class Switch extends Component {
                         flex-direction: row;
                         align-items: center;
                         justify-content: flex-start;
-                        cursor: pointer;
-                        pointer-events: all;
-                        user-select: none;
                         color: ${colors.grey900};
                         font-size: 16px;
                         line-height: 20px;
@@ -129,12 +130,23 @@ class Switch extends Component {
 
                     input {
                         opacity: 0;
-                        pointer-events: none;
                         position: absolute;
+
+                        /* The same size as the icon */
+                        height: 18px;
+                        width: 35px;
+
+                        /* The same offset as the icon, 2px border, 1px padding */
+                        margin-left: 3px;
+                    }
+
+                    label.dense input {
+                        /* The same size as the dense icon */
+                        height: 14px;
+                        width: 27px;
                     }
 
                     .icon {
-                        pointer-events: none;
                         user-select: none;
                         margin-right: 5px;
                         border: 2px solid transparent;
@@ -157,16 +169,20 @@ class Switch extends Component {
 }
 
 Switch.defaultProps = {
+    checked: false,
     dataTest: 'dhis2-uicore-switch',
+    role: 'switch',
 }
 
 /**
  * @typedef {Object} PropTypes
  * @static
+ * @prop {string} [ariaLabel]
  * @prop {string} [value]
  * @prop {Node} [label]
  * @prop {function} [onChange] - called with the signature `object, event`
  * @prop {string} [name]
+ * @prop {string} [role]
  * @prop {string} [className]
  * @prop {string} [tabIndex]
  *
@@ -186,6 +202,7 @@ Switch.defaultProps = {
  * @prop {string} [dataTest]
  */
 Switch.propTypes = {
+    ariaLabel: propTypes.string,
     checked: propTypes.bool,
     className: propTypes.string,
     dataTest: propTypes.string,
@@ -195,6 +212,7 @@ Switch.propTypes = {
     initialFocus: propTypes.bool,
     label: propTypes.node,
     name: propTypes.string,
+    role: propTypes.string,
     tabIndex: propTypes.string,
     valid: sharedPropTypes.statusPropType,
     value: propTypes.string,


### PR DESCRIPTION
See: https://jira.dhis2.org/browse/LIBS-162

This changes the inputs on our custom radio and switch input components to accept clicks. If we block clicks on them accessibility is hindered, since that's usually what will be targeted for clicks.

It also sets an appropriate default aria role for the switch, and accepts an aria label. Since a switch sometimes doesn't have a visible label, there should be an aria-label to identify it (https://www.w3.org/TR/WCAG20-TECHS/ARIA14.html).