### PR TITLE
chore: merge alpha to master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "root",
-    "version": "6.5.7",
+    "version": "6.6.0-alpha.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/dhis2/ui.git"

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/ui-constants",
-    "version": "6.5.7",
+    "version": "6.6.0-alpha.1",
     "description": "Constants used in the UI libs",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@dhis2/ui-core",
     "description": "Component primitives for DHIS2 user interfaces",
-    "version": "6.5.7",
+    "version": "6.6.0-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {
@@ -25,7 +25,7 @@
         "build": "d2-app-scripts build"
     },
     "peerDependencies": {
-        "@dhis2/ui-constants": "6.5.7",
+        "@dhis2/ui-constants": "6.6.0-alpha.1",
         "react": "^16.8",
         "react-dom": "^16.8",
         "styled-jsx": "^3.2"

--- a/packages/core/src/Checkbox/Checkbox.js
+++ b/packages/core/src/Checkbox/Checkbox.js
@@ -66,8 +66,8 @@ class Checkbox extends Component {
 
     render() {
         const {
-            checked = false,
-            indeterminate = false,
+            checked,
+            indeterminate,
             className,
             disabled,
             error,
@@ -129,8 +129,6 @@ class Checkbox extends Component {
                         align-items: center;
                         justify-content: flex-start;
                         cursor: pointer;
-                        pointer-events: all;
-                        user-select: none;
                         color: ${colors.grey900};
                         font-size: 16px;
                         line-height: 20px;
@@ -148,12 +146,21 @@ class Checkbox extends Component {
 
                     input {
                         opacity: 0;
-                        pointer-events: none;
                         position: absolute;
+                        /* The same size as the icon */
+                        height: 18px;
+                        width: 18px;
+                        /* The same offset as the icon, 2px border, 1px padding */
+                        left: 3px;
+                    }
+
+                    label.dense input {
+                        /* The same size as the dense icon */
+                        height: 14px;
+                        width: 14px;
                     }
 
                     .icon {
-                        pointer-events: none;
                         user-select: none;
                         margin-right: 5px;
                         border: 2px solid transparent;
@@ -176,6 +183,8 @@ class Checkbox extends Component {
 }
 
 Checkbox.defaultProps = {
+    checked: false,
+    indeterminate: false,
     dataTest: 'dhis2-uicore-checkbox',
 }
 

--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -116,6 +116,7 @@ export class Input extends Component {
 
     render() {
         const {
+            role,
             className,
             type,
             dense,
@@ -138,6 +139,7 @@ export class Input extends Component {
         return (
             <div className={cx('input', className)} data-test={dataTest}>
                 <input
+                    role={role}
                     id={name}
                     name={name}
                     placeholder={placeholder}
@@ -192,6 +194,7 @@ Input.defaultProps = {
  * @typedef {Object} PropTypes
  * @static
  *
+ * @prop {string} [role]
  * @prop {string} name
  * @prop {string} [type=text]
  * @prop {function} [onChange] - called with the signature `object, event`
@@ -241,6 +244,8 @@ Input.propTypes = {
     placeholder: PropTypes.string,
     /** Makes the input read-only */
     readOnly: PropTypes.bool,
+    /** Sets a role attribute on the input */
+    role: PropTypes.string,
     /** The [native `step` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefstep), for use when `type` is `'number'` */
     step: PropTypes.string,
     tabIndex: PropTypes.string,

--- a/packages/core/src/Radio/Radio.js
+++ b/packages/core/src/Radio/Radio.js
@@ -113,9 +113,6 @@ class Radio extends Component {
                         flex-direction: row;
                         align-items: center;
                         justify-content: flex-start;
-                        cursor: pointer;
-                        pointer-events: all;
-                        user-select: none;
                         color: ${colors.grey900};
                         font-size: 16px;
                         line-height: 20px;
@@ -133,12 +130,23 @@ class Radio extends Component {
 
                     input {
                         opacity: 0;
-                        pointer-events: none;
                         position: absolute;
+
+                        /* The same size as the icon */
+                        height: 18px;
+                        width: 18px;
+
+                        /* The same offset as the icon, 2px border, 1px padding */
+                        left: 3px;
+                    }
+
+                    label.dense input {
+                        /* The same size as the dense icon */
+                        height: 14px;
+                        width: 14px;
                     }
 
                     .icon {
-                        pointer-events: none;
                         user-select: none;
                         margin-right: ${label ? '5px' : 0};
                         border: 2px solid transparent;

--- a/packages/core/src/Switch/Switch.js
+++ b/packages/core/src/Switch/Switch.js
@@ -53,7 +53,8 @@ class Switch extends Component {
 
     render() {
         const {
-            checked = false,
+            ariaLabel,
+            checked,
             className,
             disabled,
             error,
@@ -65,6 +66,7 @@ class Switch extends Component {
             warning,
             dense,
             dataTest,
+            role,
         } = this.props
 
         const classes = cx({
@@ -85,7 +87,9 @@ class Switch extends Component {
                 data-test={dataTest}
             >
                 <input
+                    aria-label={ariaLabel}
                     type="checkbox"
+                    role={role}
                     ref={this.ref}
                     name={name}
                     value={value}
@@ -109,9 +113,6 @@ class Switch extends Component {
                         flex-direction: row;
                         align-items: center;
                         justify-content: flex-start;
-                        cursor: pointer;
-                        pointer-events: all;
-                        user-select: none;
                         color: ${colors.grey900};
                         font-size: 16px;
                         line-height: 20px;
@@ -129,12 +130,23 @@ class Switch extends Component {
 
                     input {
                         opacity: 0;
-                        pointer-events: none;
                         position: absolute;
+
+                        /* The same size as the icon */
+                        height: 18px;
+                        width: 35px;
+
+                        /* The same offset as the icon, 2px border, 1px padding */
+                        margin-left: 3px;
+                    }
+
+                    label.dense input {
+                        /* The same size as the dense icon */
+                        height: 14px;
+                        width: 27px;
                     }
 
                     .icon {
-                        pointer-events: none;
                         user-select: none;
                         margin-right: 5px;
                         border: 2px solid transparent;
@@ -157,16 +169,20 @@ class Switch extends Component {
 }
 
 Switch.defaultProps = {
+    checked: false,
     dataTest: 'dhis2-uicore-switch',
+    role: 'switch',
 }
 
 /**
  * @typedef {Object} PropTypes
  * @static
+ * @prop {string} [ariaLabel]
  * @prop {string} [value]
  * @prop {Node} [label]
  * @prop {function} [onChange] - called with the signature `object, event`
  * @prop {string} [name]
+ * @prop {string} [role]
  * @prop {string} [className]
  * @prop {string} [tabIndex]
  *
@@ -186,6 +202,8 @@ Switch.defaultProps = {
  * @prop {string} [dataTest]
  */
 Switch.propTypes = {
+    /** Sets an aria-label attribute on the input */
+    ariaLabel: PropTypes.string,
     checked: PropTypes.bool,
     className: PropTypes.string,
     dataTest: PropTypes.string,
@@ -201,6 +219,8 @@ Switch.propTypes = {
     label: PropTypes.node,
     /** Name associated with the switch. Passed to event handlers in object */
     name: PropTypes.string,
+    /** Sets a role attribute on the input */
+    role: PropTypes.string,
     tabIndex: PropTypes.string,
     /** Applies 'valid' styles for validation feedback. Mutually exclusive with `error` and `warning` prop types */
     valid: sharedPropTypes.statusPropType,

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/ui-forms",
-    "version": "6.5.7",
+    "version": "6.6.0-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "sideEffects": [
@@ -28,7 +28,7 @@
         "build": "d2-app-scripts build"
     },
     "peerDependencies": {
-        "@dhis2/ui-core": "6.5.7",
+        "@dhis2/ui-core": "6.6.0-alpha.1",
         "react": "^16.8",
         "react-dom": "^16.8"
     },

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/ui-icons",
-    "version": "6.5.7",
+    "version": "6.6.0-alpha.1",
     "description": "Icons used in the UI libs",
     "main": "./build/cjs/react/index.js",
     "module": "./build/es/react/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/ui",
-    "version": "6.5.7",
+    "version": "6.6.0-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {
@@ -20,11 +20,11 @@
         "build": "d2-app-scripts build"
     },
     "dependencies": {
-        "@dhis2/ui-constants": "6.5.7",
-        "@dhis2/ui-icons": "6.5.7",
-        "@dhis2/ui-core": "6.5.7",
-        "@dhis2/ui-forms": "6.5.7",
-        "@dhis2/ui-widgets": "6.5.7"
+        "@dhis2/ui-constants": "6.6.0-alpha.1",
+        "@dhis2/ui-icons": "6.6.0-alpha.1",
+        "@dhis2/ui-core": "6.6.0-alpha.1",
+        "@dhis2/ui-forms": "6.6.0-alpha.1",
+        "@dhis2/ui-widgets": "6.6.0-alpha.1"
     },
     "peerDependencies": {
         "react": "^16.8",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/ui-widgets",
-    "version": "6.5.7",
+    "version": "6.6.0-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {
@@ -33,8 +33,8 @@
         "react": "^16.8",
         "react-dom": "^16.8",
         "styled-jsx": "^3.2",
-        "@dhis2/ui-core": "6.5.7",
-        "@dhis2/ui-constants": "6.5.7",
+        "@dhis2/ui-core": "6.6.0-alpha.1",
+        "@dhis2/ui-constants": "6.6.0-alpha.1",
         "@dhis2/app-runtime": "^2",
         "@dhis2/d2-i18n": "^1"
     },


### PR DESCRIPTION
The `merge-alpha-to-master` branch has been branched off my local master, which I merged alpha into (after solving the merge conflicts). Normally I'd just push my master, but that's not possible due to our required status checks on master.

So this seems like the next best thing. I'm not sure if this will mess with history though (for semantic release), so I've requested a review from @varl, to double check if this is our intended way to merge alpha into master.

p.s.: These changes have already been reviewed when they went into alpha (though technically the merge conflict resolutions haven't).