### PR TITLE
fix: don't set the global locale in the headerbar

### DIFF
--- a/packages/widgets/src/HeaderBar/HeaderBar.js
+++ b/packages/widgets/src/HeaderBar/HeaderBar.js
@@ -2,7 +2,6 @@ import { useDataQuery, useConfig } from '@dhis2/app-runtime'
 import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
-import i18n from '../locales/index.js'
 import Apps from './Apps.js'
 import { joinPath } from './joinPath.js'
 import { Logo } from './Logo.js'
@@ -50,13 +49,6 @@ export const HeaderBar = ({ appName, className }) => {
             defaultAction: getPath(app.defaultAction),
         }))
     }, [data])
-
-    if (!loading && !error) {
-        // TODO: This will run every render which is probably wrong!  Also, setting the global locale shouldn't be done in the headerbar
-        const locale = data.user.settings.keyUiLocale || 'en'
-        i18n.setDefaultNamespace('default')
-        i18n.changeLanguage(locale)
-    }
 
     return (
         <header className={className}>


### PR DESCRIPTION
[The app shell sets the global locale before rendering the application](https://github.com/dhis2/app-platform/blob/98a7a567d0732a421df19a97faa03f40192b678b/adapter/src/components/AuthBoundary.js#L16-L18) and so setting it in the headerbar should be redundant.