### PR TITLE
feat: add native list attribute to Input

### DIFF
--- a/packages/core/src/Input/Input.js
+++ b/packages/core/src/Input/Input.js
@@ -134,6 +134,7 @@ export class Input extends Component {
             min,
             step,
             dataTest,
+            list,
         } = this.props
 
         return (
@@ -163,6 +164,7 @@ export class Input extends Component {
                         warning,
                         'read-only': readOnly,
                     })}
+                    list={list}
                 />
 
                 <div className="status-icon">
@@ -232,6 +234,8 @@ Input.propTypes = {
     error: sharedPropTypes.statusPropType,
     /** The input grabs initial focus on the page */
     initialFocus: PropTypes.bool,
+    /** The [native `list` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdeflist) */
+    list: PropTypes.string,
     /** Adds a loading indicator beside the input */
     loading: PropTypes.bool,
     /** The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmax), for use when `type` is `'number'` */

--- a/packages/core/src/Input/Input.stories.js
+++ b/packages/core/src/Input/Input.stories.js
@@ -124,3 +124,16 @@ ValueTextOverflow.args = {
     dense: true,
     warning: true,
 }
+
+export const WithDatalist = () => (
+    <>
+        <Input list="colorsList" />
+        <datalist id="colorsList">
+            <option value="red" />
+            <option value="green" />
+            <option value="blue" />
+            <option value="yellow" />
+            <option value="grey" />
+        </datalist>
+    </>
+)

--- a/packages/widgets/src/InputField/InputField.js
+++ b/packages/widgets/src/InputField/InputField.js
@@ -42,6 +42,7 @@ class InputField extends React.Component {
             validationText,
             inputWidth,
             dataTest,
+            list,
         } = this.props
 
         return (
@@ -79,6 +80,7 @@ class InputField extends React.Component {
                         tabIndex={tabIndex}
                         initialFocus={initialFocus}
                         readOnly={readOnly}
+                        list={list}
                     />
                 </Box>
             </Field>
@@ -143,6 +145,8 @@ InputField.propTypes = {
     inputWidth: PropTypes.string,
     /** Label text for the input */
     label: PropTypes.string,
+    /** The [native `list` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdeflist) */
+    list: PropTypes.string,
     /** Adds a loading indicator beside the input */
     loading: PropTypes.bool,
     /** The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmax), for use when `type` is `'number'` */


### PR DESCRIPTION
This adds the [native `<input>` `list` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdeflist) to the `Input` and `InputField` components.