### PR TITLE
fix(dropdown button): adjust dropdown default position

### DIFF
--- a/packages/core/src/DropdownButton/DropdownButton.js
+++ b/packages/core/src/DropdownButton/DropdownButton.js
@@ -88,7 +88,7 @@ class DropdownButton extends Component {
                     <Layer onClick={this.onToggle} transparent>
                         <Popper
                             dataTest={`${dataTest}-popper`}
-                            placement="bottom-end"
+                            placement="bottom-start"
                             reference={this.anchorRef}
                         >
                             {component}


### PR DESCRIPTION
This PR fixes a bug in the `dropdown button` component. The default position of the dropdown content is changed to `bottom-start`, as opposed to `bottom-end`.