### PR TITLE
chore(eslint): add global overrides for stories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,16 +6,28 @@ const config = {
         cy: 'readonly',
         Cypress: 'readonly',
     },
+    overrides: [
+        {
+            files: ['*.stories.js'],
+            rules: {
+                'import/no-extraneous-dependencies': 'off',
+                'react/display-name': 'off',
+                'react/prop-types': 'off',
+            },
+        },
+    ],
 }
 
 // Run cpu intensive checks only on CI
 const isCI = !!process.env.CI
 
 if (isCI) {
-    config.rules = {
-        'import/no-cycle': 'error',
-        'import/no-self-import': 'error',
+    if (!config.rules) {
+        config.rules = {}
     }
+
+    config.rules['import/no-cycle'] = 'error'
+    config.rules['import/no-self-import'] = 'error'
 }
 
 module.exports = config

--- a/packages/core/src/CssReset/CssReset.stories.js
+++ b/packages/core/src/CssReset/CssReset.stories.js
@@ -12,7 +12,6 @@ import { CssReset } from '@dhis2/ui'
 \`\`\`
 `
 
-// eslint-disable-next-line react/prop-types
 const App = ({ children }) => <div>{children}</div>
 
 export default {

--- a/packages/core/src/CssVariables/CssVariables.stories.js
+++ b/packages/core/src/CssVariables/CssVariables.stories.js
@@ -9,7 +9,6 @@ import { CssVariables } from '@dhis2/ui'
 \`\`\`
 `
 
-// eslint-disable-next-line react/prop-types
 const App = ({ children }) => <div>{children}</div>
 
 export default {

--- a/packages/core/src/FlyoutMenu/FlyoutMenu.stories.js
+++ b/packages/core/src/FlyoutMenu/FlyoutMenu.stories.js
@@ -196,7 +196,6 @@ DropDownMenu.parameters = {
 export const WithCustomMenuItem = args => {
     // You should not create custom components in the render cycle
     // this is just for demo purposes
-    // eslint-disable-next-line react/prop-types
     const PopupWindowMenuItem = ({ to, children, ...rest }) => {
         const HEIGHT = 1000
         const WIDTH = 1400

--- a/packages/core/src/Logo/Logo.stories.js
+++ b/packages/core/src/Logo/Logo.stories.js
@@ -11,7 +11,6 @@ import { Logo, LogoWhite, LogoIcon, LogoIconWhite } from '@dhis2/ui'
 
 const Wrapper = fn => <div style={{ width: '358px' }}>{fn()}</div>
 
-// eslint-disable-next-line react/prop-types
 const Background = ({ children }) => (
     <div style={{ backgroundColor: '#276696' }}>{children}</div>
 )

--- a/packages/widgets/src/OrganisationUnitTree/OrganisationUnitTree.stories.js
+++ b/packages/widgets/src/OrganisationUnitTree/OrganisationUnitTree.stories.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/no-unescaped-entities,react/prop-types */
+/* eslint-disable react/no-unescaped-entities */
 import { CustomDataProvider, DataProvider } from '@dhis2/app-runtime'
 import React, { useEffect, useState } from 'react'
 import { OrganisationUnitTree } from './OrganisationUnitTree.js'

--- a/packages/widgets/src/Transfer/Transfer.stories.js
+++ b/packages/widgets/src/Transfer/Transfer.stories.js
@@ -25,7 +25,7 @@ here's an explanation of their meaning:
 
 - source options: These are options listed on the left and are available for selection
 - picked options: These options have been selected by the user and are on the right side
-- highlighted option: These are visually highlighted options than can be on either side and are ready for transferral with the action buttons to the other side  
+- highlighted option: These are visually highlighted options than can be on either side and are ready for transferral with the action buttons to the other side
 - filtered options: These are the displayed source options filtered by a search term or a custom search algorithm. The api surface uses "selected" for "picked" to be consistent with the rest of the library
 
 #### More details
@@ -276,7 +276,6 @@ IndividualCustomOption.args = {
     addIndividualText: 'Add individual',
     removeAllText: 'Remove all',
     removeIndividualText: 'Remove individual',
-    // eslint-disable-next-line react/display-name
     renderOption: option => {
         if (option.value === options[0].value) {
             return renderOption(option)
@@ -353,7 +352,6 @@ const createCustomFilteringInHeader = hideFilterInput => {
 
     const allOptions = [...relativePeriods, ...fixedPeriods]
 
-    /* eslint-disable react/prop-types */
     const Header = ({
         onClick,
         relativePeriod,
@@ -444,7 +442,6 @@ const createCustomFilteringInHeader = hideFilterInput => {
         )
     }
 
-    // eslint-disable-next-line react/display-name, react/prop-types
     return ({ initiallySelected, ...args }) => {
         const [selected, setSelected] = useState(initiallySelected)
         const onChange = payload => setSelected(payload.selected)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,10 +1846,10 @@
     handlebars "^4.5.3"
     isbinaryfile "^4.0.2"
 
-"@dhis2/cli-style@^8.0.0-alpha.10":
-  version "8.0.0-alpha.10"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-8.0.0-alpha.10.tgz#e4b1f256fa0be27fdc5c5873387cf221da084ea4"
-  integrity sha512-e03wrPHszymH/TpDp7Hx16JYnoykoocOxl+DPcxr4RlbSxdxIT+m+rfS/XyJnGYWbbmcmN1pLTpIuNpg/K75OA==
+"@dhis2/cli-style@^8.0.0":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-8.1.1.tgz#0cd0c9ab3dcafa3864faaf8a27cb25b8f7c6eaf0"
+  integrity sha512-0KOWXEvMH5lQE72n/a/Yt1CgSbcyifJsFZ6/SJTeeU9Y4GlkC1nkj98bt5dNIsZdEOb2M7Pp9bsaNIvvI9bXkQ==
   dependencies:
     "@commitlint/cli" "^11.0.0"
     "@commitlint/config-conventional" "^11.0.0"
@@ -1865,6 +1865,7 @@
     find-up "^5.0.0"
     fs-extra "^9.1.0"
     husky "^5.2.0"
+    micromatch "^4.0.4"
     perfy "^1.1.5"
     prettier "^2.2.1"
     semver "^7.3.4"
@@ -13572,6 +13573,14 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
+micromatch@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  dependencies:
+    braces "^3.0.1"
+    picomatch "^2.2.3"
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -14853,6 +14862,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
 pify@^2.0.0, pify@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
Follow up for the cli-style v8 PR. This adds global overrides for rules that we've been overriding on an ad hoc basis for stories. Since they don't really make sense for stories, I feel it's cleaner to just disable them globally.

Minor fix is the yarn lock update, which I snuck into this PR, apparently the cli-style alpha was still in there.