### PR TITLE
chore(d2-style): skip ignored files for linting

### DIFF
--- a/d2-style.config.js
+++ b/d2-style.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    patterns: {
+        js: [
+            '*.{js,jsx,ts,tsx}',
+            '!packages/icons/src/react/**/*.js',
+            '!packages/{widgets,forms}/src/locales/**/*.js',
+        ],
+        text: '*.{md,json,yml,html}',
+    },
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "devDependencies": {
         "@dhis2/app-runtime": "^2.7.1",
         "@dhis2/cli-app-scripts": "^5.7.2",
-        "@dhis2/cli-style": "^8.0.0",
+        "@dhis2/cli-style": "^8.2.0",
         "@dhis2/cli-utils-cypress": "^5.1.0",
         "@dhis2/cli-utils-docsite": "^2.0.2",
         "@dhis2/cypress-commands": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,10 +1846,10 @@
     handlebars "^4.5.3"
     isbinaryfile "^4.0.2"
 
-"@dhis2/cli-style@^8.0.0":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-8.1.1.tgz#0cd0c9ab3dcafa3864faaf8a27cb25b8f7c6eaf0"
-  integrity sha512-0KOWXEvMH5lQE72n/a/Yt1CgSbcyifJsFZ6/SJTeeU9Y4GlkC1nkj98bt5dNIsZdEOb2M7Pp9bsaNIvvI9bXkQ==
+"@dhis2/cli-style@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-8.2.0.tgz#a5921e3c96e6c234d1ce92617483f768c483bdf1"
+  integrity sha512-ypYoV/XXbRU2qDke0Ux2GQMnWNbYDVD4nNsooTVzXWKnCuUSfwUSey7MsMVz8hXz2w5yr33zdnQ1UBXUX6Xt1Q==
   dependencies:
     "@commitlint/cli" "^11.0.0"
     "@commitlint/config-conventional" "^11.0.0"


### PR DESCRIPTION
This uses what was introduced in https://github.com/dhis2/cli-style/pull/400 to omit ignored files from the files passed to eslint. This prevents the lint warning you'd otherwise get on running `yarn lint`.

See here for the lint step on CI, which doesn't log any warnings now: https://github.com/dhis2/ui/pull/585/checks?check_run_id=2557102715#step:7:17

Compared to master: https://github.com/dhis2/ui/runs/2547217632#step:7:17 (which usually logs even more if the icons are built)