### PR TITLE
feat(modal): add "hide" prop to prevent content from unmounting when hiding (WIP)

### DIFF
--- a/packages/core/src/Modal/Modal.js
+++ b/packages/core/src/Modal/Modal.js
@@ -31,6 +31,12 @@ const centeredContent = resolve`
     }
 `
 
+const layerStyles = resolve`
+    div {
+        background: none;
+    }
+`
+
 /**
  * @module
  * @param {Modal.PropTypes} props
@@ -62,49 +68,58 @@ const centeredContent = resolve`
  */
 export const Modal = ({
     children,
-    onClose,
-    small,
-    large,
     className,
-    position,
     dataTest,
-}) => (
-    <Layer onClick={onClose} level={layers.blocking} translucent>
-        <CenteredContent
-            position={position}
-            className={centeredContent.className}
+    hide,
+    large,
+    onClose,
+    position,
+    small,
+}) => {
+    return (
+        <Layer
+            onClick={onClose}
+            level={hide ? -1 : layers.blocking}
+            className={hide ? layerStyles.className : ''}
+            translucent={!hide}
         >
-            <aside
-                role="dialog"
-                aria-modal="true"
-                data-test={dataTest}
-                className={cx(className, { small, large })}
+            <CenteredContent
+                position={position}
+                className={centeredContent.className}
             >
-                <Card className={scrollBoxCard.className}>{children}</Card>
-            </aside>
-            {scrollBoxCard.styles}
-            {centeredContent.styles}
-        </CenteredContent>
+                <aside
+                    role="dialog"
+                    aria-modal="true"
+                    data-test={dataTest}
+                    className={cx(className, { small, large })}
+                >
+                    <Card className={scrollBoxCard.className}>{children}</Card>
+                </aside>
+                {scrollBoxCard.styles}
+                {layerStyles.styles}
+                {centeredContent.styles}
+            </CenteredContent>
 
-        <style jsx>{`
-            aside {
-                overflow-y: hidden;
-                height: auto;
-                max-height: calc(100vh - ${2 * spacersNum.dp64}px);
-                max-width: calc(100vw - ${2 * spacersNum.dp64}px);
-                width: 600px;
-            }
+            <style jsx>{`
+                aside {
+                    overflow-y: hidden;
+                    height: auto;
+                    max-height: calc(100vh - ${2 * spacersNum.dp64}px);
+                    max-width: calc(100vw - ${2 * spacersNum.dp64}px);
+                    width: 600px;
+                }
 
-            aside.small {
-                width: 400px;
-            }
+                aside.small {
+                    width: 400px;
+                }
 
-            aside.large {
-                width: 800px;
-            }
-        `}</style>
-    </Layer>
-)
+                aside.large {
+                    width: 800px;
+                }
+            `}</style>
+        </Layer>
+    )
+}
 
 Modal.defaultProps = {
     dataTest: 'dhis2-uicore-modal',
@@ -126,6 +141,7 @@ Modal.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
+    hide: PropTypes.bool,
     large: sharedPropTypes.sizePropType,
     position: sharedPropTypes.insideAlignmentPropType,
     small: sharedPropTypes.sizePropType,

--- a/packages/core/src/Modal/Modal.stories.e2e.js
+++ b/packages/core/src/Modal/Modal.stories.e2e.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/react'
-import React from 'react'
+import React, { useState } from 'react'
 import {
     Button,
     ButtonStrip,
@@ -10,6 +10,26 @@ import {
 import { Modal } from './Modal.js'
 
 window.onClose = window.Cypress && window.Cypress.cy.stub()
+
+const StatefuleComponent = () => {
+    const [counter, setCounter] = useState(0)
+
+    return (
+        <div>
+            <p>
+                Current counter:
+                <span id="counter-value">{counter}</span>
+            </p>
+
+            <button
+                id="increment-counter"
+                onClick={() => setCounter(counter + 1)}
+            >
+                Add 1 to counter
+            </button>
+        </div>
+    )
+}
 
 storiesOf('Modal', module)
     .add('With onClose', () => (
@@ -37,3 +57,28 @@ storiesOf('Modal', module)
         </Modal>
     ))
     .add('With children', () => <Modal>I am a child</Modal>)
+    .add('With stateful children', () => {
+        const [hide, setHide] = useState(false)
+
+        return (
+            <div>
+                <button id="show-modal" onClick={() => setHide(false)}>
+                    Show
+                </button>
+
+                <Modal hide={hide}>
+                    <ModalTitle>Can be hidden</ModalTitle>
+
+                    <ModalContent>
+                        <StatefuleComponent />
+                    </ModalContent>
+
+                    <ModalActions>
+                        <button id="hide-modal" onClick={() => setHide(true)}>
+                            Hide modal
+                        </button>
+                    </ModalActions>
+                </Modal>
+            </div>
+        )
+    })

--- a/packages/core/src/Modal/Modal.stories.js
+++ b/packages/core/src/Modal/Modal.stories.js
@@ -1,5 +1,5 @@
 import { sharedPropTypes } from '@dhis2/ui-constants'
-import React from 'react'
+import React, { useState } from 'react'
 import {
     Button,
     ButtonStrip,
@@ -738,3 +738,57 @@ export const LargeModalWithMoreNestedModals = args => (
 LargeModalWithMoreNestedModals.args = { large: true }
 LargeModalWithMoreNestedModals.storyName =
     'Large: modal with more nested modals'
+
+const StatefuleComponent = () => {
+    const [counter, setCounter] = useState(0)
+
+    return (
+        <div>
+            <p>Current counter: {counter}</p>
+            <button onClick={() => setCounter(counter + 1)}>
+                Add 1 to counter
+            </button>
+        </div>
+    )
+}
+
+export const ModalThatHidesWithStatefulComponens = () => {
+    const [render, setRender] = useState(false)
+    const [hide, setHide] = useState(false)
+
+    return (
+        <div>
+            <ButtonStrip>
+                <Button onClick={() => setHide(false)} disabled={!render}>
+                    Show the hidden modal
+                </Button>
+
+                <Button onClick={() => setRender(true)} disabled={render}>
+                    Render Modal
+                </Button>
+            </ButtonStrip>
+
+            {render && (
+                <Modal hide={hide}>
+                    <ModalTitle>Can be hidden</ModalTitle>
+
+                    <ModalContent>
+                        <StatefuleComponent />
+                    </ModalContent>
+
+                    <ModalActions>
+                        <ButtonStrip end>
+                            <Button onClick={() => setRender(false)} secondary>
+                                Close modal
+                            </Button>
+
+                            <Button onClick={() => setHide(true)} primary>
+                                Hide modal
+                            </Button>
+                        </ButtonStrip>
+                    </ModalActions>
+                </Modal>
+            )}
+        </div>
+    )
+}

--- a/packages/core/src/Modal/features/does_not_unmount_children_when_hiding.feature
+++ b/packages/core/src/Modal/features/does_not_unmount_children_when_hiding.feature
@@ -1,0 +1,12 @@
+Feature: The Modal does not unmount its children when hide is set to true
+
+    Scenario: A counter gets increased and keeps its value
+        Given a modal with a counter component is rendered
+        And the counter is 0
+        When the user increases the counter once
+        Then the counter should be 1
+        When the user hides the modal
+        Then the modal should not be visible
+        When the user shows the modal
+        Then the modal should be visible
+        And  the counter value should be one

--- a/packages/core/src/Modal/features/does_not_unmount_children_when_hiding/index.js
+++ b/packages/core/src/Modal/features/does_not_unmount_children_when_hiding/index.js
@@ -1,0 +1,37 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a modal with a counter component is rendered', () => {
+    cy.visitStory('Modal', 'With stateful children')
+})
+
+Given('the counter is 0', () => {
+    cy.get('#counter-value').contains('0')
+})
+
+When('the user increases the counter once', () => {
+    cy.get('#increment-counter').click()
+})
+
+When('the counter should be 1', () => {
+    cy.get('#counter-value').contains('1')
+})
+
+When('the user hides the modal', () => {
+    cy.get('#hide-modal').click()
+})
+
+Then('the modal should not be visible', () => {
+    cy.get('#hide-modal').should('not.be.visible')
+})
+
+Then('the user shows the modal', () => {
+    cy.get('#show-modal').click()
+})
+
+Then('the modal should be visible', () => {
+    cy.get('#hide-modal').should('be.visible')
+})
+
+Then('the counter value should be one', () => {
+    cy.get('#counter-value').contains('1')
+})


### PR DESCRIPTION
Fixed LIBS-182
([link](https://jira.dhis2.org/browse/LIBS-182))

This introduces a new layer: background (= `z-index: -1`).
That was needed to make the layer to into the background when hiding the Modal. Rendering the content in a hidden div instead of the Layer made the components unmount, so that's not an option unfortunately.

This introduces a new prop on the Layer: `transparent` (= `background: none`)
When the modal is hidden and the page does not have a background, the translucent background is still shown. `transparent` prevents that from happening, the prop has a higher priority than `translucent` so both props can be set (see usage of Layer in the implementation of the Modal component)