### PR TITLE
fix(header-bar): make email prop optional as in user schema

### DIFF
--- a/packages/widgets/src/HeaderBar/Profile.js
+++ b/packages/widgets/src/HeaderBar/Profile.js
@@ -81,8 +81,8 @@ export default class Profile extends React.Component {
 }
 
 Profile.propTypes = {
-    email: propTypes.string.isRequired,
     name: propTypes.string.isRequired,
     avatarUrl: propTypes.string,
+    email: propTypes.string,
     helpUrl: propTypes.string,
 }


### PR DESCRIPTION
Also see here:
https://play.dhis2.org/dev/api/schemas/user.json
```json
{
    "fieldName": "email",
    "simple": true,
    "required": false,
    "writable": true,
    "min": 0,
    "nameableObject": false,
    "klass": "java.lang.String",
    "propertyType": "EMAIL",
    "oneToOne": false,
    "oneToMany": false,
    "propertyTransformer": false,
    "attribute": false,
    "owner": true,
    "readable": true,
    "translatable": false,
    "ordered": false,
    "identifiableObject": false,
    "max": 160,
    "manyToMany": false,
    "length": 160,
    "collection": false,
    "gistPreferences": {
        "included": "AUTO",
        "transformation": "AUTO"
    },
    "analyticalObject": false,
    "embeddedObject": false,
    "unique": false,
    "name": "email",
    "namespace": "http://dhis2.org/schema/dxf/2.0",
    "persisted": true,
    "manyToOne": false
},
```