### PR TITLE
fix(organisation-unit-tree): handle filtering when units' children have not yet been loaded

### DIFF
--- a/components/organisation-unit-tree/src/compute-child-nodes.js
+++ b/components/organisation-unit-tree/src/compute-child-nodes.js
@@ -25,6 +25,10 @@ const isPathIncluded = (includedPaths, path) => {
  * @returns {string[]}
  */
 export const computeChildNodes = (node, filter) => {
+    if (!node.children) {
+        return []
+    }
+
     if (!filter.length) {
         return node.children
     }


### PR DESCRIPTION
When initially loading an organisation unit, the organisation unit tree will not request its `children` field and so when the `OrganisationUnitNode` component calls `computeChildNodes` (see below) `node.children` will be `undefined` resulting in an error.

https://github.com/dhis2/ui/blob/e21ae4ace1ba8931dd7a5eb0d96ab4f828efe07c/components/organisation-unit-tree/src/compute-child-nodes.js#L27-L38