### PR TITLE
Match border color with InputFields

### DIFF
--- a/components/transfer/src/common/styles.js
+++ b/components/transfer/src/common/styles.js
@@ -1,5 +1,5 @@
 import { colors } from '@dhis2/ui-constants'
 
 export const backgroundColor = colors.white
-export const borderColor = colors.grey400
+export const borderColor = colors.grey500
 export const borderRadius = '3px'


### PR DESCRIPTION
``Transfer`` and ``InputFields`` have a slightly different border color (``grey500`` vs ``grey400``) and looks strange when an interface combines them.

Since ``Transfer`` should be the least used component of both, changing to match the same border color of ``Input``.

![image](https://user-images.githubusercontent.com/2181866/123938565-833c7a80-d997-11eb-9b25-d4ff6f7834d7.png)

Note: The [design system page](https://github.com/dhis2/design-system/blob/master/organisms/transfer.md) should be probably updated?