### PR TITLE
fix(select): do not throw error when selected prop does not correspond to value of existing option

### DIFF
--- a/components/select/src/multi-select/features/invalid_selected.feature
+++ b/components/select/src/multi-select/features/invalid_selected.feature
@@ -1,0 +1,6 @@
+Feature: Invalid selections are ignored
+
+    Scenario: Some of the MultiSelect's selected values do not have a corresponding option
+        Given a MultiSelect with selected values that do not have a corresponding option
+        Then the valid selected values are rendered
+        And some errors are written to the console

--- a/components/select/src/multi-select/features/invalid_selected/index.js
+++ b/components/select/src/multi-select/features/invalid_selected/index.js
@@ -1,0 +1,28 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given(
+    'a MultiSelect with selected values that do not have a corresponding option',
+    () => {
+        cy.visitStory('MultiSelect', 'With some invalid selected options', {
+            onBeforeLoad(win) {
+                cy.stub(win.console, 'error').as('consoleError')
+            },
+        })
+    }
+)
+Then('the valid selected values are rendered', () => {
+    cy.get('[data-test="dhis2-uicore-select-input"]').should(
+        'contain',
+        'option three'
+    )
+})
+Then('some errors are written to the console', () => {
+    cy.get('@consoleError').should(
+        'be.calledWith',
+        'There is no option with the value: "1". Make sure that all the values passed to the selected prop match the value of an existing option.'
+    )
+    cy.get('@consoleError').should(
+        'be.calledWith',
+        'There is no option with the value: "2". Make sure that all the values passed to the selected prop match the value of an existing option.'
+    )
+})

--- a/components/select/src/multi-select/input.js
+++ b/components/select/src/multi-select/input.js
@@ -6,8 +6,28 @@ import {
     InputClearButton,
     InputPlaceholder,
     InputPrefix,
+    findOptionChild,
+    removeOption,
 } from '../select/index.js'
 import { SelectionList } from './selection-list.js'
+
+const createSelectedOption = ({ selected, onChange, value, options }) => {
+    const optionChild = findOptionChild(value, options)
+    if (optionChild) {
+        const { label, disabled } = optionChild.props
+        return {
+            value,
+            label,
+            disabled,
+            onRemove: (_, e) => {
+                const filtered = removeOption(value, selected)
+                const data = { selected: filtered }
+
+                onChange(data, e)
+            },
+        }
+    }
+}
 
 const Input = ({
     selected,
@@ -22,7 +42,25 @@ const Input = ({
     disabled,
     inputMaxHeight,
 }) => {
-    const hasSelection = selected.length > 0
+    const selectedOptions = []
+    for (const value of selected) {
+        const selectedOption = createSelectedOption({
+            selected,
+            onChange,
+            value,
+            options,
+        })
+        if (selectedOption) {
+            selectedOptions.push(selectedOption)
+        } else {
+            console.error(
+                `There is no option with the value: "${value}". ` +
+                    'Make sure that all the values passed to the selected ' +
+                    'prop match the value of an existing option.'
+            )
+        }
+    }
+    const hasSelection = selectedOptions.length > 0
     const onClear = (_, e) => {
         const data = { selected: [] }
 
@@ -43,9 +81,7 @@ const Input = ({
                 <div className="root-input">
                     {/* the wrapper div above is necessary to enforce wrapping on overflow */}
                     <SelectionList
-                        selected={selected}
-                        onChange={onChange}
-                        options={options}
+                        selectedOptions={selectedOptions}
                         disabled={disabled}
                     />
                 </div>

--- a/components/select/src/multi-select/multi-select.stories.e2e.js
+++ b/components/select/src/multi-select/multi-select.stories.e2e.js
@@ -334,6 +334,12 @@ storiesOf('MultiSelect', module)
             <MultiSelectOption value="3" label="option three" />
         </MultiSelect>
     ))
+    .add('With some invalid selected options', () => (
+        <MultiSelect className="select" selected={['1', '2', '3']}>
+            <MultiSelectOption value="3" label="option three" />
+            <MultiSelectOption value="4" label="option four" />
+        </MultiSelect>
+    ))
     .add('With options that can be added to the input', () => {
         const [values, setValues] = React.useState([])
         return (

--- a/components/select/src/multi-select/selection-list.js
+++ b/components/select/src/multi-select/selection-list.js
@@ -1,49 +1,22 @@
 import { Chip } from '@dhis2-ui/chip'
 import propTypes from '@dhis2/prop-types'
 import React from 'react'
-import { removeOption, findOptionChild } from '../select/index.js'
 
-const createRemoveHandler = ({ selected, onChange, value }) => (_, e) => {
-    const filtered = removeOption(value, selected)
-    const data = { selected: filtered }
-
-    onChange(data, e)
-}
-
-const SelectionList = ({ selected, onChange, disabled, options }) => (
+const SelectionList = ({ selectedOptions, disabled }) => (
     <React.Fragment>
-        {selected.map(value => {
-            const selectedOption = findOptionChild(value, options)
-
-            if (!selectedOption) {
-                const message =
-                    `There is no option with the value: "${value}". ` +
-                    'Make sure that all the values passed to the selected ' +
-                    'prop match the value of an existing option.'
-                throw new Error(message)
-            }
-
+        {selectedOptions.map(selectedOption => {
             // The chip should be disabled if the option or the select are disabled
-            const isDisabled = selectedOption.props.disabled || disabled
-
-            // Create an onRemove handler, but only if it's not disabled
-            const onRemove = isDisabled
-                ? undefined
-                : createRemoveHandler({
-                      selected,
-                      onChange,
-                      value,
-                  })
+            const isDisabled = selectedOption.disabled || disabled
 
             return (
                 <Chip
-                    key={value}
-                    onRemove={onRemove}
+                    key={selectedOption.value}
+                    onRemove={isDisabled ? undefined : selectedOption.onRemove}
                     disabled={isDisabled}
                     overflow
                     dense
                 >
-                    {selectedOption.props.label}
+                    {selectedOption.label}
                 </Chip>
             )
         })}
@@ -51,10 +24,15 @@ const SelectionList = ({ selected, onChange, disabled, options }) => (
 )
 
 SelectionList.propTypes = {
+    selectedOptions: propTypes.arrayOf(
+        propTypes.shape({
+            label: propTypes.string.isRequired,
+            value: propTypes.string.isRequired,
+            onRemove: propTypes.func.isRequired,
+            disabled: propTypes.bool,
+        })
+    ).isRequired,
     disabled: propTypes.bool,
-    options: propTypes.node,
-    selected: propTypes.arrayOf(propTypes.string),
-    onChange: propTypes.func,
 }
 
 export { SelectionList }

--- a/components/select/src/single-select/features/invalid_selected.feature
+++ b/components/select/src/single-select/features/invalid_selected.feature
@@ -1,0 +1,6 @@
+Feature: An invalid selection is ignored and the select will behave as if it has no selection
+
+    Scenario: The SingleSelect's selected value does not correspond to one of its options
+        Given a SingleSelect whose selected value does not correspond to one of its options
+        Then the SingleSelect is rendered as if no value is selected
+        And an error is written to the console

--- a/components/select/src/single-select/features/invalid_selected/index.js
+++ b/components/select/src/single-select/features/invalid_selected/index.js
@@ -1,4 +1,3 @@
-import '../common'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given(

--- a/components/select/src/single-select/features/invalid_selected/index.js
+++ b/components/select/src/single-select/features/invalid_selected/index.js
@@ -1,0 +1,24 @@
+import '../common'
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given(
+    'a SingleSelect whose selected value does not correspond to one of its options',
+    () => {
+        cy.visitStory('SingleSelect', 'With invalid selected option', {
+            onBeforeLoad(win) {
+                cy.stub(win.console, 'error').as('consoleError')
+            },
+        })
+    }
+)
+Then('the SingleSelect is rendered as if no value is selected', () => {
+    cy.get('[data-test="dhis2-uicore-singleselect-placeholder"]')
+        .contains('Placeholder text')
+        .should('be.visible')
+})
+Then('an error is written to the console', () => {
+    cy.get('@consoleError').should(
+        'be.calledWith',
+        'There is no option with the value: "1". Make sure that the value passed to the selected prop matches the value of an existing option.'
+    )
+})

--- a/components/select/src/single-select/input.js
+++ b/components/select/src/single-select/input.js
@@ -26,11 +26,11 @@ const Input = ({
     const hasSelection = typeof selected === 'string' && selected !== ''
     const selectedOption = hasSelection && findOptionChild(selected, options)
     if (hasSelection && !selectedOption) {
-        const message =
+        console.error(
             `There is no option with the value: "${selected}". ` +
-            'Make sure that the value passed to the selected ' +
-            'prop matches the value of an existing option.'
-        console.error(message)
+                'Make sure that the value passed to the selected ' +
+                'prop matches the value of an existing option.'
+        )
     }
     const onClear = (_, e) => {
         const data = { selected: '' }

--- a/components/select/src/single-select/input.js
+++ b/components/select/src/single-select/input.js
@@ -6,6 +6,7 @@ import {
     InputClearButton,
     InputPlaceholder,
     InputPrefix,
+    findOptionChild,
 } from '../select/index.js'
 import { Selection } from './selection.js'
 
@@ -22,7 +23,15 @@ const Input = ({
     disabled,
     inputMaxHeight,
 }) => {
-    const hasSelection = selected && typeof selected === 'string'
+    const hasSelection = typeof selected === 'string' && selected !== ''
+    const selectedOption = hasSelection && findOptionChild(selected, options)
+    if (hasSelection && !selectedOption) {
+        const message =
+            `There is no option with the value: "${selected}". ` +
+            'Make sure that the value passed to the selected ' +
+            'prop matches the value of an existing option.'
+        console.error(message)
+    }
     const onClear = (_, e) => {
         const data = { selected: '' }
 
@@ -33,19 +42,22 @@ const Input = ({
     return (
         <div className={cx('root', className)}>
             <InputPrefix prefix={prefix} dataTest={`${dataTest}-prefix`} />
-            {!hasSelection && !prefix && (
+            {!selectedOption && !prefix && (
                 <InputPlaceholder
                     placeholder={placeholder}
                     dataTest={`${dataTest}-placeholder`}
                 />
             )}
-            {hasSelection && (
+            {selectedOption && (
                 <div className="root-input">
                     {/* the wrapper div above is necessary to enforce wrapping on overflow */}
-                    <Selection selected={selected} options={options} />
+                    <Selection
+                        icon={selectedOption.props.icon}
+                        label={selectedOption.props.label}
+                    />
                 </div>
             )}
-            {hasSelection && clearable && !disabled && (
+            {selectedOption && clearable && !disabled && (
                 <div className="root-right">
                     <InputClearButton
                         onClear={onClear}

--- a/components/select/src/single-select/selection.js
+++ b/components/select/src/single-select/selection.js
@@ -1,50 +1,34 @@
-import propTypes from '@dhis2/prop-types'
 import { spacers } from '@dhis2/ui-constants'
 import cx from 'classnames'
+import PropTypes from 'prop-types'
 import React from 'react'
-import { findOptionChild } from '../select/index.js'
 
-const Selection = ({ options, selected, className }) => {
-    const selectedOption = findOptionChild(selected, options)
+const Selection = ({ icon, label, className }) => (
+    <div className={cx(className, 'root')}>
+        {icon && <div className="root-icon">{icon}</div>}
+        {label}
 
-    if (!selectedOption) {
-        const message =
-            `There is no option with the value: "${selected}". ` +
-            'Make sure that the value passed to the selected ' +
-            'prop matches the value of an existing option.'
-        throw new Error(message)
-    }
+        <style jsx>{`
+            .root {
+                display: flex;
+                align-items: center;
+                user-select: none;
+            }
 
-    const icon = selectedOption.props.icon
-    const label = selectedOption.props.label
-
-    return (
-        <div className={cx(className, 'root')}>
-            {icon && <div className="root-icon">{icon}</div>}
-            {label}
-
-            <style jsx>{`
-                .root {
-                    display: flex;
-                    align-items: center;
-                    user-select: none;
-                }
-
-                .root-icon {
-                    margin-right: ${spacers.dp8};
-                    width: ${spacers.dp16};
-                    height: ${spacers.dp16};
-                    overflow: hidden;
-                }
-            `}</style>
-        </div>
-    )
-}
+            .root-icon {
+                margin-right: ${spacers.dp8};
+                width: ${spacers.dp16};
+                height: ${spacers.dp16};
+                overflow: hidden;
+            }
+        `}</style>
+    </div>
+)
 
 Selection.propTypes = {
-    className: propTypes.string,
-    options: propTypes.node,
-    selected: propTypes.string,
+    className: PropTypes.string,
+    icon: PropTypes.node,
+    label: PropTypes.node,
 }
 
 export { Selection }

--- a/components/select/src/single-select/single-select.stories.e2e.js
+++ b/components/select/src/single-select/single-select.stories.e2e.js
@@ -331,6 +331,16 @@ storiesOf('SingleSelect', module)
             <SingleSelectOption value="3" label="option three" />
         </SingleSelect>
     ))
+    .add('With invalid selected option', () => (
+        <SingleSelect
+            className="select"
+            placeholder="Placeholder text"
+            selected="1"
+        >
+            <SingleSelectOption value="2" label="option two" />
+            <SingleSelectOption value="3" label="option three" />
+        </SingleSelect>
+    ))
     .add('Menu width changing', () => {
         const [toggle, setToggle] = useState(false)
         return (


### PR DESCRIPTION
Thanks to [recent work integrating `react-query`](https://github.com/dhis2/app-runtime/pull/824) into the app runtime, apps will soon be able to enable and take advantage of the stale-while-revalidate fetching strategy. Unfortunately, some of our components were not designed with SWR and background refresh in mind - including the select components `SingleSelect` and `MultiSelect`.

These components expect the value(s) of their `selected` prop to correspond to the value of a `SingleSelectOption`/`MultiSelectOption` and will throw an error if this is not the case. This assumption can fail under SWR in the case that the options (and hence the value of the `selected` prop) are generated based on fetched data:

```JSX
/*
 * If the current value of `selected` refers to an item that was previously present but has now
 * been removed on the backend - and background refresh results in `data` being updated - then
 * SingleSelect will throw an error.
 * 
 * One way to guard against this issue is to use
 * `selected={data.map(i => i.value).includes(selected) ? selected : ''}`
 */
const [selected, setSelected] = useState('')
const { data } = useDataQuery(someQuery)

<SingleSelect
  selected={selected}
  onChange={({ selected }) => setSelected(selected)}
>
  {data.map(item => <SingleSelectOption key={item.value} label={item.label} value={item.value} />)
</SingleSelect>
```