### PR TITLE
feat(button): Loading state

### DIFF
--- a/components/button/package.json
+++ b/components/button/package.json
@@ -32,6 +32,7 @@
     "dependencies": {
         "@dhis2-ui/layer": "6.14.0",
         "@dhis2-ui/popper": "6.14.0",
+        "@dhis2-ui/loader": "6.14.0",
         "@dhis2/prop-types": "^1.6.4",
         "@dhis2/ui-constants": "6.14.0",
         "@dhis2/ui-icons": "6.14.0",

--- a/components/button/src/button/button.js
+++ b/components/button/src/button/button.js
@@ -1,3 +1,4 @@
+import { CircularLoader } from '@dhis2-ui/loader'
 import { sharedPropTypes } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -24,6 +25,7 @@ export const Button = ({
     onBlur,
     onClick,
     onFocus,
+    loading,
 }) => {
     const ref = useRef()
 
@@ -44,6 +46,7 @@ export const Button = ({
         large,
         'icon-only': iconOnly,
         toggled,
+        loading: loading,
     })
 
     return (
@@ -52,13 +55,22 @@ export const Button = ({
             name={name}
             className={buttonClassName}
             data-test={dataTest}
-            disabled={disabled}
+            disabled={disabled || loading}
             tabIndex={tabIndex}
             type={type}
             onBlur={handleBlur}
             onClick={handleClick}
             onFocus={handleFocus}
         >
+            {loading && (
+                <span className="loader">
+                    {destructive || primary ? (
+                        <CircularLoader extrasmall invert />
+                    ) : (
+                        <CircularLoader extrasmall />
+                    )}
+                </span>
+            )}
             {icon && <span className="button-icon">{icon}</span>}
             {children}
             <style jsx>{styles}</style>
@@ -95,6 +107,8 @@ Button.propTypes = {
     initialFocus: PropTypes.bool,
     /** Makes the button large. Mutually exclusive with `small` */
     large: sharedPropTypes.sizePropType,
+    /** Sets the button into a loading state */
+    loading: PropTypes.bool,
     /**
      * Sets `name` attribute on button element.
      * Gets passed as part of the first argument to callbacks (see `onClick`).

--- a/components/button/src/button/button.stories.js
+++ b/components/button/src/button/button.stories.js
@@ -176,11 +176,17 @@ InitialFocus.args = {
 // in the docs page. Disabled for better UX
 InitialFocus.parameters = { docs: { disable: true } }
 
-export const Icon = Template.bind({})
+export const Icon = args => (
+    <>
+        <Button {...args} />
+        <Button primary {...args} />
+        <Button secondary {...args} />
+        <Button destructive {...args} />
+    </>
+)
 Icon.args = {
     icon: DemoIcon,
     name: 'Icon button',
-    children: null,
 }
 Icon.parameters = {
     docs: {
@@ -232,4 +238,27 @@ ToggledDisabled.args = {
     icon: DemoIcon,
     name: 'Toggled button',
     children: null,
+}
+
+export const Loading = args => (
+    <>
+        <Button {...args} />
+        <Button primary {...args} />
+        <Button secondary {...args} />
+        <Button destructive {...args} />
+    </>
+)
+Loading.args = {
+    name: 'Loading button',
+    loading: true,
+    children: 'Loading...',
+    icon: DemoIcon,
+}
+Loading.parameters = {
+    docs: {
+        description: {
+            story:
+                'A button can be in a loading state. Use the loading state to show a pending action after the button has been triggered. The button text should change to let the user know what is happening. For example, a button labelled "Send" might changed to "Sending..." when in a loading state.',
+        },
+    },
 }

--- a/components/button/src/button/button.styles.js
+++ b/components/button/src/button/button.styles.js
@@ -278,4 +278,21 @@ export default css`
         color: ${colors.grey050};
         fill: ${colors.grey050};
     }
+
+    .loader {
+        width: 16px;
+        height: 16px;
+        margin-right: 8px;
+    }
+
+    .loader + .button-icon {
+        display: none;
+    }
+
+    .icon-only .loader {
+        margin: 0 8px 0 4px;
+    }
+    .small.icon-only .loader {
+        margin: 0 4px;
+    }
 `


### PR DESCRIPTION
Fixes [UX-22](https://jira.dhis2.org/browse/UX-22).

This PR adds a loading state to the `Button` component. The loading state prepends the `CircularLoader` component to the `Button` children. If an `icon` is present, it is replaced by the `CircularLoader`.

This PR also adjusts and adds stories to make testing the loading spinner states easier.

Note: This is my (potentially) naive implementation of how a `loading` state. Please do say if there is a better way of doing this. 