### PR TITLE
feat: update library-wide focus styles

### DIFF
--- a/components/button/src/button/button.styles.js
+++ b/components/button/src/button/button.styles.js
@@ -32,31 +32,15 @@ export default css`
     }
 
     button:focus {
-        /* Prevent default browser behavior which adds an outline */
-        outline: none;
-    }
-
-    /* Use the ::after pseudo-element for focus styles */
-    button::after {
-        content: ' ';
-        pointer-events: none;
-
-        position: absolute;
-        top: -2px;
-        right: -2px;
-        bottom: -2px;
-        left: -2px;
-
-        border: 2px solid transparent;
-        border-radius: inherit;
-
-        transition: border-color 0.15s cubic-bezier(0.4, 0, 0.6, 1);
+        outline: 3px solid ${theme.focus};
+        outline-offset: 2px;
+        transition: none;
     }
 
     /* Prevent focus styles on active and disabled buttons */
-    button:active:focus::after,
-    button:disabled:focus::after {
-        border-color: transparent;
+    button:active:focus,
+    button:disabled:focus {
+        outline: none;
     }
 
     button:hover {
@@ -73,10 +57,6 @@ export default css`
 
     button:focus {
         background-color: #f9fafb;
-    }
-
-    button:focus::after {
-        border-color: ${theme.primary600};
     }
 
     button:disabled {
@@ -119,7 +99,6 @@ export default css`
 
     .primary:active,
     .primary:active:focus {
-        border-color: ${theme.primary800};
         background: linear-gradient(180deg, #054fa3 0%, #034793 100%);
         background-color: #1c4a90;
         box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18) inset;
@@ -128,10 +107,6 @@ export default css`
     .primary:focus {
         background: linear-gradient(180deg, #1565c0 0%, #0650a3 100%);
         background-color: #285dac;
-    }
-
-    .primary:focus::after {
-        border-color: ${colors.yellow300};
     }
 
     .primary:disabled {
@@ -154,17 +129,12 @@ export default css`
 
     .secondary:active,
     .secondary:active:focus {
-        border-color: ${colors.grey400};
         background-color: rgba(160, 173, 186, 0.2);
         box-shadow: none;
     }
 
     .secondary:focus {
         background-color: transparent;
-    }
-
-    .secondary:focus::after {
-        border-color: ${theme.primary600};
     }
 
     .secondary:disabled {
@@ -192,7 +162,6 @@ export default css`
 
     .destructive:active,
     .destructive:active:focus {
-        border-color: #a10b0b;
         background: linear-gradient(180deg, #b81c1c 0%, #b80c0b 100%);
         background-color: #ac101b;
         box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18) inset;
@@ -201,10 +170,6 @@ export default css`
     .destructive:focus {
         background: linear-gradient(180deg, #d32f2f 0%, #b71c1c 100%);
         background-color: #b72229;
-    }
-
-    .destructive:focus:after {
-        border-color: #5e0303;
     }
 
     .destructive:disabled {
@@ -253,16 +218,11 @@ export default css`
 
     .toggled:focus {
         background: ${colors.grey800};
-        border: 1px solid ${colors.yellow300};
     }
 
     .toggled:hover {
         background: ${colors.grey800};
         border-color: ${colors.grey900};
-    }
-
-    .toggled:focus::after {
-        border-color: ${colors.yellow300};
     }
 
     .toggled:active,

--- a/components/button/src/split-button/split-button.js
+++ b/components/button/src/split-button/split-button.js
@@ -132,11 +132,9 @@ class SplitButton extends Component {
                         border-bottom-left-radius: 0;
                     }
 
-                    div > :global(button:focus)::after {
-                        // TODO: a hack that allows the pseudoelement to
-                        // render on top of the buttons so the focus
-                        // border can overflow its sibling.
-                        z-index: 1;
+                    /*bring the focused button to the front*/
+                    div > :global(button:focus) {
+                        z-index: 10;
                     }
                 `}</style>
             </div>

--- a/components/checkbox/src/checkbox/checkbox.js
+++ b/components/checkbox/src/checkbox/checkbox.js
@@ -162,7 +162,8 @@ class Checkbox extends Component {
                     }
 
                     input:focus + .icon {
-                        border-color: ${colors.blue600};
+                        outline: 3px solid ${theme.focus};
+                        outline-offset: -1px;
                     }
                 `}</style>
             </label>

--- a/components/file-input/src/file-list/file-list-item.js
+++ b/components/file-input/src/file-list/file-list-item.js
@@ -1,6 +1,6 @@
 import { CircularLoader } from '@dhis2-ui/loader'
 import propTypes from '@dhis2/prop-types'
-import { colors, spacers } from '@dhis2/ui-constants'
+import { theme, colors, spacers } from '@dhis2/ui-constants'
 import { IconAttachment16 } from '@dhis2/ui-icons'
 import cx from 'classnames'
 import React from 'react'
@@ -88,6 +88,10 @@ const FileListItem = ({
             }
             .action:active {
                 color: ${colors.red800};
+            }
+            .action:focus {
+                outline: 3px solid ${theme.focus};
+                outline-offset: 2px;
             }
         `}</style>
     </p>

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -77,11 +77,8 @@ const styles = css`
     }
 
     input:focus {
-        border-color: ${colors.teal400};
-    }
-
-    input.valid {
-        border-color: ${theme.valid};
+        outline: none;
+        box-shadow: 0 0 0 3px ${theme.focus};
     }
 
     input.warning {

--- a/components/menu/src/menu-item/menu-item.styles.js
+++ b/components/menu/src/menu-item/menu-item.styles.js
@@ -1,4 +1,4 @@
-import { colors, spacers } from '@dhis2/ui-constants'
+import { colors, spacers, theme } from '@dhis2/ui-constants'
 import css from 'styled-jsx/css'
 
 export default css`
@@ -63,6 +63,14 @@ export default css`
         min-height: 48px;
         text-decoration: none;
         color: inherit;
+    }
+    /*focus-visible backwards compatibility for safari: https://css-tricks.com/platform-news-using-focus-visible-bbcs-new-typeface-declarative-shadow-doms-a11y-and-placeholders/*/
+    a:focus {
+        outline: 3px solid ${theme.focus};
+        outline-offset: -3px;
+    }
+    a:focus:not(:focus-visible) {
+        outline: none;
     }
 
     li.with-chevron a {

--- a/components/radio/src/radio.js
+++ b/components/radio/src/radio.js
@@ -147,7 +147,8 @@ class Radio extends Component {
                     }
 
                     input:focus + .icon {
-                        border-color: ${colors.blue600};
+                        outline: 3px solid ${theme.focus};
+                        outline-offset: -1px;
                     }
                 `}</style>
             </label>

--- a/components/select/src/select/input-wrapper.js
+++ b/components/select/src/select/input-wrapper.js
@@ -53,8 +53,8 @@ const InputWrapper = ({
 
                 .root:focus,
                 .root:active {
-                    border-color: ${colors.teal400};
-                    outline: 0;
+                    outline: none;
+                    box-shadow: 0 0 0 3px ${theme.focus};
                 }
 
                 .root.valid {

--- a/components/switch/src/switch/switch.js
+++ b/components/switch/src/switch/switch.js
@@ -148,7 +148,8 @@ class Switch extends Component {
                     }
 
                     input:focus + .icon {
-                        border-color: ${colors.blue600};
+                        outline: 3px solid ${theme.focus};
+                        outline-offset: -1px;
                     }
                 `}</style>
             </label>

--- a/components/tab/src/tab/tab.js
+++ b/components/tab/src/tab/tab.js
@@ -72,9 +72,13 @@ const Tab = ({
                 text-overflow: ellipsis;
                 transition: fill 150ms ease-in-out;
             }
-
-            button:focus span {
-                outline: 1px dotted ${colors.grey900};
+            /*focus-visible backwards compatibility for safari: https://css-tricks.com/platform-news-using-focus-visible-bbcs-new-typeface-declarative-shadow-doms-a11y-and-placeholders/*/
+            button:focus {
+                outline: 3px solid ${theme.focus};
+                outline-offset: -3px;
+            }
+            button:focus:not(:focus-visible) {
+                outline: none;
             }
 
             button > :global(svg) {

--- a/components/text-area/src/text-area/text-area.styles.js
+++ b/components/text-area/src/text-area/text-area.styles.js
@@ -28,7 +28,8 @@ export const styles = css`
     }
 
     textarea:focus {
-        border-color: ${colors.teal400};
+        outline: none;
+        box-shadow: 0 0 0 3px ${theme.focus};
     }
 
     textarea.valid {

--- a/constants/src/theme.js
+++ b/constants/src/theme.js
@@ -34,4 +34,5 @@ export const theme = {
     valid: colors.blue600,
     warning: colors.yellow500,
     disabled: colors.grey600,
+    focus: colors.blue600,
 }


### PR DESCRIPTION
Partially fixes [UX-20](https://jira.dhis2.org/browse/UX-20)

This PR updates the `:focus` styles for all components to establish a standard, consistent focus style. This PR adjusts styles, but does not add keyboard functionality for several items that are current missing it.

For the following elements, `:focus` styles have been added, but it's not possible to actually focus the element. This additional functionality will be covered by another ticket. This applies to `menu-item` and `file-input`.