### PR TITLE
docs: use jsx instead of js for code in markdown

### DIFF
--- a/docs/forms/react-final-form.md
+++ b/docs/forms/react-final-form.md
@@ -16,7 +16,7 @@ Here is an example of making a form with React Final Form and DHIS2 UI component
 
 ![A form with several fields and validation feedback shown](images/form-demo.png)
 
-```js
+```jsx
 import {
     ReactFinalForm,
     InputFieldFF,

--- a/docs/forms/validators.md
+++ b/docs/forms/validators.md
@@ -2,7 +2,7 @@
 
 The UI library provides a number of premade [validator functions](https://final-form.org/docs/react-final-form/examples/field-level-validation) to use with React Final Form. Here is an example of how one can be used:
 
-```js
+```jsx
 import { ReactFinalForm, email, InputFieldFF } from '@dhis2/ui'
 
 const { Form, Field } = ReactFinalForm
@@ -60,19 +60,19 @@ Validators are functions, and some of them _create_ a validator function given o
 
 Simple validator:
 
-```js
+```jsx
 const ValidatedField = () => <Field validate={email} />
 ```
 
 'Create' validator:
 
-```js
+```jsx
 const ValidatedField = () => <Field validate={createNumberRange(0, 10)} />
 ```
 
 Composed validators:
 
-```js
+```jsx
 const ValidatedField = () => (
     <Field
         validate={composeValidators(alphaNumeric, createMinCharacterLength(4))}

--- a/docs/recipes/transfer-infinite-loading-all-options-selected.md
+++ b/docs/recipes/transfer-infinite-loading-all-options-selected.md
@@ -139,7 +139,7 @@ const loadNextOptions = async () => {
 
 And rendering the Transfer can be done now as well:
 
-```js
+```jsx
 return (
     <Transfer
         loading={loading}
@@ -155,7 +155,7 @@ return (
 Let's put all the pieces together into a working Transfer component (without
 the fix for the edge case):
 
-```js
+```jsx
 const optionsPool = [
     { value: '0', label: 'Option 0' },
     { value: '1', label: 'Option 1' },
@@ -266,7 +266,7 @@ const loadNextOptions = async () => {
 
 The final code with the workaround looks as follows:
 
-```js
+```jsx
 const optionsPool = [
     { value: '0', label: 'Option 0' },
     { value: '1', label: 'Option 1' },


### PR DESCRIPTION
The syntax highlighting of some of our documentation was incorrect due to the language being specified as `js` instead of `jsx`.