### PR TITLE
feat(header-bar): adjust notification badge placement

### DIFF
--- a/components/header-bar/src/notification-icon.js
+++ b/components/header-bar/src/notification-icon.js
@@ -33,8 +33,8 @@ export const NotificationIcon = ({ count, href, kind, dataTestId }) => (
                 align-items: center;
                 z-index: 1;
                 position: absolute;
-                top: -4px;
-                right: -4px;
+                top: -9px;
+                right: -6px;
                 min-width: 18px;
                 min-height: 18px;
                 border-radius: ${spacers.dp12};


### PR DESCRIPTION
This PR fixes an issue that was [raised on Slack](https://dhis2.slack.com/archives/CPGUFVC56/p1625056213266600), that the Messages and Interpretations icons were being blocked by notification badges with large numbers.

A discussion took place about removing the numbered badges in favour of other solutions, but no conclusion was reached. Therefore, this PR is a fix to ensure the icons are visible when the existing badges have large numbers.