### PR TITLE
feat(alert bar): increase clickable area for dismiss action

### DIFF
--- a/components/alert/src/alert-bar/alert-bar.styles.js
+++ b/components/alert/src/alert-bar/alert-bar.styles.js
@@ -10,9 +10,9 @@ export default css`
         align-items: center;
         border-radius: 4px;
         box-shadow: ${elevations.e300};
-        padding-top: ${spacers.dp12};
-        padding-right: ${spacers.dp16};
-        padding-bottom: ${spacers.dp12};
+        padding-top: ${spacers.dp8};
+        padding-right: ${spacers.dp8};
+        padding-bottom: ${spacers.dp8};
         padding-left: ${spacers.dp24};
         margin-bottom: ${spacers.dp16};
         max-width: 600px;

--- a/components/alert/src/alert-bar/dismiss.js
+++ b/components/alert/src/alert-bar/dismiss.js
@@ -1,17 +1,27 @@
 import propTypes from '@dhis2/prop-types'
 import { spacers } from '@dhis2/ui-constants'
-import { IconCross16 } from '@dhis2/ui-icons'
+import { IconCross24 } from '@dhis2/ui-icons'
 import React from 'react'
 
 const Dismiss = ({ onClick, dataTest }) => (
     <div onClick={onClick} data-test={dataTest}>
-        <IconCross16 />
+        <IconCross24 />
         <style jsx>{`
             div {
-                margin-left: ${spacers.dp24};
+                margin-left: ${spacers.dp16};
+                min-height: 32px;
+                min-width: 32px;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                border-radius: 5px;
             }
             div:hover {
                 cursor: pointer;
+                background: rgba(0, 0, 0, 0.15);
+            }
+            div:active {
+                background: rgba(0, 0, 0, 0.25);
             }
             div :global(svg) {
                 width: 18px;


### PR DESCRIPTION
This PR makes changes to the "dismiss" action in the alert bar:
- adds a visible hover state to indicate interaction.
- increases the clickable area to make the action easier to trigger.