### PR TITLE
fix: change loader sizes for organisation unit components

### DIFF
--- a/components/node/src/node.stories.js
+++ b/components/node/src/node.stories.js
@@ -27,21 +27,6 @@ window.onClose = (payload, event) => {
 const onOpen = (...args) => window.onOpen(...args)
 const onClose = (...args) => window.onClose(...args)
 
-const loadingSpinnerStyles = resolve`
-    .small {
-        margin: 3px 0;
-        width: 24px;
-        height: 18px;
-    }
-`
-
-const LoadingSpinner = () => (
-    <React.Fragment>
-        <CircularLoader small className={loadingSpinnerStyles.className} />
-        <style>{loadingSpinnerStyles.styles}</style>
-    </React.Fragment>
-)
-
 export default {
     title: 'Helpers/Node',
     component: Node,
@@ -50,7 +35,7 @@ export default {
 
 export const CustomIcon = args => <Node {...args} />
 CustomIcon.args = {
-    icon: <LoadingSpinner />,
+    icon: <CircularLoader small />,
     open: false,
     onOpen: onOpen,
     onClose: onClose,

--- a/components/node/src/node.stories.js
+++ b/components/node/src/node.stories.js
@@ -1,7 +1,6 @@
 import { Checkbox } from '@dhis2-ui/checkbox'
 import { CircularLoader } from '@dhis2-ui/loader'
 import React from 'react'
-import { resolve } from 'styled-jsx/css'
 import { Node } from './node.js'
 
 const description = `

--- a/components/organisation-unit-tree/src/organisation-unit-node/organisation-unit-node.js
+++ b/components/organisation-unit-tree/src/organisation-unit-node/organisation-unit-node.js
@@ -13,17 +13,15 @@ import { useOpenState } from './use-open-state.js'
 import { useOrgData } from './use-org-data/index.js'
 
 const loadingSpinnerStyles = resolve`
-    .small {
+    .extrasmall {
         display: block;
         margin: 3px 0;
-        width: 18px;
-        height: 18px;
     }
 `
 
 const LoadingSpinner = () => (
     <div>
-        <CircularLoader small className={loadingSpinnerStyles.className} />
+        <CircularLoader extrasmall className={loadingSpinnerStyles.className} />
         <style>{loadingSpinnerStyles.styles}</style>
         <style jsx>{`
             div {


### PR DESCRIPTION
This PR updates the `node` and `organisation-unit-tree` components with the correct usage of `CircularLoader`. 