### PR TITLE
feat(portal): introduce component

### DIFF
--- a/components/alert/package.json
+++ b/components/alert/package.json
@@ -31,6 +31,7 @@
         "styled-jsx": "^3.2"
     },
     "dependencies": {
+        "@dhis2-ui/portal": "6.17.0",
         "@dhis2/prop-types": "^1.6.4",
         "@dhis2/ui-constants": "6.17.0",
         "@dhis2/ui-icons": "6.17.0",

--- a/components/alert/src/alert-stack/alert-stack.js
+++ b/components/alert/src/alert-stack/alert-stack.js
@@ -1,35 +1,32 @@
+import { Portal } from '@dhis2-ui/portal'
 import { layers } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { createPortal } from 'react-dom'
 
 export const AlertStack = ({ className, children, dataTest }) => (
-    <>
-        {createPortal(
-            <div className={cx(className)} data-test={dataTest}>
-                {children}
-                <style jsx>{`
-                    div {
-                        position: fixed;
-                        top: auto;
-                        right: auto;
-                        bottom: 0;
-                        left: 50%;
-                        transform: translateX(-50%);
+    <Portal>
+        <div className={cx(className)} data-test={dataTest}>
+            {children}
+            <style jsx>{`
+                div {
+                    position: fixed;
+                    top: auto;
+                    right: auto;
+                    bottom: 0;
+                    left: 50%;
+                    transform: translateX(-50%);
 
-                        z-index: ${layers.alert};
+                    z-index: ${layers.alert};
 
-                        display: flex;
-                        flex-direction: column-reverse;
+                    display: flex;
+                    flex-direction: column-reverse;
 
-                        pointer-events: none;
-                    }
-                `}</style>
-            </div>,
-            document.body
-        )}
-    </>
+                    pointer-events: none;
+                }
+            `}</style>
+        </div>
+    </Portal>
 )
 
 AlertStack.defaultProps = {

--- a/components/layer/package.json
+++ b/components/layer/package.json
@@ -31,6 +31,7 @@
         "styled-jsx": "^3.2"
     },
     "dependencies": {
+        "@dhis2-ui/portal": "6.17.0",
         "@dhis2/prop-types": "^1.6.4",
         "@dhis2/ui-constants": "6.17.0",
         "classnames": "^2.3.1",

--- a/components/layer/src/index.js
+++ b/components/layer/src/index.js
@@ -1,2 +1,4 @@
 export { Layer } from './layer.js'
+
+// DEPRECATED: Remove in 7.0.0
 export { useLayerContext } from './use-layer-context.js'

--- a/components/layer/src/layer.js
+++ b/components/layer/src/layer.js
@@ -1,10 +1,7 @@
-import { layers } from '@dhis2/ui-constants'
+import { Portal } from '@dhis2-ui/portal'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
-import { createPortal } from 'react-dom'
-import { Provider } from './layer-context.js'
-import { useLayerContext } from './use-layer-context.js'
+import React from 'react'
 
 const createClickHandler = onClick => event => {
     // don't respond to clicks that originated in the children
@@ -17,85 +14,67 @@ const Layer = ({
     children,
     className,
     dataTest,
+    disablePortal,
     level,
     onClick,
     position,
     translucent,
-}) => {
-    const parentLayer = useLayerContext()
-    const [layerEl, setLayerEl] = useState(null)
-    const nextLayer = {
-        node: layerEl,
-        level: Math.max(parentLayer.level, level),
-    }
-    const portalNode =
-        level > parentLayer.level ? document.body : parentLayer.node
+}) => (
+    <Portal disable={disablePortal}>
+        <div
+            className={cx('layer', className, position, {
+                translucent,
+            })}
+            data-test={dataTest}
+            onClick={createClickHandler(onClick)}
+        >
+            {children}
 
-    return (
-        <React.Fragment>
-            {createPortal(
-                <div
-                    ref={setLayerEl}
-                    className={cx(
-                        'layer',
-                        className,
-                        position,
-                        `level-${level}`,
-                        {
-                            translucent,
-                        }
-                    )}
-                    data-test={dataTest}
-                    onClick={createClickHandler(onClick)}
-                >
-                    {layerEl && (
-                        <Provider value={nextLayer}>{children}</Provider>
-                    )}
-                    <style jsx>{`
-                        div {
-                            z-index: ${level};
-                        }
-                    `}</style>
-                    <style jsx>{`
-                        div {
-                            top: 0;
-                            left: 0;
-                            min-height: 100vh;
-                            min-width: 100vw;
-                        }
-                        div.fixed {
-                            position: fixed;
-                            height: 100vh;
-                            width: 100vw;
-                        }
-                        div.absolute {
-                            position: absolute;
-                            height: 100%;
-                            width: 100%;
-                        }
-                        div.translucent {
-                            background-color: rgba(33, 43, 54, 0.4);
-                        }
-                    `}</style>
-                </div>,
-                portalNode
-            )}
-        </React.Fragment>
-    )
-}
+            <style jsx>{`
+                div {
+                    z-index: ${level};
+                }
+            `}</style>
+
+            <style jsx>{`
+                div {
+                    top: 0;
+                    left: 0;
+                    min-height: 100vh;
+                    min-width: 100vw;
+                }
+                div.fixed {
+                    position: fixed;
+                    height: 100vh;
+                    width: 100vw;
+                }
+                div.absolute {
+                    position: absolute;
+                    height: 100%;
+                    width: 100%;
+                }
+                div.translucent {
+                    background-color: rgba(33, 43, 54, 0.4);
+                }
+            `}</style>
+        </div>
+    </Portal>
+)
 
 Layer.defaultProps = {
     position: 'fixed',
     dataTest: 'dhis2-uicore-layer',
-    level: layers.applicationTop,
+    level: 'auto',
 }
 
 Layer.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
+    /** Disable the Portal, useful for nesting layers */
+    disablePortal: PropTypes.bool,
     /** Z-index level */
-    level: PropTypes.number,
+    level: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     position: PropTypes.oneOf(['absolute', 'fixed']),
     /** Adds a semi-transparent background */
     translucent: PropTypes.bool,

--- a/components/layer/src/layer.stories.e2e.js
+++ b/components/layer/src/layer.stories.e2e.js
@@ -54,6 +54,7 @@ export const InequalSiblings = () => (
 export const NestedLowerLevels = () => (
     <Layer
         level={layers.alert}
+        disablePortal={true}
         dataTest="alert"
         onClick={createNamedLayerClick('alert')}
     >

--- a/components/layer/src/layer.stories.e2e.js
+++ b/components/layer/src/layer.stories.e2e.js
@@ -54,13 +54,13 @@ export const InequalSiblings = () => (
 export const NestedLowerLevels = () => (
     <Layer
         level={layers.alert}
-        disablePortal={true}
         dataTest="alert"
         onClick={createNamedLayerClick('alert')}
     >
         <Layer
             level={layers.blocking}
             dataTest="blocking"
+            disablePortal={true}
             onClick={createNamedLayerClick('blocking')}
         />
     </Layer>

--- a/components/menu/package.json
+++ b/components/menu/package.json
@@ -34,6 +34,7 @@
         "@dhis2-ui/card": "6.17.0",
         "@dhis2-ui/divider": "6.17.0",
         "@dhis2-ui/layer": "6.17.0",
+        "@dhis2-ui/portal": "6.17.0",
         "@dhis2-ui/popper": "6.17.0",
         "@dhis2/prop-types": "^1.6.4",
         "@dhis2/ui-constants": "6.17.0",

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -1,10 +1,9 @@
-import { useLayerContext } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
+import { Portal } from '@dhis2-ui/portal'
 import { IconChevronRight24 } from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
-import { createPortal } from 'react-dom'
 import { FlyoutMenu } from '../index.js'
 import styles from './menu-item.styles.js'
 
@@ -45,7 +44,6 @@ const MenuItem = ({
     toggleSubMenu,
 }) => {
     const menuItemRef = useRef()
-    const { node } = useLayerContext()
 
     return (
         <>
@@ -87,14 +85,13 @@ const MenuItem = ({
 
                 <style jsx>{styles}</style>
             </li>
-            {children &&
-                showSubMenu &&
-                createPortal(
+            {children && showSubMenu && (
+                <Portal>
                     <Popper placement="right-start" reference={menuItemRef}>
                         <FlyoutMenu dense={dense}>{children}</FlyoutMenu>
-                    </Popper>,
-                    node
-                )}
+                    </Popper>
+                </Portal>
+            )}
         </>
     )
 }

--- a/components/modal/package.json
+++ b/components/modal/package.json
@@ -34,6 +34,7 @@
         "@dhis2-ui/card": "6.17.0",
         "@dhis2-ui/center": "6.17.0",
         "@dhis2-ui/layer": "6.17.0",
+        "@dhis2-ui/portal": "6.17.0",
         "@dhis2/prop-types": "^1.6.4",
         "@dhis2/ui-constants": "6.17.0",
         "classnames": "^2.3.1",

--- a/components/modal/src/modal/modal.js
+++ b/components/modal/src/modal/modal.js
@@ -1,12 +1,7 @@
 import { Card } from '@dhis2-ui/card'
 import { Center } from '@dhis2-ui/center'
 import { Layer } from '@dhis2-ui/layer'
-import {
-    layers,
-    spacers,
-    spacersNum,
-    sharedPropTypes,
-} from '@dhis2/ui-constants'
+import { spacers, spacersNum, sharedPropTypes } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -32,7 +27,7 @@ const centeredContent = resolve`
 
 const layerStyles = resolve`
     div {
-        background: none;
+		display: none;
     }
 `
 
@@ -49,7 +44,6 @@ export const Modal = ({
     return (
         <Layer
             onClick={onClose}
-            level={hide ? -1 : layers.blocking}
             className={hide ? layerStyles.className : ''}
             translucent={!hide}
         >

--- a/components/modal/src/modal/modal.stories.js
+++ b/components/modal/src/modal/modal.stories.js
@@ -1,5 +1,12 @@
 import { Button, ButtonStrip } from '@dhis2-ui/button'
+import {
+    FlyoutMenu,
+    MenuDivider,
+    MenuItem,
+    MenuSectionHeader,
+} from '@dhis2-ui/menu'
 import { SingleSelect, SingleSelectOption } from '@dhis2-ui/select'
+import { Tooltip } from '@dhis2-ui/tooltip'
 import { sharedPropTypes } from '@dhis2/ui-constants'
 import React, { useState } from 'react'
 import { ModalActions, ModalContent, ModalTitle } from '../index.js'
@@ -591,143 +598,146 @@ LargeWithSelectComponent.args = { large: true }
 LargeWithSelectComponent.storyName = 'Large: with Select component'
 
 export const LargeModalWithMoreNestedModals = args => (
-    <Modal {...args}>
-        <ModalTitle>Select opens on top of the Modal - Level 1</ModalTitle>
+    <>
+        <Modal {...args}>
+            <ModalTitle>Select opens on top of the Modal - Level 1</ModalTitle>
 
-        <ModalContent>
-            <SingleSelect>
-                <SingleSelectOption key="1" value="1" label="one" />
-                <SingleSelectOption key="2" value="2" label="two" />
-                <SingleSelectOption key="3" value="3" label="three" />
-                <SingleSelectOption key="4" value="3" label="four" />
-                <SingleSelectOption key="5" value="3" label="five" />
-                <SingleSelectOption key="6" value="3" label="six" />
-                <SingleSelectOption key="7" value="3" label="seven" />
-                <SingleSelectOption key="8" value="3" label="eight" />
-                <SingleSelectOption key="9" value="3" label="nine" />
-                <SingleSelectOption key="10" value="3" label="ten" />
-            </SingleSelect>
-            <Modal large>
-                <ModalTitle>
-                    Select opens on top of the Modal - Level 2
-                </ModalTitle>
+            <ModalContent>
+                <SingleSelect>
+                    <SingleSelectOption key="1" value="1" label="one" />
+                    <SingleSelectOption key="2" value="2" label="two" />
+                    <SingleSelectOption key="3" value="3" label="three" />
+                    <SingleSelectOption key="4" value="3" label="four" />
+                    <SingleSelectOption key="5" value="3" label="five" />
+                    <SingleSelectOption key="6" value="3" label="six" />
+                    <SingleSelectOption key="7" value="3" label="seven" />
+                    <SingleSelectOption key="8" value="3" label="eight" />
+                    <SingleSelectOption key="9" value="3" label="nine" />
+                    <SingleSelectOption key="10" value="3" label="ten" />
+                </SingleSelect>
+            </ModalContent>
 
-                <ModalContent>
-                    <SingleSelect>
-                        <SingleSelectOption key="1" value="1" label="one" />
-                        <SingleSelectOption key="2" value="2" label="two" />
-                        <SingleSelectOption key="3" value="3" label="three" />
-                        <SingleSelectOption key="4" value="3" label="four" />
-                        <SingleSelectOption key="5" value="3" label="five" />
-                        <SingleSelectOption key="6" value="3" label="six" />
-                        <SingleSelectOption key="7" value="3" label="seven" />
-                        <SingleSelectOption key="8" value="3" label="eight" />
-                        <SingleSelectOption key="9" value="3" label="nine" />
-                        <SingleSelectOption key="10" value="3" label="ten" />
-                    </SingleSelect>
-                    <Modal large>
-                        <ModalTitle>
-                            Select opens on top of the Modal - Level 3
-                        </ModalTitle>
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button onClick={say('Button secondary')} secondary>
+                        Secondary action
+                    </Button>
 
-                        <ModalContent>
-                            <SingleSelect>
-                                <SingleSelectOption
-                                    key="1"
-                                    value="1"
-                                    label="one"
-                                />
-                                <SingleSelectOption
-                                    key="2"
-                                    value="2"
-                                    label="two"
-                                />
-                                <SingleSelectOption
-                                    key="3"
-                                    value="3"
-                                    label="three"
-                                />
-                                <SingleSelectOption
-                                    key="4"
-                                    value="3"
-                                    label="four"
-                                />
-                                <SingleSelectOption
-                                    key="5"
-                                    value="3"
-                                    label="five"
-                                />
-                                <SingleSelectOption
-                                    key="6"
-                                    value="3"
-                                    label="six"
-                                />
-                                <SingleSelectOption
-                                    key="7"
-                                    value="3"
-                                    label="seven"
-                                />
-                                <SingleSelectOption
-                                    key="8"
-                                    value="3"
-                                    label="eight"
-                                />
-                                <SingleSelectOption
-                                    key="9"
-                                    value="3"
-                                    label="nine"
-                                />
-                                <SingleSelectOption
-                                    key="10"
-                                    value="3"
-                                    label="ten"
-                                />
-                            </SingleSelect>
-                        </ModalContent>
+                    <Button onClick={say('Button primary')} primary>
+                        Primary action
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Modal>
 
-                        <ModalActions>
-                            <ButtonStrip end>
-                                <Button
-                                    onClick={say('Button secondary')}
-                                    secondary
-                                >
-                                    Secondary action
-                                </Button>
+        <Modal {...args}>
+            <ModalTitle>Select opens on top of the Modal - Level 2</ModalTitle>
 
-                                <Button onClick={say('Button primary')} primary>
-                                    Primary action
-                                </Button>
-                            </ButtonStrip>
-                        </ModalActions>
-                    </Modal>
-                </ModalContent>
+            <ModalContent>
+                <SingleSelect>
+                    <SingleSelectOption key="1" value="1" label="one" />
+                    <SingleSelectOption key="2" value="2" label="two" />
+                    <SingleSelectOption key="3" value="3" label="three" />
+                    <SingleSelectOption key="4" value="3" label="four" />
+                    <SingleSelectOption key="5" value="3" label="five" />
+                    <SingleSelectOption key="6" value="3" label="six" />
+                    <SingleSelectOption key="7" value="3" label="seven" />
+                    <SingleSelectOption key="8" value="3" label="eight" />
+                    <SingleSelectOption key="9" value="3" label="nine" />
+                    <SingleSelectOption key="10" value="3" label="ten" />
+                </SingleSelect>
+            </ModalContent>
 
-                <ModalActions>
-                    <ButtonStrip end>
-                        <Button onClick={say('Button secondary')} secondary>
-                            Secondary action
-                        </Button>
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button onClick={say('Button secondary')} secondary>
+                        Secondary action
+                    </Button>
 
-                        <Button onClick={say('Button primary')} primary>
-                            Primary action
-                        </Button>
-                    </ButtonStrip>
-                </ModalActions>
-            </Modal>
-        </ModalContent>
+                    <Button onClick={say('Button primary')} primary>
+                        Primary action
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Modal>
 
-        <ModalActions>
-            <ButtonStrip end>
-                <Button onClick={say('Button secondary')} secondary>
-                    Secondary action
-                </Button>
+        <Modal small>
+            <ModalTitle>Select opens on top of the Modal - Level 3</ModalTitle>
 
-                <Button onClick={say('Button primary')} primary>
-                    Primary action
-                </Button>
-            </ButtonStrip>
-        </ModalActions>
-    </Modal>
+            <ModalContent>
+                <SingleSelect>
+                    <SingleSelectOption key="1" value="1" label="one" />
+                    <SingleSelectOption key="2" value="2" label="two" />
+                    <SingleSelectOption key="3" value="3" label="three" />
+                    <SingleSelectOption key="4" value="3" label="four" />
+                    <SingleSelectOption key="5" value="3" label="five" />
+                    <SingleSelectOption key="6" value="3" label="six" />
+                    <SingleSelectOption key="7" value="3" label="seven" />
+                    <SingleSelectOption key="8" value="3" label="eight" />
+                    <SingleSelectOption key="9" value="3" label="nine" />
+                    <SingleSelectOption key="10" value="3" label="ten" />
+                </SingleSelect>
+
+                <Tooltip content="Some extra info">
+                    {({ ref, onMouseOver, onMouseOut }) => (
+                        <span
+                            ref={ref}
+                            onMouseOver={onMouseOver}
+                            onMouseOut={onMouseOut}
+                        >
+                            <button>Tooltip on button</button>
+                            <style jsx>{`
+                                span {
+                                    display: inline-flex;
+                                }
+                            `}</style>
+                        </span>
+                    )}
+                </Tooltip>
+
+                <FlyoutMenu>
+                    <MenuSectionHeader label="Section with sub-menus" />
+                    <MenuItem label="Item 1" />
+                    <MenuItem label="Item 2">
+                        <MenuItem label="Item 2 a" />
+                        <MenuItem label="Item 2 b">
+                            <MenuItem label="Item 2 b i" />
+                            <MenuItem label="Item 2 b ii" />
+                        </MenuItem>
+                        <MenuItem label="Item 2 c" />
+                    </MenuItem>
+                    <MenuItem label="Item 3" />
+                    <MenuItem label="Item 4">
+                        <MenuItem label="Item 4 a" />
+                        <MenuItem label="Item 4 b">
+                            <MenuItem label="Item 4 b i" />
+                            <MenuItem label="Item 4 b ii" />
+                        </MenuItem>
+                        <MenuItem label="Item 4 c" />
+                    </MenuItem>
+                    <MenuItem label="Item 5" />
+                    <MenuSectionHeader label="Section with dividers between menu items" />
+                    <MenuItem label="Item 1" />
+                    <MenuDivider />
+                    <MenuItem label="Item 2" />
+                    <MenuDivider />
+                    <MenuItem label="Item 3" />
+                </FlyoutMenu>
+            </ModalContent>
+
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button onClick={say('Button secondary')} secondary>
+                        Secondary action
+                    </Button>
+
+                    <Button onClick={say('Button primary')} primary>
+                        Primary action
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Modal>
+    </>
 )
 LargeModalWithMoreNestedModals.args = { large: true }
 LargeModalWithMoreNestedModals.storyName =

--- a/components/portal/README.md
+++ b/components/portal/README.md
@@ -1,0 +1,6 @@
+> :warning:
+> This is currently considered internal, please use `@dhis2/ui`.
+>
+> See the [Getting started
+> guide](https://github.com/dhis2/ui/blob/master/docs/getting-started.md)
+> for more information.

--- a/components/portal/d2.config.js
+++ b/components/portal/d2.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    type: 'lib',
+    entryPoints: {
+        lib: 'src/index.js',
+    },
+}

--- a/components/portal/package.json
+++ b/components/portal/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "@dhis2-ui/tooltip",
+    "name": "@dhis2-ui/portal",
     "version": "6.17.0",
-    "description": "UI Tooltip",
+    "description": "UI Portal",
     "repository": {
         "type": "git",
         "url": "https://github.com/dhis2/ui.git",
-        "directory": "components/tooltip"
+        "directory": "components/portal"
     },
     "homepage": "https://github.com/dhis2/ui#readme",
     "license": "BSD-3-Clause",
@@ -31,10 +31,6 @@
         "styled-jsx": "^3.2"
     },
     "dependencies": {
-        "@dhis2-ui/portal": "6.17.0",
-        "@dhis2-ui/popper": "6.17.0",
-        "@dhis2/prop-types": "^1.6.4",
-        "@dhis2/ui-constants": "6.17.0",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
     },

--- a/components/portal/src/index.js
+++ b/components/portal/src/index.js
@@ -1,0 +1,1 @@
+export { Portal } from './portal.js'

--- a/components/portal/src/portal.js
+++ b/components/portal/src/portal.js
@@ -2,6 +2,15 @@ import PropTypes from 'prop-types'
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 
+/*
+ * #dhis2-portal-root is provided by the App Platform and will be used by
+ * default.
+ *
+ * For non-platform apps, the mount node can be added manually to the HTML
+ * template.
+ *
+ * As a fallback, portals will be attached to the document body.
+ */
 const defaultNode =
     document.getElementById('dhis2-portal-root') || document.body
 

--- a/components/portal/src/portal.js
+++ b/components/portal/src/portal.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types'
+import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+export const Portal = ({ children, node, disable }) => {
+    const [mountNode, setMountNode] = useState(null)
+
+    useEffect(() => {
+        setMountNode(node || document.body)
+    }, [node])
+
+    if (disable) {
+        return children
+    }
+
+    return mountNode ? createPortal(children, mountNode) : mountNode
+}
+
+Portal.propTypes = {
+    children: PropTypes.node,
+    disable: PropTypes.bool,
+    node: PropTypes.node,
+}

--- a/components/portal/src/portal.js
+++ b/components/portal/src/portal.js
@@ -2,11 +2,14 @@ import PropTypes from 'prop-types'
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 
+const defaultNode =
+    document.getElementById('dhis2-portal-root') || document.body
+
 export const Portal = ({ children, node, disable }) => {
     const [mountNode, setMountNode] = useState(null)
 
     useEffect(() => {
-        setMountNode(node || document.body)
+        setMountNode(node || defaultNode)
     }, [node])
 
     if (disable) {

--- a/components/tooltip/src/features/layering.feature
+++ b/components/tooltip/src/features/layering.feature
@@ -4,5 +4,4 @@ Feature: Tooltip layering
         Given a Modal contains a tooltip
         When the mouse cursor enters the anchor
         Then the Tooltip is rendered above the anchor
-        And the Tooltip has attached itself to the modal layer root node
         And the Tooltip is fully visible

--- a/components/tooltip/src/features/layering/index.js
+++ b/components/tooltip/src/features/layering/index.js
@@ -5,15 +5,6 @@ Given('a Modal contains a tooltip', () => {
     cy.visitStory('Tooltip', 'Modal With Tooltip')
 })
 
-Then('the Tooltip has attached itself to the modal layer root node', () => {
-    cy.all(
-        () => cy.get('[data-test="dhis2-uicore-layer"]'),
-        () => cy.get('[data-test="dhis2-uicore-popper"]')
-    ).should(([$layer, $popper]) => {
-        expect($popper.get(0).parentNode).to.equal($layer.get(0))
-    })
-})
-
 Then('the Tooltip is fully visible', () => {
     cy.get('[data-test="dhis2-uicore-popper"]').should('be.visible')
 })

--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -1,9 +1,8 @@
-import { useLayerContext } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
+import { Portal } from '@dhis2-ui/portal'
 import { colors, layers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 import { resolve } from 'styled-jsx/css'
 
 const TOOLTIP_OFFSET = 4
@@ -50,7 +49,6 @@ const Tooltip = ({
     const popperReference = useRef()
     const openTimerRef = useRef(null)
     const closeTimerRef = useRef(null)
-    const { node: portalRootNode } = useLayerContext()
 
     const onMouseOver = () => {
         clearTimeout(closeTimerRef.current)
@@ -87,8 +85,8 @@ const Tooltip = ({
                 </span>
             )}
 
-            {open &&
-                createPortal(
+            {open && (
+                <Portal>
                     <Popper
                         className={popperStyle.className}
                         placement={placement}
@@ -101,9 +99,9 @@ const Tooltip = ({
                         >
                             {content}
                         </div>
-                    </Popper>,
-                    portalRootNode
-                )}
+                    </Popper>
+                </Portal>
+            )}
             {popperStyle.styles}
             <style jsx>{`
                 div {


### PR DESCRIPTION
Introduces a new Portal component that can be used as a standard React
component, either with a default or custom mount point.

Nested Modals in JSX is now an unsupported technique. Modals can be
siblings, but not placed within each other.

If a modal needs to create another modal, then a wrapper component that
controls which of the sibling modals should open and when it should be
used. Modals placed as siblings will render on top of one another based
on the order in the DOM, so last sibling renders on top of the
preceeding ones.
