### PR TITLE
fix(tooltip): remove `tag` from defaultProps

### DIFF
--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -128,7 +128,6 @@ Tooltip.defaultProps = {
     maxWidth: 300,
     openDelay: 200,
     placement: 'top',
-    tag: 'span',
 }
 
 Tooltip.propTypes = {


### PR DESCRIPTION
The `tag` prop is being rendered in the documentation as it is included in the default props (though it is unused and not present in propTypes).

![image](https://user-images.githubusercontent.com/4295266/130445787-18e4e357-a7c3-4238-9cad-b8b707bc9253.png)
