### PR TITLE
fix(button): remove z-index from border style

### DIFF
--- a/components/button/src/button/button.styles.js
+++ b/components/button/src/button/button.styles.js
@@ -46,7 +46,6 @@ export default css`
         right: -2px;
         bottom: -2px;
         left: -2px;
-        z-index: 1;
 
         border: 2px solid transparent;
         border-radius: inherit;

--- a/components/button/src/split-button/split-button.js
+++ b/components/button/src/split-button/split-button.js
@@ -114,9 +114,11 @@ class SplitButton extends Component {
                 <style jsx>{`
                     div {
                         display: inline-flex;
-                        position: relative;
                         color: inherit;
                         white-space: nowrap;
+                        // create a stacking context for the children
+                        position: relative;
+                        z-index: 0;
                     }
 
                     div > :global(button:first-child) {
@@ -128,6 +130,13 @@ class SplitButton extends Component {
                     div > :global(button:last-child) {
                         border-top-left-radius: 0;
                         border-bottom-left-radius: 0;
+                    }
+
+                    div > :global(button:focus)::after {
+                        // TODO: a hack that allows the pseudoelement to
+                        // render on top of the buttons so the focus
+                        // border can overflow its sibling.
+                        z-index: 1;
                     }
                 `}</style>
             </div>


### PR DESCRIPTION
Modifying the z-index on the border causes it to be shown above the
normal stacking context, which causes it to overlay on top of e.g.
modals and component covers.

Generally we should avoid modifying the z-index of components and allow
them to be automatically put into the relevant stacking context.
