### PR TITLE
feat: add online status to headerbar

### DIFF
--- a/components/header-bar/i18n/en.pot
+++ b/components/header-bar/i18n/en.pot
@@ -5,26 +5,32 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-05-10T10:09:29.830Z\n"
-"PO-Revision-Date: 2021-05-10T10:09:29.830Z\n"
+"POT-Creation-Date: 2021-08-30T10:10:25.885Z\n"
+"PO-Revision-Date: 2021-08-30T10:10:25.885Z\n"
 
 msgid "Search apps"
-msgstr ""
+msgstr "Search apps"
+
+msgid "Online"
+msgstr "Online"
+
+msgid "Offline"
+msgstr "Offline"
 
 msgid "Edit profile"
-msgstr ""
+msgstr "Edit profile"
 
 msgid "Settings"
-msgstr ""
+msgstr "Settings"
 
 msgid "Account"
-msgstr ""
+msgstr "Account"
 
 msgid "Help"
-msgstr ""
+msgstr "Help"
 
 msgid "About DHIS2"
-msgstr ""
+msgstr "About DHIS2"
 
 msgid "Logout"
-msgstr ""
+msgstr "Logout"

--- a/components/header-bar/package.json
+++ b/components/header-bar/package.json
@@ -26,7 +26,7 @@
         "test": "d2-app-scripts test --jestConfig ../../jest.config.shared.js"
     },
     "peerDependencies": {
-        "@dhis2/app-runtime": "^2",
+        "@dhis2/app-runtime": "^2.9.2",
         "@dhis2/d2-i18n": "^1",
         "react": "^16.8",
         "react-dom": "^16.8",
@@ -49,7 +49,7 @@
         "build"
     ],
     "devDependencies": {
-        "@dhis2/app-runtime": "^2.7.1",
+        "@dhis2/app-runtime": "^2.9.2",
         "@dhis2/d2-i18n": "^1.1.0",
         "react": "16.13",
         "react-dom": "16.13",

--- a/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled.feature
+++ b/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled.feature
@@ -1,0 +1,16 @@
+Feature: The HeaderBar displays online status when PWA is enabled
+
+    Scenario: The HeaderBar displays a badge on large screens
+        Given the HeaderBar loads without error when PWA is enabled
+        Then the HeaderBar displays only the desktop status badge
+        And the status badge shows online
+
+    Scenario: The HeaderBar displays a sub-bar on smaller screens
+        Given the HeaderBar loads without error when PWA is enabled
+        And the viewport is narrower than 480px
+        Then the HeaderBar displays only the mobile status bar
+
+    Scenario: The HeaderBar displays an offline status when offline
+        Given the HeaderBar loads without error when PWA is enabled
+        And the browser goes offline
+        Then the status badge shows offline

--- a/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled/the_headerbar_displays_online_status.js
+++ b/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled/the_headerbar_displays_online_status.js
@@ -62,19 +62,17 @@ And('the viewport is narrower than 480px', () => {
 
 Then('the HeaderBar displays only the desktop status badge', () => {
     // This assumes default viewport size: 1000x660
-    cy.get('[data-test="headerbar-online-status"].desktop').should('be.visible')
-    cy.get('[data-test="headerbar-online-status"].mobile').should(
-        'not.be.visible'
-    )
+    cy.get('[data-test="headerbar-online-status"].badge').should('be.visible')
+    cy.get('[data-test="headerbar-online-status"].bar').should('not.be.visible')
 })
 
 And('the status badge shows online', () => {
-    cy.get('[data-test="headerbar-online-status"].desktop .label').should(
+    cy.get('[data-test="headerbar-online-status"].badge .label').should(
         $label => {
             expect($label.text()).to.equal('Online')
         }
     )
-    cy.get('[data-test="headerbar-online-status"].desktop .icon').should(
+    cy.get('[data-test="headerbar-online-status"].badge .icon').should(
         $icon => {
             expect($icon).to.have.class('online')
         }
@@ -82,8 +80,8 @@ And('the status badge shows online', () => {
 })
 
 Then('the HeaderBar displays only the mobile status bar', () => {
-    cy.get('[data-test="headerbar-online-status"].mobile').should('be.visible')
-    cy.get('[data-test="headerbar-online-status"].desktop').should(
+    cy.get('[data-test="headerbar-online-status"].bar').should('be.visible')
+    cy.get('[data-test="headerbar-online-status"].badge').should(
         'not.be.visible'
     )
 })
@@ -93,12 +91,12 @@ And('the browser goes offline', () => {
 })
 
 Then('the status badge shows offline', () => {
-    cy.get('[data-test="headerbar-online-status"].desktop .label').should(
+    cy.get('[data-test="headerbar-online-status"].badge .label').should(
         $label => {
             expect($label.text()).to.equal('Offline')
         }
     )
-    cy.get('[data-test="headerbar-online-status"].desktop .icon').should(
+    cy.get('[data-test="headerbar-online-status"].badge .icon').should(
         $icon => {
             expect($icon).to.have.class('offline')
         }

--- a/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled/the_headerbar_displays_online_status.js
+++ b/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled/the_headerbar_displays_online_status.js
@@ -1,0 +1,106 @@
+import {
+    Before,
+    After,
+    Given,
+    Then,
+    And,
+} from 'cypress-cucumber-preprocessor/steps'
+import '../common/index'
+
+// https://www.cypress.io/blog/2020/11/12/testing-application-in-offline-network-mode/
+const goOffline = () => {
+    cy.log('**go offline**')
+        .then(() => {
+            return Cypress.automation('remote:debugger:protocol', {
+                command: 'Network.enable',
+            })
+        })
+        .then(() => {
+            return Cypress.automation('remote:debugger:protocol', {
+                command: 'Network.emulateNetworkConditions',
+                params: {
+                    offline: true,
+                    latency: -1,
+                    downloadThroughput: -1,
+                    uploadThroughput: -1,
+                },
+            })
+        })
+}
+const goOnline = () => {
+    // disable offline mode, otherwise we will break our tests :)
+    cy.log('**go online**')
+        .then(() => {
+            // https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-emulateNetworkConditions
+            return Cypress.automation('remote:debugger:protocol', {
+                command: 'Network.emulateNetworkConditions',
+                params: {
+                    offline: false,
+                    latency: -1,
+                    downloadThroughput: -1,
+                    uploadThroughput: -1,
+                },
+            })
+        })
+        .then(() => {
+            return Cypress.automation('remote:debugger:protocol', {
+                command: 'Network.disable',
+            })
+        })
+}
+
+Before(() => goOnline())
+After(() => goOnline())
+
+Given('the HeaderBar loads without error when PWA is enabled', () => {
+    cy.visitStory('HeaderBarTesting', 'PWA Enabled')
+})
+
+And('the viewport is narrower than 480px', () => {
+    cy.viewport(460, 660)
+})
+
+Then('the HeaderBar displays only the desktop status badge', () => {
+    // This assumes default viewport size: 1000x660
+    cy.get('[data-test="headerbar-online-status"].desktop').should('be.visible')
+    cy.get('[data-test="headerbar-online-status"].mobile').should(
+        'not.be.visible'
+    )
+})
+
+And('the status badge shows online', () => {
+    cy.get('[data-test="headerbar-online-status"].desktop .label').should(
+        $label => {
+            expect($label.text()).to.equal('Online')
+        }
+    )
+    cy.get('[data-test="headerbar-online-status"].desktop .icon').should(
+        $icon => {
+            expect($icon).to.have.class('online')
+        }
+    )
+})
+
+Then('the HeaderBar displays only the mobile status bar', () => {
+    cy.get('[data-test="headerbar-online-status"].mobile').should('be.visible')
+    cy.get('[data-test="headerbar-online-status"].desktop').should(
+        'not.be.visible'
+    )
+})
+
+And('the browser goes offline', () => {
+    goOffline()
+})
+
+Then('the status badge shows offline', () => {
+    cy.get('[data-test="headerbar-online-status"].desktop .label').should(
+        $label => {
+            expect($label.text()).to.equal('Offline')
+        }
+    )
+    cy.get('[data-test="headerbar-online-status"].desktop .icon').should(
+        $icon => {
+            expect($icon).to.have.class('offline')
+        }
+    )
+})

--- a/components/header-bar/src/header-bar.js
+++ b/components/header-bar/src/header-bar.js
@@ -96,7 +96,7 @@ export const HeaderBar = ({ appName, className }) => {
             </div>
             {pwaEnabled && !loading && !error && (
                 // todo: info
-                <OnlineStatus mobile />
+                <OnlineStatus dense />
             )}
 
             <style jsx>{`

--- a/components/header-bar/src/header-bar.js
+++ b/components/header-bar/src/header-bar.js
@@ -1,4 +1,4 @@
-import { useDataQuery, useConfig, useOnlineStatus } from '@dhis2/app-runtime'
+import { useDataQuery, useConfig } from '@dhis2/app-runtime'
 import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
@@ -38,10 +38,6 @@ const avatarUrl = (avatar, baseUrl) =>
 export const HeaderBar = ({ appName, className }) => {
     const { baseUrl, pwaEnabled } = useConfig()
     const { loading, error, data } = useDataQuery(query)
-    const { online } = useOnlineStatus()
-
-    // A 'reconnecting' status may come in the future
-    const onlineStatus = online ? 'online' : 'offline'
 
     const apps = useMemo(() => {
         const getPath = path =>
@@ -77,7 +73,7 @@ export const HeaderBar = ({ appName, className }) => {
                         <div className="right-control-spacer" />
                         {pwaEnabled && (
                             // todo: info
-                            <OnlineStatus status={onlineStatus} />
+                            <OnlineStatus />
                         )}
                         <Notifications
                             interpretations={
@@ -100,7 +96,7 @@ export const HeaderBar = ({ appName, className }) => {
             </div>
             {pwaEnabled && !loading && !error && (
                 // todo: info
-                <OnlineStatus status={onlineStatus} mobile />
+                <OnlineStatus mobile />
             )}
 
             <style jsx>{`

--- a/components/header-bar/src/header-bar.js
+++ b/components/header-bar/src/header-bar.js
@@ -1,7 +1,4 @@
-import {
-    useDataQuery,
-    useConfig /* useOnlineStatus */,
-} from '@dhis2/app-runtime'
+import { useDataQuery, useConfig, useOnlineStatus } from '@dhis2/app-runtime'
 import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
@@ -37,9 +34,6 @@ const query = {
 
 const avatarUrl = (avatar, baseUrl) =>
     avatar ? joinPath(baseUrl, 'api/fileResources', avatar.id, 'data') : null
-
-// todo: real online status
-const useOnlineStatus = () => ({ online: true })
 
 export const HeaderBar = ({ appName, className }) => {
     const { baseUrl, pwaEnabled } = useConfig()
@@ -82,10 +76,8 @@ export const HeaderBar = ({ appName, className }) => {
                         />
                         <div className="right-control-spacer" />
                         {pwaEnabled && (
-                            <OnlineStatus
-                                status={onlineStatus}
-                                info={'Desktop'}
-                            />
+                            // todo: info
+                            <OnlineStatus status={onlineStatus} />
                         )}
                         <Notifications
                             interpretations={
@@ -107,7 +99,8 @@ export const HeaderBar = ({ appName, className }) => {
                 )}
             </div>
             {pwaEnabled && !loading && !error && (
-                <OnlineStatus status={onlineStatus} info={'Mobile'} mobile />
+                // todo: info
+                <OnlineStatus status={onlineStatus} mobile />
             )}
 
             <style jsx>{`

--- a/components/header-bar/src/header-bar.stories.e2e.js
+++ b/components/header-bar/src/header-bar.stories.e2e.js
@@ -7,13 +7,19 @@ export default {
     component: HeaderBar,
 }
 
+const config = {
+    baseUrl: 'https://domain.tld/',
+    apiVersion: '',
+}
+
 export const Default = () => (
-    <Provider
-        config={{
-            baseUrl: 'https://domain.tld/',
-            apiVersion: '',
-        }}
-    >
+    <Provider config={config}>
+        <HeaderBar appName="Example!" />
+    </Provider>
+)
+
+export const PWAEnabled = () => (
+    <Provider config={{ ...config, pwaEnabled: true }}>
         <HeaderBar appName="Example!" />
     </Provider>
 )

--- a/components/header-bar/src/header-bar.stories.e2e.js
+++ b/components/header-bar/src/header-bar.stories.e2e.js
@@ -1,9 +1,13 @@
 import { Provider } from '@dhis2/app-runtime'
-import { storiesOf } from '@storybook/react'
 import React from 'react'
 import { HeaderBar } from './header-bar.js'
 
-storiesOf('HeaderBarTesting', module).add('Default', () => (
+export default {
+    title: 'HeaderBarTesting',
+    component: HeaderBar,
+}
+
+export const Default = () => (
     <Provider
         config={{
             baseUrl: 'https://domain.tld/',
@@ -12,4 +16,4 @@ storiesOf('HeaderBarTesting', module).add('Default', () => (
     >
         <HeaderBar appName="Example!" />
     </Provider>
-))
+)

--- a/components/header-bar/src/header-bar.stories.js
+++ b/components/header-bar/src/header-bar.stories.js
@@ -232,3 +232,25 @@ export const Error = args => (
     </Provider>
 )
 Error.storyName = 'Error!'
+
+export const WithOnlineStatus = args => {
+    const config = { ...mockConfig, pwaEnabled: true }
+    return (
+        <Provider config={config}>
+            <CustomDataProvider data={customData}>
+                <HeaderBar {...args} />
+            </CustomDataProvider>
+        </Provider>
+    )
+}
+WithOnlineStatus.parameters = {
+    docs: {
+        description: {
+            story:
+                'An online status badge will be shown in apps that set \
+                `pwa: { enabled: true }` in `d2.config.js`. The status \
+                indicator uses a different layout on viewports smaller \
+                than 480px.',
+        },
+    },
+}

--- a/components/header-bar/src/online-status.js
+++ b/components/header-bar/src/online-status.js
@@ -9,7 +9,10 @@ export function OnlineStatus({ status, info, mobile }) {
     const displayStatus = status.replace(/(^|\s)\S/g, c => c.toUpperCase())
 
     return (
-        <div className={cx('container', mobile ? 'mobile' : 'desktop')}>
+        <div
+            className={cx('container', mobile ? 'mobile' : 'desktop')}
+            data-test="headerbar-online-status"
+        >
             {info && !mobile && <span className="info">{info}</span>}
             <div className={cx('icon', status)}></div>
             <span className="label">{displayStatus}</span>

--- a/components/header-bar/src/online-status.js
+++ b/components/header-bar/src/online-status.js
@@ -6,26 +6,26 @@ import i18n from './locales/index.js'
 import styles from './online-status.styles.js'
 
 /** A badge to display online/offline status in the header bar */
-export function OnlineStatus({ info, mobile }) {
+export function OnlineStatus({ info, dense }) {
     const { online } = useOnlineStatus()
     const displayStatus = online ? i18n.t('Online') : i18n.t('Offline')
 
     return (
         <div
-            className={cx('container', mobile ? 'mobile' : 'desktop')}
+            className={cx('container', dense ? 'bar' : 'badge')}
             data-test="headerbar-online-status"
         >
-            {info && !mobile && <span className="info">{info}</span>}
+            {info && !dense && <span className="info">{info}</span>}
             <div className={cx('icon', online ? 'online' : 'offline')}></div>
             <span className="label">{displayStatus}</span>
-            {info && mobile && <span className="info-mobile">{info}</span>}
+            {info && dense && <span className="info-dense">{info}</span>}
             <style jsx>{styles}</style>
         </div>
     )
 }
 OnlineStatus.propTypes = {
-    /** Additional text to display beside badge */
+    /** If true, displays as a sub-bar instead of a badge */
+    dense: PropTypes.bool,
+    /** Additional text to display beside status */
     info: PropTypes.string,
-    /** If true, uses mobile styles */
-    mobile: PropTypes.bool,
 }

--- a/components/header-bar/src/online-status.js
+++ b/components/header-bar/src/online-status.js
@@ -1,12 +1,14 @@
+import { useOnlineStatus } from '@dhis2/app-runtime'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+import i18n from './locales/index.js'
 import styles from './online-status.styles.js'
 
 /** A badge to display online/offline status in the header bar */
-export function OnlineStatus({ status, info, mobile }) {
-    // Convert to title case
-    const displayStatus = status.replace(/(^|\s)\S/g, c => c.toUpperCase())
+export function OnlineStatus({ info, mobile }) {
+    const { online } = useOnlineStatus()
+    const displayStatus = online ? i18n.t('Online') : i18n.t('Offline')
 
     return (
         <div
@@ -14,7 +16,7 @@ export function OnlineStatus({ status, info, mobile }) {
             data-test="headerbar-online-status"
         >
             {info && !mobile && <span className="info">{info}</span>}
-            <div className={cx('icon', status)}></div>
+            <div className={cx('icon', online ? 'online' : 'offline')}></div>
             <span className="label">{displayStatus}</span>
             {info && mobile && <span className="info-mobile">{info}</span>}
             <style jsx>{styles}</style>
@@ -26,6 +28,4 @@ OnlineStatus.propTypes = {
     info: PropTypes.string,
     /** If true, uses mobile styles */
     mobile: PropTypes.bool,
-    /** Connection status */
-    status: PropTypes.oneOf(['online', 'offline', 'reconnecting']),
 }

--- a/components/header-bar/src/online-status.js
+++ b/components/header-bar/src/online-status.js
@@ -1,0 +1,28 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styles from './online-status.styles.js'
+
+/** A badge to display online/offline status in the header bar */
+export function OnlineStatus({ status, info, mobile }) {
+    // Convert to title case
+    const displayStatus = status.replace(/(^|\s)\S/g, c => c.toUpperCase())
+
+    return (
+        <div className={cx('container', mobile ? 'mobile' : 'desktop')}>
+            {info && !mobile && <span className="info">{info}</span>}
+            <div className={cx('icon', status)}></div>
+            <span className="label">{displayStatus}</span>
+            {info && mobile && <span className="info-mobile">{info}</span>}
+            <style jsx>{styles}</style>
+        </div>
+    )
+}
+OnlineStatus.propTypes = {
+    /** Additional text to display beside badge */
+    info: PropTypes.string,
+    /** If true, uses mobile styles */
+    mobile: PropTypes.bool,
+    /** Connection status */
+    status: PropTypes.oneOf(['online', 'offline', 'reconnecting']),
+}

--- a/components/header-bar/src/online-status.styles.js
+++ b/components/header-bar/src/online-status.styles.js
@@ -58,8 +58,6 @@ export default css`
     .icon.offline {
         background-color: transparent;
         border: 1px solid ${colors.yellow300};
-        width: 7px;
-        height: 7px;
     }
 
     .icon.reconnecting {

--- a/components/header-bar/src/online-status.styles.js
+++ b/components/header-bar/src/online-status.styles.js
@@ -11,14 +11,14 @@ export default css`
         color: ${colors.grey100};
     }
 
-    .container.desktop {
+    .container.badge {
         margin-right: ${spacers.dp24};
         padding: ${spacers.dp8};
         border-radius: 5px;
         font-size: 14px;
     }
 
-    .container.mobile {
+    .container.bar {
         display: none;
         padding: 0px ${spacers.dp4};
         min-height: 24px;
@@ -26,11 +26,11 @@ export default css`
     }
 
     @media (max-width: 480px) {
-        .container.desktop {
+        .container.badge {
             display: none;
         }
 
-        .container.mobile {
+        .container.bar {
             display: flex;
         }
     }

--- a/components/header-bar/src/online-status.styles.js
+++ b/components/header-bar/src/online-status.styles.js
@@ -1,0 +1,87 @@
+import { colors, spacers } from '@dhis2/ui-constants'
+import css from 'styled-jsx/css'
+
+export default css`
+    .container {
+        display: flex;
+        align-items: center;
+        justify-content: center; // new
+        background-color: #104167;
+        flex-shrink: 0; // ?
+        color: ${colors.grey100};
+    }
+
+    .container.desktop {
+        margin-right: ${spacers.dp24};
+        padding: ${spacers.dp8};
+        border-radius: 5px;
+        font-size: 14px;
+    }
+
+    .container.mobile {
+        display: none;
+        padding: 0px ${spacers.dp4};
+        min-height: 24px;
+        font-size: 13px;
+    }
+
+    @media (max-width: 480px) {
+        .container.desktop {
+            display: none;
+        }
+
+        .container.mobile {
+            display: flex;
+        }
+    }
+
+    .info {
+        margin-right: ${spacers.dp16};
+    }
+
+    .info-mobile {
+        margin-left: ${spacers.dp12};
+        font-size: 12px;
+    }
+
+    .icon {
+        width: 8px;
+        height: 8px;
+        border-radius: 8px;
+        margin-right: ${spacers.dp4};
+    }
+
+    .icon.online {
+        background-color: ${colors.teal400};
+    }
+
+    .icon.offline {
+        background-color: transparent;
+        border: 1px solid ${colors.yellow300};
+        width: 7px;
+        height: 7px;
+    }
+
+    .icon.reconnecting {
+        background: ${colors.grey300};
+        -webkit-animation: fadeinout 2s linear infinite;
+        animation: fadeinout 2s linear infinite;
+        opacity: 0;
+    }
+
+    @-webkit-keyframes fadeinout {
+        50% {
+            opacity: 1;
+        }
+    }
+
+    @keyframes fadeinout {
+        50% {
+            opacity: 1;
+        }
+    }
+
+    .label {
+        letter-spacing: 0.5px;
+    }
+`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,20 +1699,52 @@
     "@dhis2/app-service-config" "2.8.0"
     "@dhis2/app-service-data" "2.8.0"
 
+"@dhis2/app-runtime@^2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.9.2.tgz#b24174ac1a3f0ce695cd60919d90cd6be11ea59d"
+  integrity sha512-Cgy6CQjpdTaV/DFy8IyQPg8tuZztHqyfiaydEZhfikyPCaaS5W+t9X6QN7Tswj3e/U4giEJEU4way4aK2+sWww==
+  dependencies:
+    "@dhis2/app-service-alerts" "2.9.2"
+    "@dhis2/app-service-config" "2.9.2"
+    "@dhis2/app-service-data" "2.9.2"
+    "@dhis2/app-service-offline" "2.9.2"
+
 "@dhis2/app-service-alerts@2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.8.0.tgz#f480043a15b5a2b7d90a6e74931ddd3ebb65aa1c"
   integrity sha512-hpMqdxCG9w5H2EZyLPQKcKzCdp/Sof68ZGd85lNHo+1c10+1pWhKAjt/p3zoRllHppp17TbEgKoXa1oRx2NeHg==
+
+"@dhis2/app-service-alerts@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.9.2.tgz#c8bdd71d4426c356f3cf5456191a5ddca7e6db67"
+  integrity sha512-avCV8GiolYKfiw/Mez8OF9qWWwnzcjS558bAQssVJrnOdYrnjK8r6pJmS6BszCt54rpZVAneR/SGkwKfpxUauQ==
 
 "@dhis2/app-service-config@2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.8.0.tgz#4ce7520e28a7700fa11ad7bcba6468a0a58751a4"
   integrity sha512-SZnoa2EjsgV8a1QfnSk6fqxORV3pRcA+SYyz/H/nkr/VodkdgmO5CiwlZxXW8pG+4i6sbMGjGualam2jHF34wg==
 
+"@dhis2/app-service-config@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.9.2.tgz#08ccf8f449933ce4bb638724e467ee0984a8671e"
+  integrity sha512-YhtcpVUwOlRsT/rNhJZTwUnwixsdlv1tg6VtKyykrvCpuoU9qWO6BaSq3yygArApOvQBYMZHTnonDKSc5qK8fg==
+
 "@dhis2/app-service-data@2.8.0":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.8.0.tgz#9cd347127968cb6f3c8a4ab0fc6699ea7058f835"
   integrity sha512-5doyL4bxRMdMXY4RtWo2O3NVGwSDOSUY3hGPXaF1TeFWAqujlPTx17uDw6wEelN6LaryAnVwId2Ep3FOV8v5MA==
+
+"@dhis2/app-service-data@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.9.2.tgz#c048d896f5b620326284bc4ee3d10924f3153b82"
+  integrity sha512-SRqrewTFNFP58pqfJrMoHZWapMsdjRyx5OCsYeDO8XWF3N+gyYsFrQlBOah3tXGeOY0AhE4Pwji9W9ycpam0sA==
+
+"@dhis2/app-service-offline@2.9.2":
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/app-service-offline/-/app-service-offline-2.9.2.tgz#345eb009fcb9b665a9399f7d1a9ee315760a09d4"
+  integrity sha512-5V5mcGLb/HjnFKj1/WT2UMHIuNtOkA0XS0dwUqBPfVeCPjkk2itiRsCe59alosu4/cH6veasHadKPNLEm6Y5Mw==
+  dependencies:
+    lodash "^4.17.21"
 
 "@dhis2/app-shell@7.3.0":
   version "7.3.0"
@@ -19665,10 +19697,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Fulfills first iteration of [LIBS-48: Display connection status in global interface](https://jira.dhis2.org/browse/LIBS-48)

This PR adds a status badge/bar on mobile to the headerbar that shows 'Online' or 'Offline' and an appropriate icon.

The full spec for the first iteration includes the ability to add additional text beside the online status, which will come in one or more following PR's to keep the scope of this one concise. Also, the status indicator at this stage is in a useful working state.

To add the additional text to the indicator:

- [ ] Make sure styles additional info text can shrink using an ellipsis for overflow
- [ ] Enable 'Last online ___ ago' info text while offline (that can be opted into)
    - [ ] In header bar, if config option is set, add 'last online' text to `info` prop on `<OnlineStatus>` components 
    - [ ] Integrations:
        - [ ] In app platform, add config option like `headerbar: { addlOnlineStatusInfo: 'last-online'/'custom' }` in `d2.config.js` to enable (handle in app CLI, app adapter, and app shell)
        - [ ] In app runtime, add feature to `useOnlineStatus` hook that tracks 'last online' time
- [ ] Add a way to provide custom info text from the app to the header bar (this may need to come in the next iteration)