### PR TITLE
feat: add 'last online' info to status indicator

### DIFF
--- a/components/header-bar/i18n/en.pot
+++ b/components/header-bar/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-08-30T10:10:25.885Z\n"
-"PO-Revision-Date: 2021-08-30T10:10:25.885Z\n"
+"POT-Creation-Date: 2021-09-01T08:53:25.443Z\n"
+"PO-Revision-Date: 2021-09-01T08:53:25.443Z\n"
 
 msgid "Search apps"
 msgstr "Search apps"
@@ -16,6 +16,9 @@ msgstr "Online"
 
 msgid "Offline"
 msgstr "Offline"
+
+msgid "Last online {{relativeTime}}"
+msgstr "Last online {{relativeTime}}"
 
 msgid "Edit profile"
 msgstr "Edit profile"

--- a/components/header-bar/package.json
+++ b/components/header-bar/package.json
@@ -26,7 +26,7 @@
         "test": "d2-app-scripts test --jestConfig ../../jest.config.shared.js"
     },
     "peerDependencies": {
-        "@dhis2/app-runtime": "^2.9.2",
+        "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/d2-i18n": "^1",
         "react": "^16.8",
         "react-dom": "^16.8",
@@ -43,13 +43,14 @@
         "@dhis2/ui-constants": "6.20.0",
         "@dhis2/ui-icons": "6.20.0",
         "classnames": "^2.3.1",
+        "moment": "^2.29.1",
         "prop-types": "^15.7.2"
     },
     "files": [
         "build"
     ],
     "devDependencies": {
-        "@dhis2/app-runtime": "^2.9.2",
+        "@dhis2/app-runtime": "^2.11.0",
         "@dhis2/d2-i18n": "^1.1.0",
         "react": "16.13",
         "react-dom": "16.13",

--- a/components/header-bar/src/features/the_headerbar_can_display_online_status.feature
+++ b/components/header-bar/src/features/the_headerbar_can_display_online_status.feature
@@ -1,4 +1,20 @@
-Feature: The HeaderBar displays online status when PWA is enabled
+Feature: The HeaderBar can display online status
+
+    # Configuring to show
+
+    Scenario: The HeaderBar doesn't display online status when not configured
+        Given the HeaderBar loads without an error
+        Then the HeaderBar does not render online status
+
+    Scenario: The HeaderBar displays online status when configured to
+        Given the HeaderBar loads without error with showOnlineStatus configured
+        Then the HeaderBar renders online status
+
+    Scenario: The HeaderBar displays online status when PWA is enabled
+        Given the HeaderBar loads without error when PWA is enabled
+        Then the HeaderBar renders online status
+
+    # Large / small screens & Online / Offline status
 
     Scenario: The HeaderBar displays a badge on large screens
         Given the HeaderBar loads without error when PWA is enabled

--- a/components/header-bar/src/features/the_headerbar_can_display_online_status/the_headerbar_displays_online_status.js
+++ b/components/header-bar/src/features/the_headerbar_can_display_online_status/the_headerbar_displays_online_status.js
@@ -52,6 +52,13 @@ const goOnline = () => {
 Before(() => goOnline())
 After(() => goOnline())
 
+Given(
+    'the HeaderBar loads without error with showOnlineStatus configured',
+    () => {
+        cy.visitStory('HeaderBarTesting', 'Show Online Status')
+    }
+)
+
 Given('the HeaderBar loads without error when PWA is enabled', () => {
     cy.visitStory('HeaderBarTesting', 'PWA Enabled')
 })
@@ -62,6 +69,14 @@ Given("the HeaderBar loads without error with 'LAST_ONLINE' configured", () => {
 
 And('the viewport is narrower than 480px', () => {
     cy.viewport(460, 660)
+})
+
+Then('the HeaderBar does not render online status', () => {
+    cy.get('[data-test="headerbar-online-status"]').should('not.exist')
+})
+
+Then('the HeaderBar renders online status', () => {
+    cy.get('[data-test="headerbar-online-status"]').should('exist')
 })
 
 Then('the HeaderBar displays only the desktop status badge', () => {

--- a/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled.feature
+++ b/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled.feature
@@ -14,3 +14,31 @@ Feature: The HeaderBar displays online status when PWA is enabled
         Given the HeaderBar loads without error when PWA is enabled
         And the browser goes offline
         Then the status badge shows offline
+
+    # Additional text
+
+    Scenario: No additional status text is displayed by default
+        Given the HeaderBar loads without error when PWA is enabled
+        Then no info text is displayed
+        And the browser goes offline
+        Then no info text is displayed
+
+    Scenario: No additional status text is displayed by default on small screens
+        Given the HeaderBar loads without error when PWA is enabled
+        And the viewport is narrower than 480px
+        Then no info text is displayed
+        And the browser goes offline
+        Then no info text is displayed
+
+    Scenario: Last online text is displayed in status badge when configured and offline
+        Given the HeaderBar loads without error with 'LAST_ONLINE' configured
+        Then no info text is displayed
+        And the browser goes offline
+        Then last online text is displayed in the status badge
+
+    Scenario: Last online text is displayed in status bar when configured and offline
+        Given the HeaderBar loads without error with 'LAST_ONLINE' configured
+        And the viewport is narrower than 480px
+        Then no info text is displayed
+        And the browser goes offline
+        Then last online text is displayed in the mobile status bar

--- a/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled/the_headerbar_displays_online_status.js
+++ b/components/header-bar/src/features/the_headerbar_displays_online_status_when_pwa_is_enabled/the_headerbar_displays_online_status.js
@@ -56,6 +56,10 @@ Given('the HeaderBar loads without error when PWA is enabled', () => {
     cy.visitStory('HeaderBarTesting', 'PWA Enabled')
 })
 
+Given("the HeaderBar loads without error with 'LAST_ONLINE' configured", () => {
+    cy.visitStory('HeaderBarTesting', 'With Last Online')
+})
+
 And('the viewport is narrower than 480px', () => {
     cy.viewport(460, 660)
 })
@@ -100,5 +104,26 @@ Then('the status badge shows offline', () => {
         $icon => {
             expect($icon).to.have.class('offline')
         }
+    )
+})
+
+Then('no info text is displayed', () => {
+    cy.get('[data-test="headerbar-online-status"] .info').should('not.exist')
+    cy.get('[data-test="headerbar-online-status"] .info-dense').should(
+        'not.exist'
+    )
+})
+
+Then('last online text is displayed in the status badge', () => {
+    cy.get('[data-test="headerbar-online-status"].badge .info').should(
+        'include.text',
+        'Last online'
+    )
+})
+
+Then('last online text is displayed in the mobile status bar', () => {
+    cy.get('[data-test="headerbar-online-status"].bar .info-dense').should(
+        'include.text',
+        'Last online'
     )
 })

--- a/components/header-bar/src/header-bar.js
+++ b/components/header-bar/src/header-bar.js
@@ -71,10 +71,7 @@ export const HeaderBar = ({ appName, className }) => {
                             instance={data.title.applicationTitle}
                         />
                         <div className="right-control-spacer" />
-                        {pwaEnabled && (
-                            // todo: info
-                            <OnlineStatus />
-                        )}
+                        {pwaEnabled && <OnlineStatus />}
                         <Notifications
                             interpretations={
                                 data.notifications.unreadInterpretations
@@ -94,10 +91,7 @@ export const HeaderBar = ({ appName, className }) => {
                     </>
                 )}
             </div>
-            {pwaEnabled && !loading && !error && (
-                // todo: info
-                <OnlineStatus dense />
-            )}
+            {pwaEnabled && !loading && !error && <OnlineStatus dense />}
 
             <style jsx>{`
                 .main {

--- a/components/header-bar/src/header-bar.js
+++ b/components/header-bar/src/header-bar.js
@@ -36,7 +36,11 @@ const avatarUrl = (avatar, baseUrl) =>
     avatar ? joinPath(baseUrl, 'api/fileResources', avatar.id, 'data') : null
 
 export const HeaderBar = ({ appName, className }) => {
-    const { baseUrl, pwaEnabled } = useConfig()
+    const {
+        baseUrl,
+        pwaEnabled,
+        headerbar: { showOnlineStatus } = {},
+    } = useConfig()
     const { loading, error, data } = useDataQuery(query)
 
     const apps = useMemo(() => {
@@ -71,7 +75,7 @@ export const HeaderBar = ({ appName, className }) => {
                             instance={data.title.applicationTitle}
                         />
                         <div className="right-control-spacer" />
-                        {pwaEnabled && <OnlineStatus />}
+                        {(pwaEnabled || showOnlineStatus) && <OnlineStatus />}
                         <Notifications
                             interpretations={
                                 data.notifications.unreadInterpretations
@@ -91,7 +95,9 @@ export const HeaderBar = ({ appName, className }) => {
                     </>
                 )}
             </div>
-            {pwaEnabled && !loading && !error && <OnlineStatus dense />}
+            {(pwaEnabled || showOnlineStatus) && !loading && !error && (
+                <OnlineStatus dense />
+            )}
 
             <style jsx>{`
                 .main {

--- a/components/header-bar/src/header-bar.stories.e2e.js
+++ b/components/header-bar/src/header-bar.stories.e2e.js
@@ -23,3 +23,15 @@ export const PWAEnabled = () => (
         <HeaderBar appName="Example!" />
     </Provider>
 )
+
+export const WithLastOnline = () => (
+    <Provider
+        config={{
+            ...config,
+            pwaEnabled: true,
+            headerbar: { onlineStatusInfo: 'LAST_ONLINE' },
+        }}
+    >
+        <HeaderBar appName="Example!" />
+    </Provider>
+)

--- a/components/header-bar/src/header-bar.stories.e2e.js
+++ b/components/header-bar/src/header-bar.stories.e2e.js
@@ -18,6 +18,12 @@ export const Default = () => (
     </Provider>
 )
 
+export const ShowOnlineStatus = () => (
+    <Provider config={{ ...config, headerbar: { showOnlineStatus: true } }}>
+        <HeaderBar appName="Example!" />
+    </Provider>
+)
+
 export const PWAEnabled = () => (
     <Provider config={{ ...config, pwaEnabled: true }}>
         <HeaderBar appName="Example!" />
@@ -28,8 +34,10 @@ export const WithLastOnline = () => (
     <Provider
         config={{
             ...config,
-            pwaEnabled: true,
-            headerbar: { onlineStatusInfo: 'LAST_ONLINE' },
+            headerbar: {
+                showOnlineStatus: true,
+                onlineStatusInfo: 'LAST_ONLINE',
+            },
         }}
     >
         <HeaderBar appName="Example!" />

--- a/components/header-bar/src/header-bar.stories.js
+++ b/components/header-bar/src/header-bar.stories.js
@@ -254,3 +254,27 @@ WithOnlineStatus.parameters = {
         },
     },
 }
+
+export const WithLastOnlineInfo = args => {
+    const config = {
+        ...mockConfig,
+        pwaEnabled: true,
+        headerbar: { onlineStatusInfo: 'LAST_ONLINE' },
+    }
+    return (
+        <Provider config={config}>
+            <CustomDataProvider data={customData}>
+                <HeaderBar {...args} />
+            </CustomDataProvider>
+        </Provider>
+    )
+}
+WithLastOnlineInfo.parameters = {
+    docs: {
+        description: {
+            story:
+                'When offline, the status indicator will show text describing \
+                time since last online.',
+        },
+    },
+}

--- a/components/header-bar/src/online-status.js
+++ b/components/header-bar/src/online-status.js
@@ -1,13 +1,33 @@
-import { useOnlineStatus } from '@dhis2/app-runtime'
+import { useConfig, useOnlineStatus } from '@dhis2/app-runtime'
 import cx from 'classnames'
+import moment from 'moment'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from './locales/index.js'
 import styles from './online-status.styles.js'
 
+const useOnlineStatusInfo = ({ online, lastOnline }) => {
+    const { headerbar } = useConfig()
+
+    if (
+        headerbar?.onlineStatusInfo === 'LAST_ONLINE' &&
+        !online &&
+        lastOnline
+    ) {
+        return i18n.t('Last online {{relativeTime}}', {
+            relativeTime: moment(lastOnline).fromNow(),
+        })
+    }
+    // todo: in the future, support 'CUSTOM' option
+
+    return null
+}
+
 /** A badge to display online/offline status in the header bar */
-export function OnlineStatus({ info, dense }) {
-    const { online } = useOnlineStatus()
+export function OnlineStatus({ dense }) {
+    const { online, lastOnline } = useOnlineStatus()
+    const info = useOnlineStatusInfo({ online, lastOnline })
+
     const displayStatus = online ? i18n.t('Online') : i18n.t('Offline')
 
     return (
@@ -26,6 +46,4 @@ export function OnlineStatus({ info, dense }) {
 OnlineStatus.propTypes = {
     /** If true, displays as a sub-bar instead of a badge */
     dense: PropTypes.bool,
-    /** Additional text to display beside status */
-    info: PropTypes.string,
 }

--- a/components/header-bar/src/online-status.styles.js
+++ b/components/header-bar/src/online-status.styles.js
@@ -39,7 +39,7 @@ export default css`
         margin-right: ${spacers.dp16};
     }
 
-    .info-mobile {
+    .info-dense {
         margin-left: ${spacers.dp12};
         font-size: 12px;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,7 +2167,7 @@
   dependencies:
     moment "^2.24.0"
 
-"@dhis2/app-runtime@^2.11.0":
+"@dhis2/app-runtime@^2.11.0", "@dhis2/app-runtime@^2.8.0", "@dhis2/app-runtime@^2.9.2":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.11.0.tgz#85f6474ce8957e500ae129abe80bdc02a272d24d"
   integrity sha512-rHqWttpOSgKpdSZXIe+Ay9fehkIAfYuTYshH4z0tYaCOdtRLz+J7z8EbESIwtTpcgrYaqv9gcojiqwc3/RwZiA==
@@ -2177,57 +2177,25 @@
     "@dhis2/app-service-data" "2.11.0"
     "@dhis2/app-service-offline" "2.11.0"
 
-"@dhis2/app-runtime@^2.8.0", "@dhis2/app-runtime@^2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-runtime/-/app-runtime-2.9.2.tgz#b24174ac1a3f0ce695cd60919d90cd6be11ea59d"
-  integrity sha512-Cgy6CQjpdTaV/DFy8IyQPg8tuZztHqyfiaydEZhfikyPCaaS5W+t9X6QN7Tswj3e/U4giEJEU4way4aK2+sWww==
-  dependencies:
-    "@dhis2/app-service-alerts" "2.9.2"
-    "@dhis2/app-service-config" "2.9.2"
-    "@dhis2/app-service-data" "2.9.2"
-    "@dhis2/app-service-offline" "2.9.2"
-
 "@dhis2/app-service-alerts@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.11.0.tgz#a6efcfc2c42558a6d4d1784c703d43d06d50625a"
   integrity sha512-9PzDla7SxBERIYOoffWVF2bNMBQOjo46qRwNdoeXN6SCPyTpizNQjp5TGP5cSnvBIupcYtgAGnx/IIuxk0TBIA==
-
-"@dhis2/app-service-alerts@2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-alerts/-/app-service-alerts-2.9.2.tgz#c8bdd71d4426c356f3cf5456191a5ddca7e6db67"
-  integrity sha512-avCV8GiolYKfiw/Mez8OF9qWWwnzcjS558bAQssVJrnOdYrnjK8r6pJmS6BszCt54rpZVAneR/SGkwKfpxUauQ==
 
 "@dhis2/app-service-config@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.11.0.tgz#9f3b4ca82b154528dd7e0fd9ff15382ae586a53e"
   integrity sha512-nrlZSoVREuJ7wQXKAtaV8LmkuQpkKtTkvBMikuGXXKHJ/PT/Av56oSihLsLnHu4RiFFkgl7GHUdpYvFheNUhHQ==
 
-"@dhis2/app-service-config@2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-config/-/app-service-config-2.9.2.tgz#08ccf8f449933ce4bb638724e467ee0984a8671e"
-  integrity sha512-YhtcpVUwOlRsT/rNhJZTwUnwixsdlv1tg6VtKyykrvCpuoU9qWO6BaSq3yygArApOvQBYMZHTnonDKSc5qK8fg==
-
 "@dhis2/app-service-data@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.11.0.tgz#77f7d2d47872a94c12758871bd4a09b18933f2d7"
   integrity sha512-Pg4e8R05pIZkjCE6no4uYtshVwUVybPXAASRjx2VHw1vhGVPVCFqCmJdOgFSkQ1lHA1VtLkEd4uaKLXEKQpqXw==
 
-"@dhis2/app-service-data@2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-data/-/app-service-data-2.9.2.tgz#c048d896f5b620326284bc4ee3d10924f3153b82"
-  integrity sha512-SRqrewTFNFP58pqfJrMoHZWapMsdjRyx5OCsYeDO8XWF3N+gyYsFrQlBOah3tXGeOY0AhE4Pwji9W9ycpam0sA==
-
 "@dhis2/app-service-offline@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@dhis2/app-service-offline/-/app-service-offline-2.11.0.tgz#75bf0c066911530906fb0e8487c5ba72a39ecc1f"
   integrity sha512-s+5RzAvLYvkvH+x437KnmdiFv5yHaqaqUXoxbEVk0iHEp3b73giqLjONzUYf9ciWFdjEDeEwWvjZrkTzGlCl2w==
-  dependencies:
-    lodash "^4.17.21"
-
-"@dhis2/app-service-offline@2.9.2":
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/app-service-offline/-/app-service-offline-2.9.2.tgz#345eb009fcb9b665a9399f7d1a9ee315760a09d4"
-  integrity sha512-5V5mcGLb/HjnFKj1/WT2UMHIuNtOkA0XS0dwUqBPfVeCPjkk2itiRsCe59alosu4/cH6veasHadKPNLEm6Y5Mw==
   dependencies:
     lodash "^4.17.21"
 
@@ -20324,10 +20292,8 @@ watchpack@^1.7.4:
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.7.5.tgz#1267e6c55e0b9b5be44c2023aed5437a2c26c453"
   integrity sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==
   dependencies:
-    chokidar "^3.4.1"
     graceful-fs "^4.1.2"
     neo-async "^2.5.0"
-    watchpack-chokidar2 "^2.0.1"
   optionalDependencies:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"


### PR DESCRIPTION
Part of https://jira.dhis2.org/browse/LIBS-48

Applying this feature will also require some changes to the app platform:
1. to read a configuration option in `d2.config.js` that decides what kind of additional text to add to the online status indicator -- I'm thinking either `headerbar.onlineStatusInfo` or `pwa.headerbarStatusInfo` for the config property, but I'd like a second opinion 🧐 
2. and add that option to the app config through the shell and adapter