### PR TITLE
fix(sharing-dialog): prevent search field remount and focus loss

### DIFF
--- a/components/sharing-dialog/src/autocomplete/autocomplete.js
+++ b/components/sharing-dialog/src/autocomplete/autocomplete.js
@@ -67,7 +67,7 @@ export const Autocomplete = ({
         onChange(value)
     }
 
-    const AutocompleteField = () => (
+    const renderInputField = () => (
         <InputField
             label={label}
             placeholder={placeholder}
@@ -83,10 +83,10 @@ export const Autocomplete = ({
             <div ref={inputRef}>
                 {offline ? (
                     <Tooltip content={i18n.t('Not available offline')}>
-                        <AutocompleteField />
+                        {renderInputField()}
                     </Tooltip>
                 ) : (
-                    <AutocompleteField />
+                    renderInputField()
                 )}
             </div>
             {Boolean(searchResults.length) && (


### PR DESCRIPTION
Editing the search field results in the input field being remounted, which causes focus to be lost.

This PR fixes this by moving the field rendering from a component to a function.