### PR TITLE
fix(header-bar): make online status text unselectable

### DIFF
--- a/components/header-bar/src/online-status.js
+++ b/components/header-bar/src/online-status.js
@@ -35,10 +35,14 @@ export function OnlineStatus({ dense }) {
             className={cx('container', dense ? 'bar' : 'badge')}
             data-test="headerbar-online-status"
         >
-            {info && !dense && <span className="info">{info}</span>}
+            {info && !dense && (
+                <span className="info unselectable">{info}</span>
+            )}
             <div className={cx('icon', online ? 'online' : 'offline')}></div>
-            <span className="label">{displayStatus}</span>
-            {info && dense && <span className="info-dense">{info}</span>}
+            <span className="label unselectable">{displayStatus}</span>
+            {info && dense && (
+                <span className="info-dense unselectable">{info}</span>
+            )}
             <style jsx>{styles}</style>
         </div>
     )

--- a/components/header-bar/src/online-status.styles.js
+++ b/components/header-bar/src/online-status.styles.js
@@ -35,6 +35,13 @@ export default css`
         }
     }
 
+    .unselectable {
+        -moz-user-select: none;
+        -webkit-user-select: none;
+        -ms-user-select: none;
+        user-select: none;
+    }
+
     .info {
         margin-right: ${spacers.dp16};
     }

--- a/components/header-bar/src/online-status.styles.js
+++ b/components/header-bar/src/online-status.styles.js
@@ -36,9 +36,7 @@ export default css`
     }
 
     .unselectable {
-        -moz-user-select: none;
-        -webkit-user-select: none;
-        -ms-user-select: none;
+        cursor: default;
         user-select: none;
     }
 


### PR DESCRIPTION
Uses the [`user-select`](https://developer.mozilla.org/en-US/docs/Web/CSS/user-select) CSS property to make label and info text unselectable