### PR TITLE
chore(build): limit concurrent processes to 5

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -12,6 +12,7 @@
  * 3. keeping the package.json file readable
  */
 
+const os = require('os')
 const path = require('path')
 const concurrently = require('concurrently')
 
@@ -37,11 +38,14 @@ const commands = packages.map(p => {
     }
 })
 
+const threads = os.cpus().length
+
 concurrently([...commands], {
     prefix: 'name',
     killOthers: ['failure'],
     restartTries: 1,
     cwd: path.resolve(__dirname, '..'),
+    maxProcesses: Math.max(threads - 1, 1),
 }).then(
     () => {
         console.log('Built UI successfully')


### PR DESCRIPTION
See: https://dhis2.slack.com/archives/CBM8LNEQM/p1631613953060600. Prevents all build processes from running at once.