### PR TITLE
feat(pagination): add hidePageSummary prop and story for custom summary

### DIFF
--- a/components/pagination/src/pagination.js
+++ b/components/pagination/src/pagination.js
@@ -12,6 +12,7 @@ const Pagination = ({
     dataTest,
     hidePageSizeSelect,
     hidePageSelect,
+    hidePageSummary,
     page,
     pageCount,
     pageSize,
@@ -38,14 +39,16 @@ const Pagination = ({
                     pageSizeSelectText={pageSizeSelectText}
                 />
             )}
-            <PageSummary
-                dataTest={dataTest}
-                page={page}
-                pageCount={pageCount}
-                pageSize={pageSize}
-                total={total}
-                pageSummaryText={pageSummaryText}
-            />
+            {!hidePageSummary && (
+                <PageSummary
+                    dataTest={dataTest}
+                    page={page}
+                    pageCount={pageCount}
+                    pageSize={pageSize}
+                    total={total}
+                    pageSummaryText={pageSummaryText}
+                />
+            )}
             <div className="page-navigation">
                 {!hidePageSelect && (
                     <PageSelect
@@ -107,6 +110,7 @@ Pagination.propTypes = {
     dataTest: PropTypes.string,
     hidePageSelect: PropTypes.bool,
     hidePageSizeSelect: PropTypes.bool,
+    hidePageSummary: PropTypes.bool,
     nextPageText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     pageSelectText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     pageSizeSelectText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),

--- a/components/pagination/src/pagination.stories.js
+++ b/components/pagination/src/pagination.stories.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import React from 'react'
 import * as pagers from './__fixtures__/index.js'
 import { Pagination } from './pagination.js'
@@ -56,6 +57,18 @@ WithoutPageSizeSelect.args = { hidePageSizeSelect: true }
 
 export const WithoutGoToPageSelect = Template.bind({})
 WithoutGoToPageSelect.args = { hidePageSelect: true }
+
+export const WithoutPageSummary = Template.bind({})
+WithoutPageSummary.args = { hidePageSummary: true }
+
+export const WithCustomPageSummary = Template.bind({})
+WithCustomPageSummary.args = {
+    pageSummaryText: interpolationObject =>
+        i18n.t(
+            'Page nr {{page}} of {{pageCount}} pages, items {{firstItem}}-{{lastItem}}, NO TOTAL',
+            interpolationObject
+        ),
+}
 
 export const WithoutAnySelect = Template.bind({})
 WithoutAnySelect.args = {


### PR DESCRIPTION
Let me know:
- Do we need that addiitonal prop? I'm afraid we do since it matches the design specs. I suppose we could allow for hiding it by setting `pageSummaryText` to an empty string too, but that's not very consistent with everything else.
- Is the way we can customise summary text OK?