### PR TITLE
chore(git): unignore collections/core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ node_modules/
 build/
 dist/
 
+# unignore collections so it shows up when transitioning from older ui
+# versions to versions that no longer ship core
+!/collections/core/build/
+
 # misc
 .DS_Store
 .env.local


### PR DESCRIPTION
This doesn't mean that we should go committing collections/core of course. It's there so that this build artifact will show up in git history when transitioning from older ui versions that did ship core. It'll fail the build when not removed so this'll at least send a little clearer of a signal to the dev.