### PR TITLE
fix(data-table): use padding instead of fixed cell heights

### DIFF
--- a/components/table/src/data-table/__tests__/data-table-column-header.test.js
+++ b/components/table/src/data-table/__tests__/data-table-column-header.test.js
@@ -38,10 +38,11 @@ describe('<DataTableColumnHeader>', () => {
         expect(wrapper.find(TableHeaderCell).prop('align')).toBe(right)
     })
     it('accepts a className prop', () => {
-        const className = 'test'
-        const wrapper = shallow(<DataTableColumnHeader className={className} />)
+        const wrapper = shallow(<DataTableColumnHeader className="test" />)
 
-        expect(wrapper.find(TableHeaderCell).prop('className')).toBe(className)
+        expect(wrapper.find(TableHeaderCell).prop('className')).toBe(
+            'test DataTableColumnHeader'
+        )
     })
     it('accepts a colSpan prop', () => {
         const colSpan = '3'

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.js
@@ -3,7 +3,10 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 import { TableHeaderCell } from '../table-elements/index.js'
-import styles from './data-table-column-header.styles.js'
+import {
+    styles,
+    resolvedTableHeaderCss,
+} from './data-table-column-header.styles.js'
 import { FilterHandle } from './filter-handle.js'
 import { Sorter, SORT_DIRECTIONS } from './sorter.js'
 
@@ -40,7 +43,11 @@ export const DataTableColumnHeader = forwardRef(
     ) => (
         <TableHeaderCell
             align={align}
-            className={className}
+            className={cx(
+                className,
+                'DataTableColumnHeader',
+                resolvedTableHeaderCss.className
+            )}
             colSpan={colSpan}
             dataTest={dataTest}
             fixed={fixed}
@@ -53,7 +60,7 @@ export const DataTableColumnHeader = forwardRef(
             top={top}
             width={width}
         >
-            <span className={cx('container', { showFilter })}>
+            <span className="container">
                 <span className={cx('top', { large })}>
                     <span className="content">{children}</span>
                     {sortDirection && (
@@ -73,6 +80,7 @@ export const DataTableColumnHeader = forwardRef(
                 </span>
                 {showFilter && filter}
             </span>
+            {resolvedTableHeaderCss.styles}
             <style jsx>{styles}</style>
             <style jsx>{`
                 .label {

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.js
@@ -55,7 +55,7 @@ export const DataTableColumnHeader = forwardRef(
         >
             <span className={cx('container', { showFilter })}>
                 <span className={cx('top', { large })}>
-                    {children}
+                    <span className="content">{children}</span>
                     {sortDirection && (
                         <Sorter
                             name={name}

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
@@ -1,14 +1,10 @@
-import { spacers } from '@dhis2/ui-constants'
 import css from 'styled-jsx/css'
 
-export default css`
+export const styles = css`
     span.container {
         display: flex;
         flex-direction: column;
         height: 100%;
-    }
-    span.showFilter {
-        padding-bottom: ${spacers.dp4};
     }
     span.top {
         display: flex;
@@ -18,5 +14,17 @@ export default css`
     span.content {
         display: flex;
         align-items: center;
+        min-height: 24px;
+    }
+`
+
+export const resolvedTableHeaderCss = css.resolve`
+    :global(thead) > :global(tr) > th.DataTableColumnHeader {
+        padding-top: 3px;
+        padding-bottom: 3px;
+    }
+    :global(thead) > :global(tr) > th.DataTableColumnHeader.large {
+        padding-top: 8px;
+        padding-bottom: 8px;
     }
 `

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
@@ -14,9 +14,5 @@ export default css`
         display: flex;
         flex-direction: row;
         align-items: center;
-        height: 36px;
-    }
-    span.top.large {
-        height: 48px;
     }
 `

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
@@ -13,7 +13,7 @@ export default css`
     span.top {
         display: flex;
         flex-direction: row;
-        align-items: top;
+        align-items: flex-start;
     }
     span.content {
         display: flex;

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
@@ -13,6 +13,10 @@ export default css`
     span.top {
         display: flex;
         flex-direction: row;
+        align-items: top;
+    }
+    span.content {
+        display: flex;
         align-items: center;
     }
 `

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.styles.js
@@ -20,11 +20,11 @@ export const styles = css`
 
 export const resolvedTableHeaderCss = css.resolve`
     :global(thead) > :global(tr) > th.DataTableColumnHeader {
-        padding-top: 3px;
-        padding-bottom: 3px;
+        padding-top: 6px;
+        padding-bottom: 6px;
     }
     :global(thead) > :global(tr) > th.DataTableColumnHeader.large {
-        padding-top: 8px;
-        padding-bottom: 8px;
+        padding-top: 12px;
+        padding-bottom: 12px;
     }
 `

--- a/components/table/src/data-table/data-table.stories.js
+++ b/components/table/src/data-table/data-table.stories.js
@@ -1033,9 +1033,8 @@ const ScrollingDataTableWithToolbarsTemplate = args => (
     </Box>
 )
 
-export const ScrollingDataTableWithToolbars = ScrollingDataTableWithToolbarsTemplate.bind(
-    {}
-)
+export const ScrollingDataTableWithToolbars =
+    ScrollingDataTableWithToolbarsTemplate.bind({})
 ScrollingDataTableWithToolbars.args = {
     layout: 'fixed',
     width: '1000px',

--- a/components/table/src/data-table/data-table.stories.js
+++ b/components/table/src/data-table/data-table.stories.js
@@ -1033,8 +1033,9 @@ const ScrollingDataTableWithToolbarsTemplate = args => (
     </Box>
 )
 
-export const ScrollingDataTableWithToolbars =
-    ScrollingDataTableWithToolbarsTemplate.bind({})
+export const ScrollingDataTableWithToolbars = ScrollingDataTableWithToolbarsTemplate.bind(
+    {}
+)
 ScrollingDataTableWithToolbars.args = {
     layout: 'fixed',
     width: '1000px',
@@ -1218,11 +1219,12 @@ InlineFiltering.args = {
     layout: 'fixed',
 }
 
-const LongCellContentTemplate = () => (
+const LongCellContentTemplate = ({ large }) => (
     <DataTable>
         <DataTableHead>
             <DataTableRow>
                 <DataTableColumnHeader
+                    large={large}
                     onSortIconClick={() => {}}
                     sortDirection="asc"
                     name="first"
@@ -1234,6 +1236,7 @@ const LongCellContentTemplate = () => (
                     voluptas?
                 </DataTableColumnHeader>
                 <DataTableColumnHeader
+                    large={large}
                     onFilterIconClick={() => {}}
                     name="firstName"
                     showFilter={true}
@@ -1253,6 +1256,7 @@ const LongCellContentTemplate = () => (
                     voluptas?
                 </DataTableColumnHeader>
                 <DataTableColumnHeader
+                    large={large}
                     onSortIconClick={() => {}}
                     sortDirection="asc"
                     name="third"
@@ -1260,6 +1264,7 @@ const LongCellContentTemplate = () => (
                     Third (short)
                 </DataTableColumnHeader>
                 <DataTableColumnHeader
+                    large={large}
                     onSortIconClick={() => {}}
                     sortDirection="asc"
                     name="fourth"
@@ -1274,22 +1279,22 @@ const LongCellContentTemplate = () => (
         </DataTableHead>
         <DataTableBody>
             <DataTableRow>
-                <DataTableCell>
+                <DataTableCell large={large}>
                     FIRST - Lorem ipsum dolor sit amet, consectetur adipisicing
                     elit. Eligendi non quis exercitationem culpa nesciunt nihil
                     aut nostrum explicabo reprehenderit optio amet ab temporibus
                     asperiores quasi cupiditate. Voluptatum ducimus voluptates
                     voluptas?
                 </DataTableCell>
-                <DataTableCell>
+                <DataTableCell large={large}>
                     SECOND - Lorem ipsum dolor sit amet, consectetur adipisicing
                     elit. Eligendi non quis exercitationem culpa nesciunt nihil
                     aut nostrum explicabo reprehenderit optio amet ab temporibus
                     asperiores quasi cupiditate. Voluptatum ducimus voluptates
                     voluptas?
                 </DataTableCell>
-                <DataTableCell>Third (short)</DataTableCell>
-                <DataTableCell>
+                <DataTableCell large={large}>Third (short)</DataTableCell>
+                <DataTableCell large={large}>
                     Fourth - Lorem ipsum dolor sit amet, consectetur adipisicing
                     elit. Eligendi non quis exercitationem culpa nesciunt nihil
                     aut nostrum explicabo reprehenderit optio amet ab temporibus
@@ -1302,3 +1307,8 @@ const LongCellContentTemplate = () => (
 )
 
 export const LongCellContent = LongCellContentTemplate.bind({})
+
+export const LongCellContentLargeCells = LongCellContentTemplate.bind({})
+LongCellContentLargeCells.args = {
+    large: 'true',
+}

--- a/components/table/src/data-table/data-table.stories.js
+++ b/components/table/src/data-table/data-table.stories.js
@@ -1217,3 +1217,88 @@ export const InlineFiltering = InlineFilteringTemplate.bind({})
 InlineFiltering.args = {
     layout: 'fixed',
 }
+
+const LongCellContentTemplate = () => (
+    <DataTable>
+        <DataTableHead>
+            <DataTableRow>
+                <DataTableColumnHeader
+                    onSortIconClick={() => {}}
+                    sortDirection="asc"
+                    name="first"
+                >
+                    FIRST - Lorem ipsum dolor sit amet, consectetur adipisicing
+                    elit. Eligendi non quis exercitationem culpa nesciunt nihil
+                    aut nostrum explicabo reprehenderit optio amet ab temporibus
+                    asperiores quasi cupiditate. Voluptatum ducimus voluptates
+                    voluptas?
+                </DataTableColumnHeader>
+                <DataTableColumnHeader
+                    onFilterIconClick={() => {}}
+                    name="firstName"
+                    showFilter={true}
+                    filter={
+                        <Input
+                            dense
+                            onChange={() => {}}
+                            name="firstName"
+                            value="Filter value"
+                        />
+                    }
+                >
+                    SECOND - Lorem ipsum dolor sit amet, consectetur adipisicing
+                    elit. Eligendi non quis exercitationem culpa nesciunt nihil
+                    aut nostrum explicabo reprehenderit optio amet ab temporibus
+                    asperiores quasi cupiditate. Voluptatum ducimus voluptates
+                    voluptas?
+                </DataTableColumnHeader>
+                <DataTableColumnHeader
+                    onSortIconClick={() => {}}
+                    sortDirection="asc"
+                    name="third"
+                >
+                    Third (short)
+                </DataTableColumnHeader>
+                <DataTableColumnHeader
+                    onSortIconClick={() => {}}
+                    sortDirection="asc"
+                    name="fourth"
+                >
+                    Fourth - Lorem ipsum dolor sit amet, consectetur adipisicing
+                    elit. Eligendi non quis exercitationem culpa nesciunt nihil
+                    aut nostrum explicabo reprehenderit optio amet ab temporibus
+                    asperiores quasi cupiditate. Voluptatum ducimus voluptates
+                    voluptas?
+                </DataTableColumnHeader>
+            </DataTableRow>
+        </DataTableHead>
+        <DataTableBody>
+            <DataTableRow>
+                <DataTableCell>
+                    FIRST - Lorem ipsum dolor sit amet, consectetur adipisicing
+                    elit. Eligendi non quis exercitationem culpa nesciunt nihil
+                    aut nostrum explicabo reprehenderit optio amet ab temporibus
+                    asperiores quasi cupiditate. Voluptatum ducimus voluptates
+                    voluptas?
+                </DataTableCell>
+                <DataTableCell>
+                    SECOND - Lorem ipsum dolor sit amet, consectetur adipisicing
+                    elit. Eligendi non quis exercitationem culpa nesciunt nihil
+                    aut nostrum explicabo reprehenderit optio amet ab temporibus
+                    asperiores quasi cupiditate. Voluptatum ducimus voluptates
+                    voluptas?
+                </DataTableCell>
+                <DataTableCell>Third (short)</DataTableCell>
+                <DataTableCell>
+                    Fourth - Lorem ipsum dolor sit amet, consectetur adipisicing
+                    elit. Eligendi non quis exercitationem culpa nesciunt nihil
+                    aut nostrum explicabo reprehenderit optio amet ab temporibus
+                    asperiores quasi cupiditate. Voluptatum ducimus voluptates
+                    voluptas?
+                </DataTableCell>
+            </DataTableRow>
+        </DataTableBody>
+    </DataTable>
+)
+
+export const LongCellContent = LongCellContentTemplate.bind({})

--- a/components/table/src/data-table/table-elements/table-data-cell/table-data-cell.styles.js
+++ b/components/table/src/data-table/table-elements/table-data-cell/table-data-cell.styles.js
@@ -3,13 +3,12 @@ import css from 'styled-jsx/css'
 
 export default css`
     td {
-        padding: 0 12px;
+        padding: 14px 12px;
         font-size: 14px;
         border: 1px solid transparant;
         border-bottom: 1px solid ${colors.grey300};
         background-color: ${colors.white};
         color: ${colors.grey900};
-        height: 45px;
     }
     td.active {
         background-color: ${colors.white};
@@ -33,8 +32,8 @@ export default css`
         color: ${colors.green700};
     }
     td.large {
+        padding: 20px 12px;
         font-size: 16px;
-        height: 60px;
     }
     :global(tr:last-child) td {
         border-bottom: 1px solid transparent;

--- a/components/table/src/data-table/table-elements/table-header-cell-action.js
+++ b/components/table/src/data-table/table-elements/table-header-cell-action.js
@@ -19,12 +19,13 @@ export const TableHeaderCellAction = forwardRef(
                     padding: 0;
                     background: transparent;
                     width: 24px;
-                    height: 100%;
+                    height: 24px;
                     display: inline-flex;
                     align-items: center;
                     justify-content: center;
                     flex-shrink: 0;
                     cursor: pointer;
+                    border-radius: 4px;
                 }
                 button:hover,
                 button:focus-visible {

--- a/components/table/src/data-table/table-elements/table-header-cell-action.js
+++ b/components/table/src/data-table/table-elements/table-header-cell-action.js
@@ -26,6 +26,7 @@ export const TableHeaderCellAction = forwardRef(
                     flex-shrink: 0;
                     cursor: pointer;
                     border-radius: 4px;
+                    margin-left: 2px;
                 }
                 button:hover,
                 button:focus-visible {

--- a/components/table/src/data-table/table-elements/table-header-cell/table-header-cell.styles.js
+++ b/components/table/src/data-table/table-elements/table-header-cell/table-header-cell.styles.js
@@ -10,6 +10,7 @@ export default css`
         background-color: ${colors.grey200};
         font-weight: normal;
         font-size: 14px;
+        vertical-align: top;
     }
     :global(thead) th {
         padding: 8px 12px;

--- a/components/table/src/data-table/table-elements/table-header-cell/table-header-cell.styles.js
+++ b/components/table/src/data-table/table-elements/table-header-cell/table-header-cell.styles.js
@@ -3,18 +3,17 @@ import css from 'styled-jsx/css'
 
 export default css`
     th {
-        padding: 0 12px;
+        padding: 12px;
         border: 1px solid transparant;
         border-bottom: 1px solid ${colors.grey300};
         color: ${colors.grey800};
         background-color: ${colors.grey200};
         font-weight: normal;
         font-size: 14px;
-        height: 45px;
     }
     :global(thead) th {
+        padding: 8px 12px;
         font-size: 13px;
-        height: 36px;
     }
     th:last-of-type {
         border-right: 1px solid ${colors.grey300};
@@ -41,12 +40,12 @@ export default css`
         color: ${colors.green700};
     }
     th.large {
+        padding: 14px 12px;
         font-size: 16px;
-        height: 60px;
     }
     :global(thead) th.large {
+        padding: 13px 12px;
         font-size: 15px;
-        height: 48px;
     }
     th.fixed {
         position: sticky;


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/LIBS-236

This PR replaces the use of fixed height table cells with a less brittle padding-based approach.

The primary benefit of this change is the elimination of overflow-related issues:

| Before | After |
| --------- | ------ |
| ![image](https://user-images.githubusercontent.com/4295266/135469315-8da12318-7917-46c6-8c15-e06e97f17fb3.png) | ![image](https://user-images.githubusercontent.com/4295266/135469187-fbe2b70f-c2c8-4b35-8af3-7bdb6c70ce61.png) |
| ![image](https://user-images.githubusercontent.com/4295266/135469841-09cbd9f0-c9ce-40a3-a3f7-2daaeb24069e.png)  | ![image](https://user-images.githubusercontent.com/4295266/135469738-4437d61e-df22-4d1c-aacd-f75232447b07.png) |

