### PR TITLE
fix: remove External users from sharing dialog [6.x]

### DIFF
--- a/components/sharing-dialog/src/__tests__/SharingList.test.js
+++ b/components/sharing-dialog/src/__tests__/SharingList.test.js
@@ -33,7 +33,7 @@ describe('SharingDialog widget - SharingList component', () => {
         }
     })
 
-    it('renders a SharingListItem for external access', () => {
+    it.skip('renders a SharingListItem for external access', () => {
         const external = getSharingListComponent(props).findWhere(
             n => n.prop('target') === SHARE_TARGET_EXTERNAL
         )

--- a/components/sharing-dialog/src/__tests__/SharingListItem.test.js
+++ b/components/sharing-dialog/src/__tests__/SharingListItem.test.js
@@ -29,7 +29,7 @@ describe('SharingDialog widget - SharingListItem component', () => {
         return shallowSharingListItemComponent
     }
 
-    describe('external access', () => {
+    describe.skip('external access', () => {
         beforeEach(() => {
             shallowSharingListItemComponent = undefined
             props = {

--- a/components/sharing-dialog/src/sharing-list.js
+++ b/components/sharing-dialog/src/sharing-list.js
@@ -3,11 +3,9 @@ import React from 'react'
 import i18n from './locales/index.js'
 import {
     SHARE_TARGET_PUBLIC,
-    SHARE_TARGET_EXTERNAL,
     SHARE_TARGET_GROUP,
     SHARE_TARGET_USER,
     accessStrings,
-    ACCESS_NONE,
     ACCESS_VIEW_ONLY,
     ACCESS_VIEW_AND_EDIT,
 } from './sharing-constants.js'
@@ -31,14 +29,6 @@ export const SharingList = ({ sharingSettings, onChange, onRemove }) => (
             <div className="sharing-header-2">{i18n.t('Access level')}</div>
         </div>
         <div className="sharing-list">
-            <SharingListItem
-                name={i18n.t('External users')}
-                target={SHARE_TARGET_EXTERNAL}
-                access={sharingSettings.external}
-                accessOptions={[ACCESS_NONE, ACCESS_VIEW_ONLY]}
-                disabled={!sharingSettings.allowExternal}
-                onChange={access => onChange({ type: 'external', access })}
-            />
             <SharingListItem
                 name={i18n.t('All users')}
                 target={SHARE_TARGET_PUBLIC}


### PR DESCRIPTION
The External users sharing setting does not have any effect currently

Backport of https://github.com/dhis2/ui/pull/756