### PR TITLE
feat(data-table): loading state for DataTableBody

### DIFF
--- a/components/table/src/data-table/data-table.stories.js
+++ b/components/table/src/data-table/data-table.stories.js
@@ -57,7 +57,7 @@ export default {
     },
 }
 
-const BasicTemplate = ({ bordered, large, draggable, ...args }) => (
+const BasicTemplate = ({ bordered, large, draggable, bodyProps, ...args }) => (
     <DataTable {...args}>
         <DataTableHead>
             <DataTableRow>
@@ -76,7 +76,7 @@ const BasicTemplate = ({ bordered, large, draggable, ...args }) => (
                 </DataTableColumnHeader>
             </DataTableRow>
         </DataTableHead>
-        <DataTableBody>
+        <DataTableBody {...bodyProps}>
             <DataTableRow draggable={draggable}>
                 <DataTableCell large={large} bordered={bordered}>
                     Onyekachukwu
@@ -132,6 +132,9 @@ const BasicTemplate = ({ bordered, large, draggable, ...args }) => (
 
 export const Default = BasicTemplate.bind({})
 Default.args = {}
+
+export const Loading = BasicTemplate.bind({})
+Loading.args = { bodyProps: { loading: true } }
 
 export const BorderedCells = BasicTemplate.bind({})
 BorderedCells.args = {

--- a/components/table/src/data-table/table-elements/table-body.js
+++ b/components/table/src/data-table/table-elements/table-body.js
@@ -1,16 +1,55 @@
+import { colors } from '@dhis2/ui-constants'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { forwardRef } from 'react'
 
 export const TableBody = forwardRef(
-    ({ children, className, dataTest, role, ...props }, ref) => (
+    ({ children, className, dataTest, role, loading, ...props }, ref) => (
         <tbody
             {...props}
-            className={className}
+            className={cx(className, {
+                loading,
+            })}
             data-test={dataTest}
             ref={ref}
             role={role}
         >
             {children}
+            <style jsx>{`
+                tbody {
+                    position: relative;
+                }
+                .loading:before {
+                    content: '';
+                    position: absolute;
+                    top: 0;
+                    bottom: 0;
+                    left: 0;
+                    right: 0;
+                    background-color: rgba(255, 255, 255, 0.8);
+                }
+                .loading:after {
+                    content: '';
+                    position: absolute;
+                    top: calc(50% - 24px);
+                    left: calc(50% - 24px);
+                    width: 48px;
+                    height: 48px;
+                    border: 6px solid rgba(110, 122, 138, 0.15);
+                    border-bottom-color: ${colors.blue600};
+                    border-radius: 50%;
+                    animation: rotation 1s linear infinite;
+                }
+                @keyframes rotation {
+                    0% {
+                        transform: rotate(0);
+                    }
+
+                    100% {
+                        transform: rotate(360deg);
+                    }
+                }
+            `}</style>
         </tbody>
     )
 )
@@ -25,5 +64,6 @@ TableBody.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
+    loading: PropTypes.bool,
     role: PropTypes.string,
 }


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/LIBS-244

This PR adds a loading state to the `DataTableBody` component. As `<div>`s cannot be children of `<table>`s, the circular loader is rendered as a pseudo element.

Demo: https://pr-800--dhis2-ui.netlify.app/?path=/story/data-display-datatable--loading