### PR TITLE
fix(input): add autoComplete prop to Input and InputField

### DIFF
--- a/components/input/src/input-field/input-field.js
+++ b/components/input/src/input-field/input-field.js
@@ -105,9 +105,9 @@ InputField.propTypes = {
     label: PropTypes.string,
     /** Adds a loading indicator beside the input */
     loading: PropTypes.bool,
-    /** The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmax), for use when `type` is `'number'` */
+    /** The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-max), for use when `type` is `'number'` */
     max: PropTypes.string,
-    /** The [native `min` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmin), for use when `type` is `'number'` */
+    /** The [native `min` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-min), for use when `type` is `'number'` */
     min: PropTypes.string,
     /** Name associated with the input. Passed to event handler callbacks in object */
     name: PropTypes.string,
@@ -117,7 +117,7 @@ InputField.propTypes = {
     readOnly: PropTypes.bool,
     /** Indicates this input is required */
     required: PropTypes.bool,
-    /** The [native `step` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefstep), for use when `type` is `'number'` */
+    /** The [native `step` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-step), for use when `type` is `'number'` */
     step: PropTypes.string,
     tabIndex: PropTypes.string,
     /** Type of input */

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -236,9 +236,9 @@ Input.propTypes = {
     initialFocus: PropTypes.bool,
     /** Adds a loading indicator beside the input */
     loading: PropTypes.bool,
-    /** The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmax), for use when `type` is `'number'` */
+    /** The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-max), for use when `type` is `'number'` */
     max: PropTypes.string,
-    /** The [native `min` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefmin), for use when `type` is `'number'` */
+    /** The [native `min` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-min), for use when `type` is `'number'` */
     min: PropTypes.string,
     /** Name associated with the input. Passed to event handler callbacks in object */
     name: PropTypes.string,
@@ -248,7 +248,7 @@ Input.propTypes = {
     readOnly: PropTypes.bool,
     /** Sets a role attribute on the input */
     role: PropTypes.string,
-    /** The [native `step` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefstep), for use when `type` is `'number'` */
+    /** The [native `step` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-step), for use when `type` is `'number'` */
     step: PropTypes.string,
     tabIndex: PropTypes.string,
     /** The native input `type` attribute */


### PR DESCRIPTION
Adds the `autoComplete` prop to `Input` and `InputField`, which allows us to set the native `autocomplete` attribute.