### PR TITLE
fix(modal): use correct title color

### DIFF
--- a/components/modal/src/modal-title/modal-title.js
+++ b/components/modal/src/modal-title/modal-title.js
@@ -1,4 +1,4 @@
-import { spacers } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -9,6 +9,7 @@ export const ModalTitle = ({ children, dataTest }) => (
 
         <style jsx>{`
             h1 {
+                color: ${colors.grey900};
                 font-size: 20px;
                 font-weight: 500;
                 line-height: 24px;


### PR DESCRIPTION
This PR applies the correct color to the modal title. Previously, the color was undefined and defaults to `#000`.

Aside: Is there a reason this component did not set a color before? Should it actually be inheriting the correct color (`grey900`) from somewhere else? I thought this might be the case, but all the examples in use I found are inheriting `#000`.