### PR TITLE
fix(user-avatar): use correct hex value for 0.8 background opacity

### DIFF
--- a/components/user-avatar/src/text-avatar.js
+++ b/components/user-avatar/src/text-avatar.js
@@ -46,7 +46,7 @@ export const TextAvatar = ({
                 height: 100%;
                 overflow: hidden;
                 border-radius: 50%;
-                background-color: ${colors.grey800}80;
+                background-color: ${colors.grey800}cc;
                 color: ${colors.grey050};
                 cursor: pointer;
             }


### PR DESCRIPTION
As @cooper-joe found out, the previous background color was set to 0.5 opacity. The correct representation of 80 in hex is `cc`.