### PR TITLE
feat(modal): viewport constrained fluid size

### DIFF
--- a/components/modal/src/modal-actions/modal-actions.js
+++ b/components/modal/src/modal-actions/modal-actions.js
@@ -1,4 +1,3 @@
-import { spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -8,9 +7,10 @@ export const ModalActions = ({ children, dataTest }) => (
 
         <style jsx>{`
             div {
-                padding: 0 ${spacers.dp24} ${spacers.dp24} ${spacers.dp24};
+                order: 3;
                 display: flex;
                 justify-content: flex-end;
+                align-self: flex-end;
             }
         `}</style>
     </div>

--- a/components/modal/src/modal-content/modal-content.js
+++ b/components/modal/src/modal-content/modal-content.js
@@ -8,9 +8,9 @@ export const ModalContent = ({ children, className, dataTest }) => (
 
         <style jsx>{`
             div {
-                flex-grow: 1;
+                order: 2;
+                flex-grow: 2;
                 margin: ${spacers.dp24} 0;
-                padding: 0 ${spacers.dp24};
                 overflow-y: auto;
             }
         `}</style>

--- a/components/modal/src/modal-title/modal-title.js
+++ b/components/modal/src/modal-title/modal-title.js
@@ -1,4 +1,4 @@
-import { colors, spacers } from '@dhis2/ui-constants'
+import { colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -14,7 +14,7 @@ export const ModalTitle = ({ children, dataTest }) => (
                 color: ${colors.grey900};
                 font-size: 20px;
                 font-weight: 500;
-                line-height: ${spacers.dp24};
+                line-height: 24px;
                 margin: 0;
             }
         `}</style>

--- a/components/modal/src/modal-title/modal-title.js
+++ b/components/modal/src/modal-title/modal-title.js
@@ -9,12 +9,13 @@ export const ModalTitle = ({ children, dataTest }) => (
 
         <style jsx>{`
             h1 {
+                order: 1;
+                align-self: flex-start;
                 color: ${colors.grey900};
                 font-size: 20px;
                 font-weight: 500;
-                line-height: 24px;
+                line-height: ${spacers.dp24};
                 margin: 0;
-                padding: ${spacers.dp24} ${spacers.dp24} 0 ${spacers.dp24};
             }
         `}</style>
     </h1>

--- a/components/modal/src/modal/modal.js
+++ b/components/modal/src/modal/modal.js
@@ -7,16 +7,18 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { resolve } from 'styled-jsx/css'
 
-const scrollBoxCard = resolve`
-    div {
-        display: flex;
-        flex-direction: column;
-        max-height: calc(100vh - ${2 * spacersNum.dp64}px);
-        max-width: calc(100vw - ${2 * spacersNum.dp64}px);
-    }
-`
+const getScrollBoxCardStyles = () => {
+    return resolve`
+        div {
+            display: flex;
+            flex-direction: column;
+            max-height: calc(100vh - ${2 * spacersNum.dp64}px);
+            max-width: calc(100vw - ${2 * spacersNum.dp64}px);
+        }
+    `
+}
 
-const centeredContent = resolve`
+const centeredContentStyles = resolve`
     .top {
         padding-top: ${spacers.dp64};
     }
@@ -36,38 +38,46 @@ export const Modal = ({
     className,
     dataTest,
     hide,
+    fluid,
     large,
     onClose,
     position,
     small,
 }) => {
+    const scrollBoxCardStyles = getScrollBoxCardStyles()
+
     return (
         <Layer
             onClick={onClose}
             className={hide ? layerStyles.className : ''}
             translucent={!hide}
         >
-            <Center position={position} className={centeredContent.className}>
+            <Center
+                position={position}
+                className={cx(centeredContentStyles.className)}
+            >
                 <aside
                     role="dialog"
                     aria-modal="true"
                     data-test={dataTest}
-                    className={cx(className, { small, large })}
+                    className={cx(className, { small, large, fluid })}
                 >
-                    <Card className={scrollBoxCard.className}>{children}</Card>
+                    <Card className={scrollBoxCardStyles.className}>
+                        {children}
+                    </Card>
                 </aside>
-                {scrollBoxCard.styles}
+                {scrollBoxCardStyles.styles}
                 {layerStyles.styles}
-                {centeredContent.styles}
+                {centeredContentStyles.styles}
             </Center>
 
             <style jsx>{`
                 aside {
                     overflow-y: hidden;
                     height: auto;
-                    max-height: calc(100vh - ${2 * spacersNum.dp64}px);
-                    max-width: calc(100vw - ${2 * spacersNum.dp64}px);
                     width: 600px;
+                    max-height: calc(100vh - 128px);
+                    max-width: calc(100vw - 128px);
                 }
 
                 aside.small {
@@ -76,6 +86,10 @@ export const Modal = ({
 
                 aside.large {
                     width: 800px;
+                }
+
+                aside.fluid {
+                    width: auto;
                 }
             `}</style>
         </Layer>
@@ -91,6 +105,7 @@ Modal.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
+    fluid: PropTypes.bool,
     hide: PropTypes.bool,
     large: sharedPropTypes.sizePropType,
     position: sharedPropTypes.insideAlignmentPropType,

--- a/components/modal/src/modal/modal.js
+++ b/components/modal/src/modal/modal.js
@@ -7,31 +7,13 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { resolve } from 'styled-jsx/css'
 
-const getScrollBoxCardStyles = () => {
-    return resolve`
+const resolveLayerStyles = (hide) =>
+    resolve`
         div {
-            display: flex;
-            flex-direction: column;
-            max-height: calc(100vh - ${2 * spacersNum.dp64}px);
-            max-width: calc(100vw - ${2 * spacersNum.dp64}px);
+            padding: ${spacers.dp64};
+            display: ${hide ? 'none' : ''};
         }
     `
-}
-
-const centeredContentStyles = resolve`
-    .top {
-        padding-top: ${spacers.dp64};
-    }
-    .bottom {
-        padding-bottom: ${spacers.dp64};
-    }
-`
-
-const layerStyles = resolve`
-    div {
-		display: none;
-    }
-`
 
 export const Modal = ({
     children,
@@ -44,40 +26,41 @@ export const Modal = ({
     position,
     small,
 }) => {
-    const scrollBoxCardStyles = getScrollBoxCardStyles()
-
+    const layerStyles = resolveLayerStyles(hide)
     return (
         <Layer
             onClick={onClose}
-            className={hide ? layerStyles.className : ''}
+            className={layerStyles.className}
             translucent={!hide}
         >
-            <Center
-                position={position}
-                className={cx(centeredContentStyles.className)}
-            >
+            <Center position={position}>
                 <aside
                     role="dialog"
                     aria-modal="true"
                     data-test={dataTest}
                     className={cx(className, { small, large, fluid })}
                 >
-                    <Card className={scrollBoxCardStyles.className}>
-                        {children}
+                    <Card>
+                        <div>{children}</div>
                     </Card>
                 </aside>
-                {scrollBoxCardStyles.styles}
                 {layerStyles.styles}
-                {centeredContentStyles.styles}
             </Center>
 
             <style jsx>{`
+                div {
+                    padding: 24px;
+                    display: flex;
+                    flex-flow: column;
+                    max-width: calc(100vw - ${2 * spacersNum.dp64}px);
+                    max-height: calc(100vh - ${2 * spacersNum.dp64}px);
+                }
+
                 aside {
-                    overflow-y: hidden;
                     height: auto;
                     width: 600px;
-                    max-height: calc(100vh - 128px);
-                    max-width: calc(100vw - 128px);
+                    max-width: calc(100vw - ${2 * spacersNum.dp64}px);
+                    max-height: calc(100vh - ${2 * spacersNum.dp64}px);
                 }
 
                 aside.small {

--- a/components/modal/src/modal/modal.js
+++ b/components/modal/src/modal/modal.js
@@ -11,7 +11,7 @@ const resolveLayerStyles = (hide) =>
     resolve`
         div {
             padding: ${spacers.dp64};
-            display: ${hide ? 'none' : ''};
+            display: ${hide ? 'none' : 'block'};
         }
     `
 

--- a/components/modal/src/modal/modal.stories.js
+++ b/components/modal/src/modal/modal.stories.js
@@ -1,3 +1,4 @@
+import { Box } from '@dhis2-ui/box'
 import { Button, ButtonStrip } from '@dhis2-ui/button'
 import {
     FlyoutMenu,
@@ -128,8 +129,8 @@ export const AlignmentBottom = (args) => (
         </ModalContent>
     </Modal>
 )
-AlignmentBottom.args = { onClose, alignment: 'bottom' }
-AlignmentBottom.storyName = 'Alignment: Bottom'
+AlignmentBottom.args = { onClose, position: 'bottom' }
+AlignmentBottom.storyName = 'Position: Bottom'
 
 export const SmallTitleContentAction = (args) => (
     <Modal {...args}>
@@ -235,6 +236,47 @@ export const LargeTitleContentPrimary = (args) => (
 )
 LargeTitleContentPrimary.args = { large: true }
 LargeTitleContentPrimary.storyName = 'Large: Title, Content, Primary'
+
+export const FluidTitleContentPrimary = (args) => (
+    <Modal {...args}>
+        <ModalTitle>
+            This is a modal using custom dimensions, with title, content and
+            primary action
+        </ModalTitle>
+
+        <ModalContent>
+            <Box height="100vh" width="100vw">
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                diam nonumy eirmod tempor invidunt ut labore et dolore magna
+                aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+                takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
+                dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+                eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+                sed diam voluptua. At vero eos et accusam et justo duo dolores
+                et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+                est Lorem ipsum dolor sit amet.
+            </Box>
+        </ModalContent>
+
+        <ModalActions>
+            <ButtonStrip end>
+                <Button onClick={say('Button secondary')} secondary>
+                    Secondary action
+                </Button>
+
+                <Button onClick={say('Button primary')} primary>
+                    Primary action
+                </Button>
+            </ButtonStrip>
+        </ModalActions>
+    </Modal>
+)
+FluidTitleContentPrimary.args = {
+    fluid: true,
+}
+FluidTitleContentPrimary.storyName =
+    'Fluid (Custom sizes): Title, Content, Primary'
 
 export const SmallContentPrimary = (args) => (
     <Modal {...args}>
@@ -796,3 +838,126 @@ export const ModalThatHidesWithStatefulComponens = () => {
         </div>
     )
 }
+
+export const FluidTop = (args) => (
+    <Modal {...args}>
+        <Box>
+            <ModalTitle>
+                This is a modal using custom dimensions, with title, content and
+                primary action
+            </ModalTitle>
+
+            <ModalContent>
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                diam nonumy eirmod tempor invidunt ut labore et dolore magna
+                aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+                takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
+                dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+                eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+                sed diam voluptua. At vero eos et accusam et justo duo dolores
+                et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+                est Lorem ipsum dolor sit amet.
+            </ModalContent>
+
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button onClick={say('Button secondary')} secondary>
+                        Secondary action
+                    </Button>
+
+                    <Button onClick={say('Button primary')} primary>
+                        Primary action
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Box>
+    </Modal>
+)
+FluidTop.args = {
+    fluid: true,
+    position: 'top',
+}
+FluidTop.storyName = 'Fluid (Top)'
+
+export const FluidMiddle = (args) => (
+    <Modal {...args}>
+        <Box>
+            <ModalTitle>
+                This is a modal using custom dimensions, with title, content and
+                primary action
+            </ModalTitle>
+
+            <ModalContent>
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                diam nonumy eirmod tempor invidunt ut labore et dolore magna
+                aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+                takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
+                dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+                eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+                sed diam voluptua. At vero eos et accusam et justo duo dolores
+                et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+                est Lorem ipsum dolor sit amet.
+            </ModalContent>
+
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button onClick={say('Button secondary')} secondary>
+                        Secondary action
+                    </Button>
+
+                    <Button onClick={say('Button primary')} primary>
+                        Primary action
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Box>
+    </Modal>
+)
+FluidMiddle.args = {
+    fluid: true,
+    position: 'middle',
+}
+FluidMiddle.storyName = 'Fluid (Middle)'
+
+export const FluidBottom = (args) => (
+    <Modal {...args}>
+        <Box>
+            <ModalTitle>
+                This is a modal using custom dimensions, with title, content and
+                primary action
+            </ModalTitle>
+
+            <ModalContent>
+                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                diam nonumy eirmod tempor invidunt ut labore et dolore magna
+                aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+                takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
+                dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
+                eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+                sed diam voluptua. At vero eos et accusam et justo duo dolores
+                et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
+                est Lorem ipsum dolor sit amet.
+            </ModalContent>
+
+            <ModalActions>
+                <ButtonStrip end>
+                    <Button onClick={say('Button secondary')} secondary>
+                        Secondary action
+                    </Button>
+
+                    <Button onClick={say('Button primary')} primary>
+                        Primary action
+                    </Button>
+                </ButtonStrip>
+            </ModalActions>
+        </Box>
+    </Modal>
+)
+FluidBottom.args = {
+    fluid: true,
+    position: 'bottom',
+}
+FluidBottom.storyName = 'Fluid (Bottom)'

--- a/components/modal/src/modal/modal.stories.js
+++ b/components/modal/src/modal/modal.stories.js
@@ -245,18 +245,47 @@ export const FluidTitleContentPrimary = (args) => (
         </ModalTitle>
 
         <ModalContent>
-            <Box height="100vh" width="100vw">
-                Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
-                diam nonumy eirmod tempor invidunt ut labore et dolore magna
-                aliquyam erat, sed diam voluptua. At vero eos et accusam et
-                justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
-                takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum
-                dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
-                eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
-                sed diam voluptua. At vero eos et accusam et justo duo dolores
-                et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
-                est Lorem ipsum dolor sit amet.
-            </Box>
+            <div
+                style={{
+                    display: 'flex',
+                    flexFlow: 'row wrap',
+                }}
+            >
+                <div
+                    style={{
+                        width: '600px',
+                        backgroundColor: '#fea',
+                    }}
+                >
+                    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                    diam nonumy eirmod tempor invidunt ut labore et dolore magna
+                    aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                    justo duo dolores et ea rebum. Stet clita kasd gubergren, no
+                    sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem
+                    ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+                    nonumy eirmod tempor invidunt ut labore et dolore magna
+                    aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                    justo duo dolores et ea rebum. Stet clita kasd gubergren, no
+                    sea takimata sanctus est Lorem ipsum dolor sit amet.
+                </div>
+                <div
+                    style={{
+                        width: '300px',
+                        backgroundColor: '#eaf',
+                    }}
+                >
+                    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
+                    diam nonumy eirmod tempor invidunt ut labore et dolore magna
+                    aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                    justo duo dolores et ea rebum. Stet clita kasd gubergren, no
+                    sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem
+                    ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+                    nonumy eirmod tempor invidunt ut labore et dolore magna
+                    aliquyam erat, sed diam voluptua. At vero eos et accusam et
+                    justo duo dolores et ea rebum. Stet clita kasd gubergren, no
+                    sea takimata sanctus est Lorem ipsum dolor sit amet.
+                </div>
+            </div>
         </ModalContent>
 
         <ModalActions>
@@ -274,6 +303,7 @@ export const FluidTitleContentPrimary = (args) => (
 )
 FluidTitleContentPrimary.args = {
     fluid: true,
+    position: 'top',
 }
 FluidTitleContentPrimary.storyName =
     'Fluid (Custom sizes): Title, Content, Primary'
@@ -841,13 +871,13 @@ export const ModalThatHidesWithStatefulComponens = () => {
 
 export const FluidTop = (args) => (
     <Modal {...args}>
-        <Box>
-            <ModalTitle>
-                This is a modal using custom dimensions, with title, content and
-                primary action
-            </ModalTitle>
+        <ModalTitle>
+            This is a modal using custom dimensions, with title, content and
+            primary action
+        </ModalTitle>
 
-            <ModalContent>
+        <ModalContent>
+            <Box width="666px" height="666px">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
                 diam nonumy eirmod tempor invidunt ut labore et dolore magna
                 aliquyam erat, sed diam voluptua. At vero eos et accusam et
@@ -858,20 +888,20 @@ export const FluidTop = (args) => (
                 sed diam voluptua. At vero eos et accusam et justo duo dolores
                 et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
                 est Lorem ipsum dolor sit amet.
-            </ModalContent>
+            </Box>
+        </ModalContent>
 
-            <ModalActions>
-                <ButtonStrip end>
-                    <Button onClick={say('Button secondary')} secondary>
-                        Secondary action
-                    </Button>
+        <ModalActions>
+            <ButtonStrip end>
+                <Button onClick={say('Button secondary')} secondary>
+                    Secondary action
+                </Button>
 
-                    <Button onClick={say('Button primary')} primary>
-                        Primary action
-                    </Button>
-                </ButtonStrip>
-            </ModalActions>
-        </Box>
+                <Button onClick={say('Button primary')} primary>
+                    Primary action
+                </Button>
+            </ButtonStrip>
+        </ModalActions>
     </Modal>
 )
 FluidTop.args = {
@@ -882,13 +912,13 @@ FluidTop.storyName = 'Fluid (Top)'
 
 export const FluidMiddle = (args) => (
     <Modal {...args}>
-        <Box>
-            <ModalTitle>
-                This is a modal using custom dimensions, with title, content and
-                primary action
-            </ModalTitle>
+        <ModalTitle>
+            This is a modal using custom dimensions, with title, content and
+            primary action
+        </ModalTitle>
 
-            <ModalContent>
+        <ModalContent>
+            <Box width="666px" height="666px">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
                 diam nonumy eirmod tempor invidunt ut labore et dolore magna
                 aliquyam erat, sed diam voluptua. At vero eos et accusam et
@@ -899,20 +929,20 @@ export const FluidMiddle = (args) => (
                 sed diam voluptua. At vero eos et accusam et justo duo dolores
                 et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
                 est Lorem ipsum dolor sit amet.
-            </ModalContent>
+            </Box>
+        </ModalContent>
 
-            <ModalActions>
-                <ButtonStrip end>
-                    <Button onClick={say('Button secondary')} secondary>
-                        Secondary action
-                    </Button>
+        <ModalActions>
+            <ButtonStrip end>
+                <Button onClick={say('Button secondary')} secondary>
+                    Secondary action
+                </Button>
 
-                    <Button onClick={say('Button primary')} primary>
-                        Primary action
-                    </Button>
-                </ButtonStrip>
-            </ModalActions>
-        </Box>
+                <Button onClick={say('Button primary')} primary>
+                    Primary action
+                </Button>
+            </ButtonStrip>
+        </ModalActions>
     </Modal>
 )
 FluidMiddle.args = {
@@ -923,13 +953,13 @@ FluidMiddle.storyName = 'Fluid (Middle)'
 
 export const FluidBottom = (args) => (
     <Modal {...args}>
-        <Box>
-            <ModalTitle>
-                This is a modal using custom dimensions, with title, content and
-                primary action
-            </ModalTitle>
+        <ModalTitle>
+            This is a modal using custom dimensions, with title, content and
+            primary action
+        </ModalTitle>
 
-            <ModalContent>
+        <ModalContent>
+            <Box width="666px" height="666px">
                 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed
                 diam nonumy eirmod tempor invidunt ut labore et dolore magna
                 aliquyam erat, sed diam voluptua. At vero eos et accusam et
@@ -940,20 +970,20 @@ export const FluidBottom = (args) => (
                 sed diam voluptua. At vero eos et accusam et justo duo dolores
                 et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus
                 est Lorem ipsum dolor sit amet.
-            </ModalContent>
+            </Box>
+        </ModalContent>
 
-            <ModalActions>
-                <ButtonStrip end>
-                    <Button onClick={say('Button secondary')} secondary>
-                        Secondary action
-                    </Button>
+        <ModalActions>
+            <ButtonStrip end>
+                <Button onClick={say('Button secondary')} secondary>
+                    Secondary action
+                </Button>
 
-                    <Button onClick={say('Button primary')} primary>
-                        Primary action
-                    </Button>
-                </ButtonStrip>
-            </ModalActions>
-        </Box>
+                <Button onClick={say('Button primary')} primary>
+                    Primary action
+                </Button>
+            </ButtonStrip>
+        </ModalActions>
     </Modal>
 )
 FluidBottom.args = {

--- a/components/modal/src/modal/modal.test.js
+++ b/components/modal/src/modal/modal.test.js
@@ -42,8 +42,8 @@ describe('Modal', () => {
             const style = window.getComputedStyle(modalEl)
 
             expect(style.height).toBe('auto')
-            expect(style.maxHeight).toBe('100vh')
-            expect(style.maxWidth).toBe('100vw')
+            expect(style.maxHeight).toBe('calc(100vh - 128px)')
+            expect(style.maxWidth).toBe('calc(100vw - 128px)')
             expect(style.width).toBe('auto')
         })
     })

--- a/components/modal/src/modal/modal.test.js
+++ b/components/modal/src/modal/modal.test.js
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { Modal } from './modal.js'
+
+describe('Modal', () => {
+    describe('Regular dimensions', () => {
+        it('has the correct dimension styles in its default state', () => {
+            render(<Modal />)
+            const modalEl = screen.getByRole('dialog')
+            const style = window.getComputedStyle(modalEl)
+
+            expect(style.height).toBe('auto')
+            expect(style.maxHeight).toBe('calc(100vh - 128px)')
+            expect(style.maxWidth).toBe('calc(100vw - 128px)')
+            expect(style.width).toBe('600px')
+        })
+        it('has the correct dimension styles when the "small" prop is provided', () => {
+            render(<Modal small />)
+            const modalEl = screen.getByRole('dialog')
+            console.log('modalEl.outerWidth', modalEl.offsetWidth)
+            const style = window.getComputedStyle(modalEl)
+
+            expect(style.height).toBe('auto')
+            expect(style.maxHeight).toBe('calc(100vh - 128px)')
+            expect(style.maxWidth).toBe('calc(100vw - 128px)')
+            expect(style.width).toBe('400px')
+        })
+        it('has the correct dimension styles when the "large" prop is provided', () => {
+            render(<Modal large />)
+            const modalEl = screen.getByRole('dialog')
+            const style = window.getComputedStyle(modalEl)
+
+            expect(style.height).toBe('auto')
+            expect(style.maxHeight).toBe('calc(100vh - 128px)')
+            expect(style.maxWidth).toBe('calc(100vw - 128px)')
+            expect(style.width).toBe('800px')
+        })
+
+        it('has the correct dimension styles when the "fluid" prop is provided', () => {
+            render(<Modal fluid />)
+            const modalEl = screen.getByRole('dialog')
+            const style = window.getComputedStyle(modalEl)
+
+            expect(style.height).toBe('auto')
+            expect(style.maxHeight).toBe('100vh')
+            expect(style.maxWidth).toBe('100vw')
+            expect(style.width).toBe('auto')
+        })
+    })
+})

--- a/constants/src/shared-prop-types.js
+++ b/constants/src/shared-prop-types.js
@@ -48,7 +48,7 @@ export const buttonVariantArgType = {
  * small/large
  */
 export const sizePropType = mutuallyExclusive(
-    ['small', 'large', 'extrasmall'],
+    ['small', 'large', 'extrasmall', 'fluid'],
     PropTypes.bool
 )
 export const sizeArgType = {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "@manypkg/cli": "^0.18.0",
         "@svgr/cli": "^5.5.0",
         "@testing-library/react-hooks": "^7.0.1",
+        "@testing-library/react": "^12.1.2",
         "concurrently": "^6.2.1",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3079,6 +3079,17 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.2.5":
+  version "27.2.5"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.2.5.tgz#420765c052605e75686982d24b061b4cbba22132"
+  integrity sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@juggle/resize-observer@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.3.1.tgz#b50a781709c81e10701004214340f25475a171a0"
@@ -4295,6 +4306,20 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@testing-library/dom@^8.0.0":
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.11.0.tgz#3679dfb4db58e0d2b95e4b0929eaf45237b60d94"
+  integrity sha512-8Ay4UDiMlB5YWy+ZvCeRyFFofs53ebxrWnOFvCoM1HpMAX4cHyuSrCuIM9l2lVuUWUt+Gr3loz/nCwdrnG6ShQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^5.0.0"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.4.4"
+    pretty-format "^27.0.2"
+
 "@testing-library/react-hooks@^7.0.1":
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.1.tgz#8429d8bf55bfe82e486bd582dd06457c2464900a"
@@ -4306,6 +4331,14 @@
     "@types/react-test-renderer" ">=16.9.0"
     react-error-boundary "^3.1.0"
 
+"@testing-library/react@^12.1.2":
+  version "12.1.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.2.tgz#f1bc9a45943461fa2a598bb4597df1ae044cfc76"
+  integrity sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^8.0.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -4315,6 +4348,11 @@
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
   integrity sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==
+
+"@types/aria-query@^4.2.0":
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"
+  integrity sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14", "@types/babel__core@^7.1.7":
   version "7.1.16"
@@ -5565,6 +5603,11 @@ aria-query@^4.2.2:
   dependencies:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
+
+aria-query@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.0.0.tgz#210c21aaf469613ee8c9a62c7f86525e058db52c"
+  integrity sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==
 
 arity-n@^1.0.4:
   version "1.0.4"
@@ -8849,6 +8892,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz#caa6d08f60388d0bb4539dd75fe458a9a1d0014c"
+  integrity sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -14293,6 +14341,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+
 magic-string@^0.25.0, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -16713,6 +16766,16 @@ pretty-format@^26.6.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.3.1.tgz#7e9486365ccdd4a502061fa761d3ab9ca1b78df5"
+  integrity sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 pretty-format@^27.2.0:


### PR DESCRIPTION
## Use case

There is a recurring need for larger Modals than our `large` variant (600px wide).

## Potential solutions

- `height` and `width` props that sets the size of the Modal
- Override using `className` and `!important`
- Unconstrained fluid Modal size that scrolls with the page
- Constrained fluid Modal size that scrolls the ModalContent

## Chosen solution

> Constrained fluid Modal size that scrolls the ModalContent

Allowing the Modal to have a `fluid` prop allows the size of the Modal to be:

- adaptable to the content of the ModalContent component
- controlled by the app developer, by utilising an additional wrapper with defined sizes inside of the ModalContent

This provides enough flexibility without opening up the API too much.

The other solution's drawbacks that excluded them:

- `height`/`width` props tied into ongoing discussion about overrides/extensions/global props
- using `className`/`!important` is not recommended by us
- scrolling the page because the Modal is very large is not an UX we want as it obscures the modality traits

## Future

- Consider changing the default from `medium` to `fluid` (breaking change)
- If we want to allow page scroll, we need to open the Layer component to allow overflow.
- The Card CSS can probably be simplified.