### PR TITLE
fix(select): adjust menu style

### DIFF
--- a/components/select/src/multi-select/features/accepts_max_height/index.js
+++ b/components/select/src/multi-select/features/accepts_max_height/index.js
@@ -20,7 +20,7 @@ Given('the MultiSelect is open', () => {
 })
 
 Then('has the default max-height', () => {
-    cy.get('[data-test="dhis2-uicore-card"]').should(
+    cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]').should(
         'have.css',
         'max-height',
         '280px'
@@ -28,7 +28,7 @@ Then('has the default max-height', () => {
 })
 
 Then('has a max-height of 100px', () => {
-    cy.get('[data-test="dhis2-uicore-card"]').should(
+    cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]').should(
         'have.css',
         'max-height',
         '100px'

--- a/components/select/src/select/menu-wrapper.js
+++ b/components/select/src/select/menu-wrapper.js
@@ -1,9 +1,8 @@
-import { Card } from '@dhis2-ui/card'
 import { Layer } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
+import { colors, elevations } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { resolve } from 'styled-jsx/css'
 
 const MenuWrapper = ({
     children,
@@ -13,11 +12,6 @@ const MenuWrapper = ({
     onClick,
     selectRef,
 }) => {
-    const { styles, className: cardClassName } = resolve`
-        height: auto;
-        max-height: ${maxHeight};
-        overflow: auto;
-    `
     return (
         <Layer onClick={onClick} transparent>
             <Popper
@@ -26,13 +20,18 @@ const MenuWrapper = ({
                 observeReferenceResize
             >
                 <div data-test={`${dataTest}-menuwrapper`}>
-                    <Card className={cardClassName}>{children}</Card>
-
-                    {styles}
+                    {children}
 
                     <style jsx>{`
                         div {
                             width: ${menuWidth};
+                            height: auto;
+                            max-height: ${maxHeight};
+                            overflow: auto;
+                            background: ${colors.white};
+                            border: 1px solid ${colors.grey200};
+                            border-radius: 3px;
+                            box-shadow: ${elevations.e300};
                         }
                     `}</style>
                 </div>

--- a/components/select/src/single-select/features/accepts_max_height/index.js
+++ b/components/select/src/single-select/features/accepts_max_height/index.js
@@ -20,7 +20,7 @@ Given('the SingleSelect is open', () => {
 })
 
 Then('has the default max-height', () => {
-    cy.get('[data-test="dhis2-uicore-card"]').should(
+    cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]').should(
         'have.css',
         'max-height',
         '280px'
@@ -28,7 +28,7 @@ Then('has the default max-height', () => {
 })
 
 Then('has a max-height of 100px', () => {
-    cy.get('[data-test="dhis2-uicore-card"]').should(
+    cy.get('[data-test="dhis2-uicore-select-menu-menuwrapper"]').should(
         'have.css',
         'max-height',
         '100px'


### PR DESCRIPTION
This PR adjusts the menu wrapper used by `select`, both `single-` and `multi-` variants, fully fixing [UX-46](https://jira.dhis2.org/browse/UX-46). https://github.com/dhis2/ui/pull/836 fixed this for all other menus using `flyoutMenu`, but the `select`s used a custom menu.

This PR removes the `card` component, which had a `cardClassName`, though it wasn't exposed as a prop. So, removing this doesn't appear to be a breaking change?