### PR TITLE
docs(user-avatar): update available types

### DIFF
--- a/components/user-avatar/src/user-avatar.js
+++ b/components/user-avatar/src/user-avatar.js
@@ -8,7 +8,7 @@ import { TextAvatar } from './text-avatar.js'
 /**
 An avatar is a visual icon that represents a user.
 
-Avatars are used to give extra information when a user is mentioned or displayed in DHIS2. The avatar contains either user uploaded photograph, initials or a default icon. The avatar is intended to give context to a user and help to quickly identify different users. An avatar is usually shown alongside the user name, but can be used alone to show a visual hint of a user.
+Use an avatar to give extra information when a user is mentioned or displayed in DHIS2. The avatar shows a user uploaded photograph or initials. The avatar is intended to give context and help to identify different users. An avatar is usually shown alongside the user name, but can be used alone to show a visual hint of a user.
 
 See specification: [Design System](https://github.com/dhis2/design-system/blob/master/atoms/avatar.md)
 


### PR DESCRIPTION
This PR adjusts the documentation for the `user-avatar` to clarify the available types (and reflect updated Design System docs). `Icon` fallback is deferred and not implemented yet, and should not be mentioned in the documentation.