### PR TITLE
fix(tooltip): clear timeouts when unmounting

### DIFF
--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -2,7 +2,7 @@ import { Popper } from '@dhis2-ui/popper'
 import { Portal } from '@dhis2-ui/portal'
 import { colors, layers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { resolve } from 'styled-jsx/css'
 
 const TOOLTIP_OFFSET = 4
@@ -65,6 +65,14 @@ const Tooltip = ({
             setOpen(false)
         }, closeDelay)
     }
+
+    useEffect(
+        () => () => {
+            clearTimeout(openTimerRef.current)
+            clearTimeout(closeTimerRef.current)
+        },
+        []
+    )
 
     return (
         <>


### PR DESCRIPTION
This takes care of a problem that occurs when attaching a tooltip to something that is going to be unmounted. For example a delete button. By clearing the timeouts when unmounting, we prevent a react developer warning regarding potential memory leaks.

I tried to write a test for this, but could not manage it. I was able to reproduce the problem and could see the developer warning in the terminal during the test run. But I wasn't able to create a working spy for this waring function, so I wasn't able to assert the warning is not shown after applying the fix.