### PR TITLE
refactor(alert): add example for forwarding refs for all components

### DIFF
--- a/components/alert/src/alert-bar/alert-bar.js
+++ b/components/alert/src/alert-bar/alert-bar.js
@@ -8,20 +8,23 @@ import { Dismiss } from './dismiss.js'
 import { Icon, iconPropType } from './icon.js'
 import { Message } from './message.js'
 
-const AlertBar = ({
-    actions,
-    children,
-    className,
-    critical,
-    dataTest,
-    duration,
-    hidden,
-    icon,
-    permanent,
-    success,
-    warning,
-    onHidden,
-}) => {
+export const AlertBar = React.forwardRef(function AlertBar(
+    {
+        actions,
+        children,
+        className,
+        critical,
+        dataTest,
+        duration,
+        hidden,
+        icon,
+        permanent,
+        success,
+        warning,
+        onHidden,
+    },
+    ref
+) {
     const [inViewport, setInViewport] = useState(!hidden)
     const [inDOM, setInDOM] = useState(!hidden)
     const showTimeout = useRef(null)
@@ -102,6 +105,7 @@ const AlertBar = ({
 
     return !inDOM ? null : (
         <div
+            ref={ref}
             className={cx(className, {
                 info,
                 success,
@@ -135,7 +139,7 @@ const AlertBar = ({
             <style jsx>{styles}</style>
         </div>
     )
-}
+})
 
 const alertTypePropType = mutuallyExclusive(
     ['success', 'warning', 'critical'],
@@ -170,5 +174,3 @@ AlertBar.propTypes = {
     warning: alertTypePropType,
     onHidden: PropTypes.func,
 }
-
-export { AlertBar }


### PR DESCRIPTION
So one approach could be that we just allow refs for all our components.

- All our components accept a ref
- They all forward the ref to the root node of the returned markup (this means that the ref isn't necessarily always attached to the same element over subsequent renders if the markup changes)

This means that the burden of proper use lies with the end user of our component lib (I don't think we can enforce proper use anyway). It's also easy to test, we could write a single test that just iterates through all components. It's also simple to implement and understand, no discussion necessary.

Note that this should be a breaking change: https://reactjs.org/docs/forwarding-refs.html#note-for-component-library-maintainers