### PR TITLE
fix: tooltip adjustments

### DIFF
--- a/components/tooltip/src/features/positions/index.js
+++ b/components/tooltip/src/features/positions/index.js
@@ -2,7 +2,7 @@ import '../common/index.js'
 import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
 
 const TOOLTIP_OFFSET = 4
-const TOOLTIP_HEIGHT = 28
+const TOOLTIP_HEIGHT = 25
 
 // Stories
 Given(
@@ -33,7 +33,7 @@ Then(
             const refCenterX = refPos.left + refPos.width / 2
             const contentCenterX = contentPos.left + contentPos.width / 2
 
-            expect(refCenterX).to.be.approximately(contentCenterX, 0.5)
+            expect(refCenterX).to.be.approximately(contentCenterX, 1)
         })
     }
 )

--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -116,12 +116,12 @@ const Tooltip = ({
                     max-width: ${maxWidth}px;
                 }
                 div {
-                    padding: 6px 8px;
-                    background-color: ${colors.grey800};
+                    padding: 4px 6px;
+                    background-color: ${colors.grey900};
                     border-radius: 3px;
                     color: ${colors.white};
-                    font-size: 12px;
-                    line-height: 16px;
+                    font-size: 13px;
+                    line-height: 17px;
                 }
             `}</style>
         </>

--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -129,7 +129,7 @@ const Tooltip = ({
 }
 
 Tooltip.defaultProps = {
-    closeDelay: 400,
+    closeDelay: 200,
     dataTest: 'dhis2-uicore-tooltip',
     maxWidth: 300,
     openDelay: 200,

--- a/components/tooltip/src/tooltip.stories.e2e.js
+++ b/components/tooltip/src/tooltip.stories.e2e.js
@@ -31,6 +31,10 @@ export const FlippedVertically = () => (
         contains a tooltip.
         <style jsx>{noPaddingStyles}</style>
         <style jsx>{`
+            :global(div#root) {
+                padding-top: 0;
+            }
+
             p {
                 margin-top: 0;
             }


### PR DESCRIPTION
This PR makes the following changes to the `Tooltip` component:
- adjusts the colors, sizes and spacings to increase contrast from `8.85` to `14.67`, without increasing the overlall size of the element. Fixes [UX-53](https://jira.dhis2.org/browse/UX-53).
  - note: I tried reducing the height hardcoded in the `.feature` for testing, but still failing a couple of tests here. Any pointers what I'm missing here?
- reduces the default `closeDelay` from `400` to `200`, reducing the sense asymmetrical lag.

