### PR TITLE
refactor(button): add example for base components

### DIFF
--- a/components/button/src/button-base/button-base.js
+++ b/components/button/src/button-base/button-base.js
@@ -1,0 +1,70 @@
+import { colors, theme, spacers } from '@dhis2/ui-constants'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
+    const { children, dataTest, ...rest } = props
+
+    return (
+        <button ref={ref} data-test={dataTest} {...rest}>
+            {children}
+            <style jsx>{`
+                button {
+                    border-radius: 4px;
+                    font-weight: 400;
+                    letter-spacing: 0.5px;
+                    transition: all 0.15s cubic-bezier(0.4, 0, 0.6, 1);
+                    color: ${colors.grey900};
+                    height: 36px;
+                    padding: 0 ${spacers.dp12};
+                    font-size: 14px;
+                    line-height: 16px;
+                    border: 1px solid ${colors.grey500};
+                    background-color: #f9fafb;
+                }
+
+                button:hover {
+                    border-color: ${colors.grey500};
+                    background-color: ${colors.grey200};
+                }
+
+                button:disabled {
+                    cursor: not-allowed;
+                    border-color: ${colors.grey400};
+                    background-color: #f9fafb;
+                    box-shadow: none;
+                    color: ${theme.disabled};
+                    fill: ${theme.disabled};
+                }
+
+                button:focus {
+                    background-color: #f9fafb;
+                    outline: 3px solid ${theme.focus};
+                    outline-offset: 2px;
+                    transition: none;
+                }
+
+                button:active {
+                    border-color: ${colors.grey500};
+                    background-color: ${colors.grey200};
+                    box-shadow: 0 0 0 1px rgb(0, 0, 0, 0.1) inset;
+                }
+            `}</style>
+        </button>
+    )
+})
+
+ButtonBase.defaultProps = {
+    children: null,
+    dataTest: '',
+}
+
+ButtonBase.propTypes = {
+    /** Component to render inside the button */
+    children: PropTypes.node,
+    /**
+     * A string that will be applied as a `data-test` attribute on the button element
+     * for identification during testing
+     */
+    dataTest: PropTypes.string,
+}

--- a/components/button/src/button-base/button.stories.js
+++ b/components/button/src/button-base/button.stories.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import { ButtonBase } from './button-base.js'
+
+// Note: make sure 'fenced code blocks' are not indentend in this template string
+const description = `Buttons are used for triggering actions.
+There are different types of buttons in the design system which are intended
+for different types of actions.
+
+\`\`\`js
+import { Button } from '@dhis2/ui'
+\`\`\``
+
+const logger = ({ name, value }) => console.log(`${name}: ${value}`)
+
+export default {
+    title: 'Actions/Buttons/ButtonBase',
+    component: ButtonBase,
+    parameters: {
+        componentSubtitle: 'Initiates an action',
+        docs: {
+            description: {
+                component: description,
+            },
+        },
+    },
+    args: {
+        children: 'Label me!',
+        onClick: logger,
+    },
+}
+
+const Template = (args) => <ButtonBase {...args} />
+
+export const Basic = Template.bind({})
+Basic.args = {
+    name: 'Basic button',
+}
+
+export const Disabled = (args) => (
+    <ButtonBase name="Disabled button" {...args} />
+)
+Disabled.args = {
+    disabled: true,
+}
+Disabled.parameters = {
+    docs: {
+        description: {
+            story: "Use disabled buttons when an action is being prevented for some reason. \
+                Always communicate to the user why the button can't be clicked. This can \
+                be done through a tooltip on hover, or with supplementary text underneath \
+                the button. Do not change the button label between disabled/enabled states.",
+        },
+    },
+}

--- a/components/button/src/button-base/index.js
+++ b/components/button/src/button-base/index.js
@@ -1,0 +1,1 @@
+export { ButtonBase } from './button-base.js'

--- a/components/button/src/button/button.js
+++ b/components/button/src/button/button.js
@@ -1,9 +1,265 @@
 import { CircularLoader } from '@dhis2-ui/loader'
-import { sharedPropTypes } from '@dhis2/ui-constants'
+import { sharedPropTypes, colors, theme, spacers } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useEffect, useRef } from 'react'
-import styles from './button.styles.js'
+import css from 'styled-jsx/css'
+import { ButtonBase } from '../button-base/index.js'
+
+const { className: resolvedClassName, styles } = css.resolve`
+    button {
+        display: inline-flex;
+        position: relative;
+        align-items: center;
+        justify-content: center;
+        border-radius: 4px;
+        font-weight: 400;
+        letter-spacing: 0.5px;
+        text-decoration: none;
+        cursor: pointer;
+        transition: all 0.15s cubic-bezier(0.4, 0, 0.6, 1);
+        user-select: none;
+        color: ${colors.grey900};
+
+        /*medium*/
+        height: 36px;
+        padding: 0 ${spacers.dp12};
+        font-size: 14px;
+        line-height: 16px;
+
+        /*basic*/
+        border: 1px solid ${colors.grey500};
+        background-color: #f9fafb;
+    }
+
+    button:disabled {
+        cursor: not-allowed;
+    }
+
+    button:focus {
+        outline: 3px solid ${theme.focus};
+        outline-offset: 2px;
+        transition: none;
+    }
+
+    /* Prevent focus styles on active and disabled buttons */
+    button:active:focus,
+    button:disabled:focus {
+        outline: none;
+    }
+
+    button:hover {
+        border-color: ${colors.grey500};
+        background-color: ${colors.grey200};
+    }
+
+    button:active,
+    button:active:focus {
+        border-color: ${colors.grey500};
+        background-color: ${colors.grey200};
+        box-shadow: 0 0 0 1px rgb(0, 0, 0, 0.1) inset;
+    }
+
+    button:focus {
+        background-color: #f9fafb;
+    }
+
+    button:disabled {
+        border-color: ${colors.grey400};
+        background-color: #f9fafb;
+        box-shadow: none;
+        color: ${theme.disabled};
+        fill: ${theme.disabled};
+    }
+
+    .small {
+        height: 28px;
+        padding: 0 8px;
+        font-size: 14px;
+        line-height: 16px;
+    }
+
+    .large {
+        height: 43px;
+        padding: 0 ${spacers.dp24};
+        font-size: 16px;
+        letter-spacing: 0.57px;
+        line-height: 19px;
+    }
+
+    .primary {
+        border-color: ${theme.primary800};
+        background: linear-gradient(180deg, #1565c0 0%, #0650a3 100%);
+        background-color: #2b61b3;
+        color: ${colors.white};
+        fill: ${colors.white};
+        font-weight: 500;
+    }
+
+    .primary:hover {
+        border-color: ${theme.primary800};
+        background: linear-gradient(180deg, #054fa3 0%, #034793 100%);
+        background-color: #21539f;
+    }
+
+    .primary:active,
+    .primary:active:focus {
+        background: linear-gradient(180deg, #054fa3 0%, #034793 100%);
+        background-color: #1c4a90;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18) inset;
+    }
+
+    .primary:focus {
+        background: linear-gradient(180deg, #1565c0 0%, #0650a3 100%);
+        background-color: #285dac;
+    }
+
+    .primary:disabled {
+        border-color: #93a6bd;
+        background: #b3c6de;
+        box-shadow: none;
+        color: ${colors.white};
+        fill: ${colors.white};
+    }
+
+    .secondary {
+        border-color: ${colors.grey400};
+        background-color: transparent;
+    }
+
+    .secondary:hover {
+        border-color: ${colors.grey400};
+        background-color: rgba(160, 173, 186, 0.08);
+    }
+
+    .secondary:active,
+    .secondary:active:focus {
+        background-color: rgba(160, 173, 186, 0.2);
+        box-shadow: none;
+    }
+
+    .secondary:focus {
+        background-color: transparent;
+    }
+
+    .secondary:disabled {
+        border-color: ${colors.grey400};
+        background-color: transparent;
+        box-shadow: none;
+        color: ${theme.disabled};
+        fill: ${theme.disabled};
+    }
+
+    .destructive {
+        border-color: #a10b0b;
+        background: linear-gradient(180deg, #d32f2f 0%, #b71c1c 100%);
+        background-color: #b9242b;
+        color: ${colors.white};
+        fill: ${colors.white};
+        font-weight: 500;
+    }
+
+    .destructive:hover {
+        border-color: #a10b0b;
+        background: linear-gradient(180deg, #b81c1c 0%, #b80c0b 100%);
+        background-color: #ac0f1a;
+    }
+
+    .destructive:active,
+    .destructive:active:focus {
+        background: linear-gradient(180deg, #b81c1c 0%, #b80c0b 100%);
+        background-color: #ac101b;
+        box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18) inset;
+    }
+
+    .destructive:focus {
+        background: linear-gradient(180deg, #d32f2f 0%, #b71c1c 100%);
+        background-color: #b72229;
+    }
+
+    .destructive:disabled {
+        border-color: #c59898;
+        background: #d6a8a8;
+        box-shadow: none;
+        color: ${colors.white};
+        fill: ${colors.white};
+    }
+
+    .icon-only {
+        padding: 0 0 0 5px;
+    }
+
+    .button-icon {
+        margin-right: 6px;
+        color: inherit;
+        fill: inherit;
+        font-size: 26px;
+        vertical-align: middle;
+        pointer-events: none;
+    }
+
+    .icon-only .button-icon {
+        margin-right: 5px;
+    }
+
+    .small.icon-only {
+        padding: 0 0 0 1px;
+    }
+
+    .small .button-icon {
+        margin-right: 2px;
+    }
+
+    .small.icon-only .button-icon {
+        margin-right: 1px;
+    }
+
+    .toggled {
+        background: ${colors.grey700};
+        border: 1px solid ${colors.grey900};
+        color: ${colors.grey050};
+        fill: ${colors.grey050};
+    }
+
+    .toggled:focus {
+        background: ${colors.grey800};
+    }
+
+    .toggled:hover {
+        background: ${colors.grey800};
+        border-color: ${colors.grey900};
+    }
+
+    .toggled:active,
+    .toggled:active:focus {
+        background: ${colors.grey900};
+        border-color: ${colors.grey900};
+    }
+
+    .toggled:disabled {
+        background: ${colors.grey500};
+        border-color: ${colors.grey600};
+        color: ${colors.grey050};
+        fill: ${colors.grey050};
+    }
+
+    .loader {
+        width: 16px;
+        height: 16px;
+        margin-right: 8px;
+    }
+
+    .loader + .button-icon {
+        display: none;
+    }
+
+    .icon-only .loader {
+        margin: 0 8px 0 4px;
+    }
+    .small.icon-only .loader {
+        margin: 0 4px;
+    }
+`
 
 export const Button = ({
     children,
@@ -40,7 +296,7 @@ export const Button = ({
     const handleFocus = (event) => onFocus && onFocus({ value, name }, event)
 
     const iconOnly = icon && !children
-    const buttonClassName = cx(className, {
+    const buttonClassName = cx(className, resolvedClassName, {
         primary,
         secondary,
         destructive,
@@ -52,11 +308,11 @@ export const Button = ({
     })
 
     return (
-        <button
+        <ButtonBase
             ref={ref}
             name={name}
             className={buttonClassName}
-            data-test={dataTest}
+            dataTest={dataTest}
             disabled={disabled || loading}
             tabIndex={tabIndex}
             type={type}
@@ -75,8 +331,8 @@ export const Button = ({
             )}
             {icon && <span className="button-icon">{icon}</span>}
             {children}
-            <style jsx>{styles}</style>
-        </button>
+            {styles}
+        </ButtonBase>
     )
 }
 

--- a/components/button/src/index.js
+++ b/components/button/src/index.js
@@ -1,3 +1,4 @@
+export { ButtonBase } from './button-base/index.js'
 export { Button } from './button/index.js'
 export { ButtonStrip } from './button-strip/index.js'
 export { SplitButton } from './split-button/index.js'


### PR DESCRIPTION
Since even our most basic components already have a ton of logic, a straightforward initial strategy seems to me to create `*-base` components. Those components:

- Only add styles (and not styles that relate only to parent component functionality, those should be added by the parents)
- Are used as the base for our more complex parent components (`ButtonBase` for `Button`, etc.)

Check the story for a demo for the `ButtonBase`. Styles should be tweaked a little, but it demonstrates the gist of the idea. I'd start with components that have an equivalent in html, so:

- button
- checkbox
- divider
- input
- label
- legend
- radio
- table
- textarea

Not the select as that does have an equivalent in html, but not the way we've implemented it.

This way it should be simple to implement as the base components have a very clear definition: single tag, only styles can be added. We'll also use them internally, which should prevent them from going stale as they'll be used actively.

We could start with this, and see if there's a need to expand on it later.