### PR TITLE
feat(dropdown-button): add controlled mode

### DIFF
--- a/components/button/src/dropdown-button/__tests__/dropdown-button.test.js
+++ b/components/button/src/dropdown-button/__tests__/dropdown-button.test.js
@@ -1,7 +1,8 @@
 import { Layer } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
-import { shallow } from 'enzyme'
+import { mount } from 'enzyme'
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 import { Button } from '../../index.js'
 import { DropdownButton } from '../dropdown-button.js'
 
@@ -9,19 +10,27 @@ describe('<DropdownButton>', () => {
     describe('controlled mode', () => {
         describe('open state', () => {
             const onClick = jest.fn()
-            const wrapper = shallow(
+            const Component = (
                 <DropdownButton
                     onClick={onClick}
                     open={true}
                     component={<span>test</span>}
                 />
             )
-            it('it shows the Popper when open is true', () => {
+            it('shows the Popper when open is true', async () => {
+                // TODO: https://github.com/popperjs/react-popper/issues/350
+                const wrapper = mount(Component)
+                await act(async () => await null)
+
                 const popper = wrapper.find(Popper)
                 expect(popper).toHaveLength(1)
                 expect(popper.find('span').text()).toEqual('test')
             })
-            it('passes an "open" property to the callback payload with the next open state', () => {
+            it('passes an "open" property to the callback payload with the next open state', async () => {
+                // TODO: https://github.com/popperjs/react-popper/issues/350
+                const wrapper = mount(Component)
+                await act(async () => await null)
+
                 wrapper.find(Layer).simulate('click')
                 expect(onClick).toHaveBeenCalledTimes(1)
 
@@ -37,13 +46,14 @@ describe('<DropdownButton>', () => {
         })
         describe('closed state', () => {
             const onClick = jest.fn()
-            const wrapper = shallow(
+            const wrapper = mount(
                 <DropdownButton
                     onClick={onClick}
                     open={false}
                     component={<span>test</span>}
                 />
             )
+
             it('it does not show the Popper when open is false', () => {
                 const popper = wrapper.find(Popper)
                 expect(popper).toHaveLength(0)

--- a/components/button/src/dropdown-button/__tests__/dropdown-button.test.js
+++ b/components/button/src/dropdown-button/__tests__/dropdown-button.test.js
@@ -1,0 +1,66 @@
+import { Layer } from '@dhis2-ui/layer'
+import { Popper } from '@dhis2-ui/popper'
+import { shallow } from 'enzyme'
+import React from 'react'
+import { Button } from '../../index.js'
+import { DropdownButton } from '../dropdown-button.js'
+
+describe('<DropdownButton>', () => {
+    describe('controlled mode', () => {
+        describe('open state', () => {
+            const onClick = jest.fn()
+            const wrapper = shallow(
+                <DropdownButton
+                    onClick={onClick}
+                    open={true}
+                    component={<span>test</span>}
+                />
+            )
+            it('it shows the Popper when open is true', () => {
+                const popper = wrapper.find(Popper)
+                expect(popper).toHaveLength(1)
+                expect(popper.find('span').text()).toEqual('test')
+            })
+            it('passes an "open" property to the callback payload with the next open state', () => {
+                wrapper.find(Layer).simulate('click')
+                expect(onClick).toHaveBeenCalledTimes(1)
+
+                const args = onClick.mock.calls[0]
+
+                expect(args).toHaveLength(2)
+                expect(args[0]).toEqual(
+                    expect.objectContaining({
+                        open: false,
+                    })
+                )
+            })
+        })
+        describe('closed state', () => {
+            const onClick = jest.fn()
+            const wrapper = shallow(
+                <DropdownButton
+                    onClick={onClick}
+                    open={false}
+                    component={<span>test</span>}
+                />
+            )
+            it('it does not show the Popper when open is false', () => {
+                const popper = wrapper.find(Popper)
+                expect(popper).toHaveLength(0)
+            })
+            it('passes an "open" property to the callback payload with the next open state (false)', () => {
+                wrapper.find(Button).simulate('click')
+                expect(onClick).toHaveBeenCalledTimes(1)
+
+                const args = onClick.mock.calls[0]
+
+                expect(args).toHaveLength(2)
+                expect(args[0]).toEqual(
+                    expect.objectContaining({
+                        open: true,
+                    })
+                )
+            })
+        })
+    })
+})

--- a/components/button/src/dropdown-button/dropdown-button.js
+++ b/components/button/src/dropdown-button/dropdown-button.js
@@ -68,7 +68,7 @@ class DropdownButton extends Component {
     }
     anchorRef = React.createRef()
 
-    controlledOnClick = ({ name, value } = {}, event) => {
+    controlledOnClick = ({ name, value }, event) => {
         this.props.onClick(
             {
                 name,

--- a/components/button/src/dropdown-button/dropdown-button.js
+++ b/components/button/src/dropdown-button/dropdown-button.js
@@ -1,5 +1,6 @@
 import { Layer } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
+import { requiredIf } from '@dhis2/prop-types/build/cjs/propTypes'
 import { spacers, sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
@@ -67,7 +68,18 @@ class DropdownButton extends Component {
     }
     anchorRef = React.createRef()
 
-    onToggle = ({ name, value }, event) => {
+    controlledOnClick = ({ name, value } = {}, event) => {
+        this.props.onClick(
+            {
+                name,
+                value,
+                open: !this.props.open,
+            },
+            event
+        )
+    }
+
+    toggleOpenState = ({ name, value }, event) => {
         this.setState({ open: !this.state.open }, () => {
             if (this.props.onClick) {
                 this.props.onClick(
@@ -83,7 +95,6 @@ class DropdownButton extends Component {
     }
 
     render() {
-        const { open } = this.state
         const {
             component,
             children,
@@ -102,7 +113,13 @@ class DropdownButton extends Component {
             initialFocus,
             dataTest,
         } = this.props
-
+        const isControlled =
+            typeof this.props.open === 'boolean' &&
+            typeof this.props.onClick === 'function'
+        const open = isControlled ? this.props.open : this.state.open
+        const onClick = isControlled
+            ? this.controlledOnClick
+            : this.toggleOpenState
         const ArrowIconComponent = open ? ArrowUp : ArrowDown
 
         return (
@@ -116,7 +133,7 @@ class DropdownButton extends Component {
                     primary={primary}
                     secondary={secondary}
                     small={small}
-                    onClick={this.onToggle}
+                    onClick={onClick}
                     name={name}
                     value={value}
                     tabIndex={tabIndex}
@@ -128,7 +145,7 @@ class DropdownButton extends Component {
                 </Button>
 
                 {open && (
-                    <Layer onClick={this.onToggle} transparent>
+                    <Layer onClick={onClick} transparent>
                         <Popper
                             dataTest={`${dataTest}-popper`}
                             placement="bottom-start"
@@ -174,6 +191,8 @@ DropdownButton.propTypes = {
     /** Button size. Mutually exclusive with `small` prop */
     large: sharedPropTypes.sizePropType,
     name: PropTypes.string,
+    /** Controls popper visibility. When implementing this prop the component becomes a controlled component */
+    open: PropTypes.bool,
     /** Button variant. Mutually exclusive with `destructive` and `secondary` props */
     primary: sharedPropTypes.buttonVariantPropType,
     /** Button variant. Mutually exclusive with `primary` and `destructive` props */
@@ -187,8 +206,12 @@ DropdownButton.propTypes = {
     /**
      * Callback triggered on click.
      * Called with signature `({ name: string, value: string, open: bool }, event)`
+     * Is required when using this component in controlled mode, i.e. when
      */
-    onClick: PropTypes.func,
+    onClick: requiredIf(
+        (props) => typeof props.open === 'boolean',
+        PropTypes.func
+    ),
 }
 
 export { DropdownButton }

--- a/components/button/src/dropdown-button/dropdown-button.stories.js
+++ b/components/button/src/dropdown-button/dropdown-button.stories.js
@@ -1,6 +1,6 @@
 import { FlyoutMenu, MenuItem } from '@dhis2-ui/menu'
 import { sharedPropTypes } from '@dhis2/ui-constants'
-import React from 'react'
+import React, { useState } from 'react'
 import { DropdownButton } from './index.js'
 
 const description = `
@@ -89,3 +89,25 @@ InitialFocus.args = { initialFocus: true }
  * not the normal 'canvas' story viewer)
  */
 InitialFocus.parameters = { docs: { disable: true } }
+
+const ControlledTemplate = (args) => {
+    const [open, setOpen] = useState(false)
+    const toggleOpen = ({ open }) => {
+        console.log(`Set open to ${open}`)
+        setOpen(open)
+    }
+    const onComponentClick = () => {
+        console.log('dropdown will close')
+        setOpen(false)
+    }
+    return (
+        <DropdownButton
+            {...args}
+            component={<button onClick={onComponentClick}>Click me</button>}
+            onClick={toggleOpen}
+            open={open}
+        />
+    )
+}
+export const Controlled = ControlledTemplate.bind({})
+Controlled.args = {}


### PR DESCRIPTION
The idea is as follows:
- If an `open` prop is provided this component goes into "controlled mode", so the parent component can determine when the `Popper` should render.
- If that's the case, the `onClick` becomes a required prop, because that callback will be needed.

Note:
I noticed one strange thing, only in the tests, which I couldn't really explain and I have had to work around it. I have left a code comment to clarify [here](https://github.com/dhis2/ui/pull/865#discussion_r758343075).