### PR TITLE
fix(modal): reduce spacing between elements

### DIFF
--- a/components/modal/src/modal-actions/modal-actions.js
+++ b/components/modal/src/modal-actions/modal-actions.js
@@ -1,3 +1,4 @@
+import { spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -11,6 +12,7 @@ export const ModalActions = ({ children, dataTest }) => (
                 display: flex;
                 justify-content: flex-end;
                 align-self: flex-end;
+                margin: ${spacers.dp16} 0 0;
             }
         `}</style>
     </div>

--- a/components/modal/src/modal-content/modal-content.js
+++ b/components/modal/src/modal-content/modal-content.js
@@ -1,4 +1,3 @@
-import { spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -10,7 +9,6 @@ export const ModalContent = ({ children, className, dataTest }) => (
             div {
                 order: 2;
                 flex-grow: 2;
-                margin: ${spacers.dp24} 0;
                 overflow-y: auto;
             }
         `}</style>

--- a/components/modal/src/modal-title/modal-title.js
+++ b/components/modal/src/modal-title/modal-title.js
@@ -1,4 +1,4 @@
-import { colors } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -15,7 +15,7 @@ export const ModalTitle = ({ children, dataTest }) => (
                 font-size: 20px;
                 font-weight: 500;
                 line-height: 24px;
-                margin: 0;
+                margin: 0 0 ${spacers.dp12};
             }
         `}</style>
     </h1>


### PR DESCRIPTION
Fixes [LIBS-277](https://jira.dhis2.org/browse/LIBS-277).

This PR reduces margins and changes how they are applied. Instead of applying top/bottom margins to `ModalContent`, the respective margins are applied to `ModalTitle` and `ModalActions`. If these elements aren't present, those margins aren't needed (the `Modal` itself has frame padding).
