### PR TITLE
fix: focus styles

### DIFF
--- a/components/button/src/button/button.styles.js
+++ b/components/button/src/button/button.styles.js
@@ -33,14 +33,22 @@ export default css`
 
     button:focus {
         outline: 3px solid ${theme.focus};
-        outline-offset: 2px;
+        outline-offset: -3px;
         transition: none;
+        text-decoration: underline;
+    }
+
+    /* Prevent focus styles when mouse clicking */
+    button:focus:not(:focus-visible) {
+        outline: none;
+        text-decoration: none;
     }
 
     /* Prevent focus styles on active and disabled buttons */
     button:active:focus,
     button:disabled:focus {
         outline: none;
+        text-decoration: none;
     }
 
     button:hover {
@@ -105,8 +113,9 @@ export default css`
     }
 
     .primary:focus {
-        background: linear-gradient(180deg, #1565c0 0%, #0650a3 100%);
-        background-color: #285dac;
+        background: ${colors.blue800};
+        border-color: ${colors.blue900};
+        outline-offset: -5px;
     }
 
     .primary:disabled {

--- a/components/button/src/split-button/split-button.js
+++ b/components/button/src/split-button/split-button.js
@@ -131,11 +131,6 @@ class SplitButton extends Component {
                         border-top-left-radius: 0;
                         border-bottom-left-radius: 0;
                     }
-
-                    /*bring the focused button to the front*/
-                    div > :global(button:focus) {
-                        z-index: 10;
-                    }
                 `}</style>
             </div>
         )

--- a/components/checkbox/src/checkbox/checkbox.js
+++ b/components/checkbox/src/checkbox/checkbox.js
@@ -163,7 +163,7 @@ class Checkbox extends Component {
 
                     input:focus + .icon {
                         outline: 3px solid ${theme.focus};
-                        outline-offset: -1px;
+                        outline-offset: -3px;
                     }
                 `}</style>
             </label>

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -78,7 +78,8 @@ const styles = css`
 
     input:focus {
         outline: none;
-        box-shadow: 0 0 0 3px ${theme.focus};
+        box-shadow: inset 0 0 0 2px ${theme.focus};
+        border-color: ${theme.focus};
     }
 
     input.warning {

--- a/components/radio/src/radio.js
+++ b/components/radio/src/radio.js
@@ -148,7 +148,7 @@ class Radio extends Component {
 
                     input:focus + .icon {
                         outline: 3px solid ${theme.focus};
-                        outline-offset: -1px;
+                        outline-offset: -3px;
                     }
                 `}</style>
             </label>

--- a/components/segmented-control/src/segmented-control.js
+++ b/components/segmented-control/src/segmented-control.js
@@ -69,10 +69,8 @@ export const SegmentedControl = ({ options, selected, onChange }) => {
                 }
 
                 .segment:focus {
-                    /* z-index is required to ensure that outlines appear above sibling buttons */
-                    z-index: 1;
                     outline: 3px solid ${theme.focus};
-                    outline-offset: 2px;
+                    outline-offset: -3px;
                 }
                 /*focus-visible backwards compatibility for safari: https://css-tricks.com/platform-news-using-focus-visible-bbcs-new-typeface-declarative-shadow-doms-a11y-and-placeholders/*/
                 .segment:focus:not(:focus-visible) {
@@ -105,6 +103,10 @@ export const SegmentedControl = ({ options, selected, onChange }) => {
                 .segment.selected:not(:last-of-type) {
                     z-index: 1;
                     margin-right: -1px;
+                }
+
+                .segment.selected:focus {
+                    background: ${colors.teal700};
                 }
 
                 .segment.disabled {

--- a/components/select/src/select/input-wrapper.js
+++ b/components/select/src/select/input-wrapper.js
@@ -54,7 +54,8 @@ const InputWrapper = ({
                 .root:focus,
                 .root:active {
                     outline: none;
-                    box-shadow: 0 0 0 3px ${theme.focus};
+                    box-shadow: inset 0 0 0 2px ${theme.focus};
+                    border-color: ${theme.focus};
                 }
 
                 .root.valid {

--- a/components/switch/src/switch/switch.js
+++ b/components/switch/src/switch/switch.js
@@ -149,7 +149,7 @@ class Switch extends Component {
 
                     input:focus + .icon {
                         outline: 3px solid ${theme.focus};
-                        outline-offset: -1px;
+                        outline-offset: -3px;
                     }
                 `}</style>
             </label>

--- a/components/text-area/src/text-area/text-area.styles.js
+++ b/components/text-area/src/text-area/text-area.styles.js
@@ -29,7 +29,8 @@ export const styles = css`
 
     textarea:focus {
         outline: none;
-        box-shadow: 0 0 0 3px ${theme.focus};
+        box-shadow: inset 0 0 0 2px ${theme.focus};
+        border-color: ${theme.focus};
     }
 
     textarea.valid {


### PR DESCRIPTION
Fixes [UX-20](https://jira.dhis2.org/browse/UX-20). 

This PR fixes focus styles across the library. Focus styles were previously updated, but there were issues where the focus outline was cut off by the parent container. All focus styles are now contained within the element.

For example, issues like:
![image](https://user-images.githubusercontent.com/33054985/145998006-c5e86725-6b4b-4cc8-9b9d-b250c3ed4b99.png)

--- 

## Screenshots

| Component | Before | After |
| --- | --- | --- |
| `Button` | ![image](https://user-images.githubusercontent.com/33054985/145997919-89e8e568-53f4-4f8e-b324-fc439909ba65.png) | ![image](https://user-images.githubusercontent.com/33054985/145997718-851d939d-b525-4ea7-86b9-c84eb1d66cf8.png) |
| `Button secondary` | ![image](https://user-images.githubusercontent.com/33054985/145998375-0bcce00c-b4d3-493d-96a7-b4bab787b1e9.png) |  ![image](https://user-images.githubusercontent.com/33054985/145998288-1cea3ba3-779b-4c70-84cf-ba91132ef35b.png) |
| `Button primary` | ![image](https://user-images.githubusercontent.com/33054985/145998697-1afe1ec5-4bb3-4c8f-9ae4-b9d576556c82.png) | ![image](https://user-images.githubusercontent.com/33054985/145998512-50931841-92bd-4559-9f23-c458b4f0f9f0.png)  |
| `Button destructive` | ![image](https://user-images.githubusercontent.com/33054985/145998807-9b5ca26c-f72f-4e8c-97b0-d70d00d4542e.png) | ![image](https://user-images.githubusercontent.com/33054985/145998862-978b81c9-c3b5-4904-88ff-a566836575cb.png) |
| `Checkbox` | ![image](https://user-images.githubusercontent.com/33054985/145998983-3d3a93fd-9e9a-4ba8-95a3-bfd875b12fd1.png) | ![image](https://user-images.githubusercontent.com/33054985/145999050-b4fbbecf-1dd9-4d53-bf56-9c9abbc62cf8.png) |
| `Radio` | ![image](https://user-images.githubusercontent.com/33054985/145999195-dd39f2e9-fdce-4427-b6a1-29e0f566cbb0.png) | ![image](https://user-images.githubusercontent.com/33054985/145999237-2b82db6b-2152-42ca-a5fc-753d1b5347c8.png) |
| `Input` / `Select` | ![image](https://user-images.githubusercontent.com/33054985/145999490-135c9c79-d04b-4b2e-b2af-4884d6ede233.png) | ![image](https://user-images.githubusercontent.com/33054985/145999611-ee0c0d69-3703-4e5a-ab2a-af8d5d0b7206.png) |
| `Segmented control` | ![image](https://user-images.githubusercontent.com/33054985/146004035-6bb882d5-ec0c-416d-9187-750b3dac42ec.png) | ![image](https://user-images.githubusercontent.com/33054985/146004128-d66bee5c-66ae-451f-909a-1031297025f4.png) |
| `Switch` | ![image](https://user-images.githubusercontent.com/33054985/146004231-bf7686c0-edd4-4a52-a8d5-c0fd1383e8fa.png) | ![image](https://user-images.githubusercontent.com/33054985/146004341-02a88a60-3ce1-45f8-bcdd-e3d45fd9bfc7.png) |

_Note: The focus styles appear outside of the `Checkbox`, `Radio`, and `Switch`, but are actually inside the bounds of the element._