### PR TITLE
fix(alert-bar): prevent cutoff on small screens

### DIFF
--- a/components/alert/src/alert-bar/alert-bar.styles.js
+++ b/components/alert/src/alert-bar/alert-bar.styles.js
@@ -16,6 +16,7 @@ export default css`
         padding-left: ${spacers.dp24};
         margin-bottom: ${spacers.dp16};
         max-width: 600px;
+        min-width: 300px;
         font-size: 14px;
         pointer-events: all;
     }

--- a/components/alert/src/alert-bar/message.js
+++ b/components/alert/src/alert-bar/message.js
@@ -7,7 +7,6 @@ const Message = ({ children }) => (
         <style jsx>{`
             div {
                 flex-grow: 1;
-                min-width: 240px;
             }
         `}</style>
     </div>


### PR DESCRIPTION
Fixes [UX-54](https://jira.dhis2.org/browse/UX-54).

This PR prevents alert bars from being cut off on small screens. Small screens in this case is defined down to 320px, which realistically represents the smallest screen that DHIS2 web apps could be used for.

### Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/33054985/146737386-9d67a142-27de-4481-b8b0-711ad822de43.png) | ![image](https://user-images.githubusercontent.com/33054985/146737414-723e6031-7208-4ef4-b4f5-85efbc69da86.png) |