### PR TITLE
fix(forms): update username regex to match 2.38 backend

### DIFF
--- a/collections/forms/i18n/en.pot
+++ b/collections/forms/i18n/en.pot
@@ -5,96 +5,100 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-12-07T19:28:56.162Z\n"
-"PO-Revision-Date: 2020-12-07T19:28:56.162Z\n"
+"POT-Creation-Date: 2022-01-10T18:10:56.819Z\n"
+"PO-Revision-Date: 2022-01-10T18:10:56.819Z\n"
 
 msgid "Upload file"
-msgstr ""
+msgstr "Upload file"
 
 msgid "Upload files"
-msgstr ""
+msgstr "Upload files"
 
 msgid "Remove"
-msgstr ""
+msgstr "Remove"
 
 msgid "No file(s) selected yet"
-msgstr ""
+msgstr "No file(s) selected yet"
 
 msgid "Please provide an alpha-numeric value"
-msgstr ""
+msgstr "Please provide an alpha-numeric value"
 
 msgid "Please provide a boolean value"
-msgstr ""
+msgstr "Please provide a boolean value"
 
 msgid "Please enter between {{lowerBound}} and {{upperBound}} characters"
-msgstr ""
+msgstr "Please enter between {{lowerBound}} and {{upperBound}} characters"
 
 msgid ""
 "Please make sure the value of this input matches the value in "
 "\"{{otherField}}\"."
 msgstr ""
+"Please make sure the value of this input matches the value in "
+"\"{{otherField}}\"."
 
 msgid "Please enter a maximum of {{upperBound}} characters"
-msgstr ""
+msgstr "Please enter a maximum of {{upperBound}} characters"
 
 msgid "Please enter a number with a maximum of {{upperBound}}"
-msgstr ""
+msgstr "Please enter a number with a maximum of {{upperBound}}"
 
 msgid "Please enter at least {{lowerBound}} characters"
-msgstr ""
+msgstr "Please enter at least {{lowerBound}} characters"
 
 msgid "Please enter a number of at least {{lowerBound}}"
-msgstr ""
+msgstr "Please enter a number of at least {{lowerBound}}"
 
 msgid "Number cannot be less than {{lowerBound}} or more than {{upperBound}}"
-msgstr ""
+msgstr "Number cannot be less than {{lowerBound}} or more than {{upperBound}}"
 
 msgid ""
 "Please make sure the value of this input matches the pattern "
 "{{patternString}}."
 msgstr ""
+"Please make sure the value of this input matches the pattern "
+"{{patternString}}."
 
 msgid "Password should be a string"
-msgstr ""
+msgstr "Password should be a string"
 
 msgid "Password should be at least 8 characters long"
-msgstr ""
+msgstr "Password should be at least 8 characters long"
 
 msgid "Password should be no longer than 34 characters"
-msgstr ""
+msgstr "Password should be no longer than 34 characters"
 
 msgid "Password should contain at least one lowercase letter"
-msgstr ""
+msgstr "Password should contain at least one lowercase letter"
 
 msgid "Password should contain at least one UPPERCASE letter"
-msgstr ""
+msgstr "Password should contain at least one UPPERCASE letter"
 
 msgid "Password should contain at least one number"
-msgstr ""
+msgstr "Password should contain at least one number"
 
 msgid "Password should have at least one special character"
-msgstr ""
+msgstr "Password should have at least one special character"
 
-msgid "Please provide a username between 1 and 255 characters"
-msgstr ""
+msgid "Please provide a username between 4 and 255 characters"
+msgstr "Please provide a username between 4 and 255 characters"
 
 msgid "Please provide a valid email address"
-msgstr ""
+msgstr "Please provide a valid email address"
 
 msgid "Please provide a value"
-msgstr ""
+msgstr "Please provide a value"
 
 msgid "Please provide a round number without decimals"
-msgstr ""
+msgstr "Please provide a round number without decimals"
 
 msgid "Please provide a valid international phone number."
-msgstr ""
+msgstr "Please provide a valid international phone number."
 
 msgid "Please provide a number"
-msgstr ""
+msgstr "Please provide a number"
 
 msgid "Please provide a string"
-msgstr ""
+msgstr "Please provide a string"
 
 msgid "Please provide a valid url"
-msgstr ""
+msgstr "Please provide a valid url"

--- a/collections/forms/src/validators/__tests__/dhis2Username.test.js
+++ b/collections/forms/src/validators/__tests__/dhis2Username.test.js
@@ -7,29 +7,63 @@ import {
 describe('validator: dhis2Username', () => {
     allowsEmptyValues(dhis2Username)
 
-    describe('allows all sorts of strings between 1 and 255 characters long', () => {
+    describe('constrains length of username to between 4 and 255 characters long', () => {
         testValidatorValues(dhis2Username, undefined, [
-            'electricchicken',
-            '1', //1
-            'sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss', //255
-            'some_username^%&*(',
-            'あいうえお',
+            's'.repeat(4),
+            's'.repeat(255),
+            'valid_username',
+        ])
+
+        testValidatorValues(dhis2Username, invalidUsernameMessage, [
+            '1',
+            's',
+            's'.repeat(256),
         ])
     })
 
-    describe('rejects other data types', () => {
+    describe('does not allow usernames to start with _, . or @', () => {
+        testValidatorValues(dhis2Username, invalidUsernameMessage, [
+            '_xxx',
+            '.xxx',
+            '@xxx',
+        ])
+    })
+
+    describe('does not allow usernames to end with _, . or @', () => {
+        testValidatorValues(dhis2Username, invalidUsernameMessage, [
+            'xxx_',
+            'xxx.',
+            'xxx@',
+        ])
+    })
+
+    describe('does not allow usernames to contain __, .. or @@', () => {
+        testValidatorValues(dhis2Username, invalidUsernameMessage, [
+            '__xx',
+            '..xx',
+            '@@xx',
+        ])
+    })
+
+    describe('constrains characters in usernames to [a-z0-9._@]', () => {
+        testValidatorValues(dhis2Username, undefined, [
+            'v@lid_user.name',
+            '123another_v@lid_usern@me',
+        ])
+
+        testValidatorValues(dhis2Username, invalidUsernameMessage, [
+            'あいうえお',
+            'some_username^%&*(',
+        ])
+    })
+
+    describe('rejects non-string data types', () => {
         testValidatorValues(dhis2Username, invalidUsernameMessage, [
             1,
             true,
             {},
             [],
             () => {},
-        ])
-    })
-
-    describe('values that are too long', () => {
-        testValidatorValues(dhis2Username, invalidUsernameMessage, [
-            'ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss', //256
         ])
     })
 })

--- a/collections/forms/src/validators/dhis2Username.js
+++ b/collections/forms/src/validators/dhis2Username.js
@@ -1,13 +1,15 @@
 import i18n from '../locales/index.js'
 import { isEmpty, isString } from './helpers/index.js'
 
+const USERNAME_PATTERN =
+    /^(?=.{4,255}$)(?![_.@])(?!.*[_.@]{2})[a-z0-9._@]+(?<![_.@])$/
+
 const invalidUsernameMessage = i18n.t(
-    'Please provide a username between 1 and 255 characters'
+    'Please provide a username between 4 and 255 characters'
 )
 
 const dhis2Username = (value) =>
-    isEmpty(value) ||
-    (isString(value) && value.length >= 1 && value.length <= 255)
+    isEmpty(value) || (isString(value) && USERNAME_PATTERN.test(value))
         ? undefined
         : invalidUsernameMessage
 


### PR DESCRIPTION
As part of [DHIS2-10886](https://jira.dhis2.org/browse/DHIS2-10886) (see [PR](https://github.com/dhis2/dhis2-core/pull/9358) here), the backend was updated to constrain the range of possible usernames.

This PR updates the username validator in the `forms` collection to match the new restrictions.