### PR TITLE
fix: reduce size of date/time icon in Chrome (LIBS-212)

### DIFF
--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -82,6 +82,15 @@ const styles = css`
         border-color: ${theme.focus};
     }
 
+    input[type="date"]::-webkit-inner-spin-button,
+    input[type="date"]::-webkit-calendar-picker-indicator,
+    input[type="time"]::-webkit-inner-spin-button,
+    input[type="time"]::-webkit-calendar-picker-indicator,
+    input[type="datetime-local"]::-webkit-inner-spin-button,
+    input[type="datetime-local"]::-webkit-calendar-picker-indicator  {
+        height: 14px;
+    }
+
     input.warning {
         border-color: ${theme.warning};
     }

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -82,13 +82,21 @@ const styles = css`
         border-color: ${theme.focus};
     }
 
-    input[type="date"]::-webkit-inner-spin-button,
-    input[type="date"]::-webkit-calendar-picker-indicator,
-    input[type="time"]::-webkit-inner-spin-button,
-    input[type="time"]::-webkit-calendar-picker-indicator,
-    input[type="datetime-local"]::-webkit-inner-spin-button,
-    input[type="datetime-local"]::-webkit-calendar-picker-indicator  {
+    input[type='date']::-webkit-inner-spin-button,
+    input[type='date']::-webkit-calendar-picker-indicator,
+    input[type='time']::-webkit-inner-spin-button,
+    input[type='time']::-webkit-calendar-picker-indicator,
+    input[type='datetime-local']::-webkit-inner-spin-button,
+    input[type='datetime-local']::-webkit-calendar-picker-indicator {
         height: 14px;
+        padding-top: 1px;
+        padding-bottom: 1px;
+    }
+
+    input[type='date']::-webkit-datetime-edit,
+    input[type='datetime-local']::-webkit-datetime-edit,
+    input[type='time']::-webkit-datetime-edit {
+        line-height: 14px;
     }
 
     input.warning {

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -93,10 +93,10 @@ const styles = css`
         padding-bottom: 1px;
     }
 
-    input[type='date']::-webkit-datetime-edit,
-    input[type='datetime-local']::-webkit-datetime-edit,
-    input[type='time']::-webkit-datetime-edit {
-        line-height: 14px;
+    input[type='date']::-webkit-datetime-edit-fields-wrapper,
+    input[type='datetime-local']::-webkit-datetime-edit-fields-wrapper,
+    input[type='time']::-webkit-datetime-edit-fields-wrapper {
+        padding: 0;
     }
 
     input.warning {


### PR DESCRIPTION
Resolves [LIBS-212](https://jira.dhis2.org/browse/LIBS-212), which is a Chrome-specific issue caused by the icon added for `date` and `time` type inputs. The size of the icon has been reduced to fit properly within a `dense` input.

Live example here: https://codesandbox.io/s/chrome-date-time-picker-height-x1f6l?file=/src/styles.css

Example of `text` compared to `date` / `datetime-local` / `time`:

![image](https://user-images.githubusercontent.com/12590483/149125293-f5ce7268-15a2-4b7e-8604-7c2330041b25.png)
