### PR TITLE
feat(data-table): configurable sort icon button title

### DIFF
--- a/components/table/src/data-table/__tests__/data-table-column-header.test.js
+++ b/components/table/src/data-table/__tests__/data-table-column-header.test.js
@@ -155,39 +155,62 @@ describe('<DataTableColumnHeader>', () => {
 
         expect(wrapper.find(TableHeaderCell).prop('scope')).toBe(scope)
     })
-    it('accepts sortDirection and onSortIconClick props', () => {
-        //
-        const name = 'test'
-        const fakeEvent = {
-            target: 'test',
-            value: 'test',
-        }
-        const onClick = jest.fn()
-        const wrapper = shallow(
-            <DataTableColumnHeader
-                name={name}
-                onSortIconClick={onClick}
-                sortDirection={'asc'}
-            />
-        )
+    describe('column header sorting', () => {
+        it('accepts sortDirection, sortIconTitle, and onSortIconClick props', () => {
+            const name = 'test'
+            const title = 'Custom title'
+            const fakeEvent = {
+                target: 'test',
+                value: 'test',
+            }
+            const onClick = jest.fn()
+            const wrapper = shallow(
+                <DataTableColumnHeader
+                    name={name}
+                    onSortIconClick={onClick}
+                    sortDirection={'asc'}
+                    sortIconTitle={title}
+                />
+            )
 
-        wrapper
-            .find(Sorter)
-            .dive()
-            .find(TableHeaderCellAction)
-            .dive()
-            .find('button')
-            .simulate('click', fakeEvent)
+            const button = wrapper
+                .find(Sorter)
+                .dive()
+                .find(TableHeaderCellAction)
+                .dive()
+                .find('button')
 
-        expect(onClick).toHaveBeenCalledTimes(1)
-        expect(onClick).toHaveBeenCalledWith(
-            {
-                name,
-                // next sort direction
-                direction: 'desc',
-            },
-            fakeEvent
-        )
+            button.simulate('click', fakeEvent)
+
+            expect(onClick).toHaveBeenCalledTimes(1)
+            expect(onClick).toHaveBeenCalledWith(
+                {
+                    name,
+                    // next sort direction
+                    direction: 'desc',
+                },
+                fakeEvent
+            )
+            expect(button.prop('title')).toBe(title)
+        })
+        it('has a default sort icon title', () => {
+            const wrapper = shallow(
+                <DataTableColumnHeader
+                    name={'test'}
+                    onSortIconClick={() => {}}
+                    sortDirection={'asc'}
+                />
+            )
+
+            const button = wrapper
+                .find(Sorter)
+                .dive()
+                .find(TableHeaderCellAction)
+                .dive()
+                .find('button')
+
+            expect(button.prop('title')).toBe('Sort items')
+        })
     })
     it('accepts a top prop', () => {
         const top = '200px'

--- a/components/table/src/data-table/data-table-column-header/data-table-column-header.js
+++ b/components/table/src/data-table/data-table-column-header/data-table-column-header.js
@@ -34,6 +34,7 @@ export const DataTableColumnHeader = forwardRef(
             scope,
             showFilter,
             sortDirection,
+            sortIconTitle,
             top,
             width,
             onFilterIconClick,
@@ -68,6 +69,7 @@ export const DataTableColumnHeader = forwardRef(
                             name={name}
                             sortDirection={sortDirection}
                             onClick={onSortIconClick}
+                            title={sortIconTitle}
                         />
                     )}
                     {filter && (
@@ -122,6 +124,7 @@ DataTableColumnHeader.propTypes = {
         (props) => props.onSortIconClick,
         PropTypes.oneOf(SORT_DIRECTIONS)
     ),
+    sortIconTitle: PropTypes.string,
     /** Left or top required when fixed */
     top: requiredIf((props) => props.fixed && !props.left, PropTypes.string),
     width: PropTypes.string,

--- a/components/table/src/data-table/data-table-column-header/sorter.js
+++ b/components/table/src/data-table/data-table-column-header/sorter.js
@@ -17,7 +17,7 @@ export const getNextSortDirection = (currentDirection) => {
     return SORT_DIRECTIONS[nextIndex]
 }
 
-export const Sorter = ({ name, sortDirection, onClick }) => {
+export const Sorter = ({ name, sortDirection, title, onClick }) => {
     const nextSortDirection = getNextSortDirection(sortDirection)
     const clickHandler = onClick
         ? (event) => {
@@ -28,7 +28,7 @@ export const Sorter = ({ name, sortDirection, onClick }) => {
     return (
         <TableHeaderCellAction
             onClick={clickHandler}
-            title={i18n.t('Sort items')}
+            title={title || i18n.t('Sort items')}
         >
             <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -62,5 +62,6 @@ Sorter.propTypes = {
         (props) => props.onClick,
         PropTypes.oneOf(SORT_DIRECTIONS)
     ),
+    title: PropTypes.string,
     onClick: PropTypes.func,
 }

--- a/components/table/src/data-table/data-table.stories.js
+++ b/components/table/src/data-table/data-table.stories.js
@@ -1080,6 +1080,7 @@ const ColumnHeaderSortingTemplate = (args) => {
                         onSortIconClick={onSortIconClick}
                         sortDirection={getSortDirection('firstName')}
                         name={'firstName'}
+                        sortIconTitle="Sort by first name"
                     >
                         First name
                     </DataTableColumnHeader>
@@ -1087,6 +1088,7 @@ const ColumnHeaderSortingTemplate = (args) => {
                         onSortIconClick={onSortIconClick}
                         sortDirection={getSortDirection('lastName')}
                         name={'lastName'}
+                        sortIconTitle="Sort by last name"
                     >
                         Last name
                     </DataTableColumnHeader>


### PR DESCRIPTION
This adds a `sortIconTitle` to `DataTableColumnHeader` which makes it possible to configure the sort-button's title. I decided not to add a specific demo for this, because IMO it was quite a logical addition to one of the existing demos. I did add a unit test for both a custom value, and the default.