### PR TITLE
fix(status-icon): only apply margin between input and status icon if icon rendered

### DIFF
--- a/components/file-input/package.json
+++ b/components/file-input/package.json
@@ -37,6 +37,7 @@
         "@dhis2-ui/field": "7.14.1",
         "@dhis2-ui/label": "7.14.1",
         "@dhis2-ui/loader": "7.14.1",
+        "@dhis2-ui/status-icon": "7.14.1",
         "@dhis2/ui-constants": "7.14.1",
         "@dhis2/ui-icons": "7.14.1",
         "classnames": "^2.3.1",

--- a/components/file-input/src/file-input/file-input.js
+++ b/components/file-input/src/file-input/file-input.js
@@ -1,107 +1,11 @@
 import { Button } from '@dhis2-ui/button'
-import { CircularLoader } from '@dhis2-ui/loader'
-import { colors, theme, spacers, sharedPropTypes } from '@dhis2/ui-constants'
-import {
-    IconErrorFilled24,
-    IconCheckmark24,
-    IconInfo24,
-    IconUpload24,
-    IconWarningFilled24,
-} from '@dhis2/ui-icons'
+import { StatusIcon } from '@dhis2-ui/status-icon'
+import { colors, spacers, sharedPropTypes } from '@dhis2/ui-constants'
+import { IconUpload24 } from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { createRef, Component } from 'react'
 
-function Valid({ className }) {
-    return <IconCheckmark24 color={theme.valid} className={className} />
-}
-
-Valid.propTypes = {
-    className: PropTypes.string,
-}
-
-function Warning({ className }) {
-    return <IconWarningFilled24 color={theme.warning} className={className} />
-}
-
-Warning.propTypes = {
-    className: PropTypes.string,
-}
-
-function Error({ className }) {
-    return <IconErrorFilled24 color={theme.error} className={className} />
-}
-
-Error.propTypes = {
-    className: PropTypes.string,
-}
-
-function Info({ className }) {
-    return <IconInfo24 color={theme.info} className={className} />
-}
-
-Info.propTypes = {
-    className: PropTypes.string,
-}
-
-function Loading({ className }) {
-    return <CircularLoader small className={className} />
-}
-
-Loading.propTypes = {
-    className: PropTypes.string,
-}
-
-// TODO: extract
-const StatusIcon = ({
-    error,
-    warning,
-    valid,
-    loading,
-    info,
-    className,
-    defaultTo,
-}) => {
-    if (error) {
-        return <Error className={className} />
-    }
-    if (warning) {
-        return <Warning className={className} />
-    }
-    if (valid) {
-        return <Valid className={className} />
-    }
-    if (loading) {
-        return <Loading className={className} />
-    }
-    if (info) {
-        return <Info className={className} />
-    }
-
-    return defaultTo
-}
-
-StatusIcon.defaultProps = {
-    defaultTo: null,
-}
-
-StatusIcon.propTypes = {
-    className: PropTypes.string,
-    defaultTo: PropTypes.element,
-    error: PropTypes.bool,
-    info: PropTypes.bool,
-    loading: PropTypes.bool,
-    valid: PropTypes.bool,
-    warning: PropTypes.bool,
-}
-
-function Upload({ className }) {
-    return <IconUpload24 color={colors.grey700} className={className} />
-}
-
-Upload.propTypes = {
-    className: PropTypes.string,
-}
 class FileInput extends Component {
     ref = createRef()
 
@@ -171,7 +75,7 @@ class FileInput extends Component {
                     />
                     <Button
                         disabled={disabled}
-                        icon={<Upload />}
+                        icon={<IconUpload24 color={colors.grey700} />}
                         initialFocus={initialFocus}
                         large={large}
                         onBlur={this.handleBlur}

--- a/components/file-input/src/file-input/file-input.js
+++ b/components/file-input/src/file-input/file-input.js
@@ -52,6 +52,7 @@ Loading.propTypes = {
     className: PropTypes.string,
 }
 
+// TODO: extract
 const StatusIcon = ({
     error,
     warning,
@@ -157,30 +158,32 @@ class FileInput extends Component {
 
         return (
             <div className={cx('file-input', className)} data-test={dataTest}>
-                <input
-                    id={name}
-                    name={name}
-                    type="file"
-                    ref={this.ref}
-                    onChange={this.handleChange}
-                    accept={accept}
-                    multiple={multiple}
-                    disabled={disabled}
-                />
-                <Button
-                    disabled={disabled}
-                    icon={<Upload />}
-                    initialFocus={initialFocus}
-                    large={large}
-                    onBlur={this.handleBlur}
-                    onClick={this.handleClick}
-                    onFocus={this.handleFocus}
-                    small={small}
-                    tabIndex={tabIndex}
-                    type="button"
-                >
-                    {buttonLabel}
-                </Button>
+                <div>
+                    <input
+                        id={name}
+                        name={name}
+                        type="file"
+                        ref={this.ref}
+                        onChange={this.handleChange}
+                        accept={accept}
+                        multiple={multiple}
+                        disabled={disabled}
+                    />
+                    <Button
+                        disabled={disabled}
+                        icon={<Upload />}
+                        initialFocus={initialFocus}
+                        large={large}
+                        onBlur={this.handleBlur}
+                        onClick={this.handleClick}
+                        onFocus={this.handleFocus}
+                        small={small}
+                        tabIndex={tabIndex}
+                        type="button"
+                    >
+                        {buttonLabel}
+                    </Button>
+                </div>
                 <StatusIcon error={error} valid={valid} warning={warning} />
 
                 <style jsx>{`
@@ -191,11 +194,8 @@ class FileInput extends Component {
                     .file-input {
                         display: flex;
                         align-items: center;
+                        gap: ${spacers.dp8};
                         padding-bottom: ${spacers.dp4};
-                    }
-
-                    .file-input > :global(svg) {
-                        margin-left: ${spacers.dp8};
                     }
                 `}</style>
             </div>

--- a/components/input/package.json
+++ b/components/input/package.json
@@ -36,6 +36,7 @@
         "@dhis2-ui/field": "7.14.1",
         "@dhis2-ui/input": "7.14.1",
         "@dhis2-ui/loader": "7.14.1",
+        "@dhis2-ui/status-icon": "7.14.1",
         "@dhis2/ui-constants": "7.14.1",
         "@dhis2/ui-icons": "7.14.1",
         "classnames": "^2.3.1",

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -1,39 +1,9 @@
-import { CircularLoader } from '@dhis2-ui/loader'
+import { StatusIcon } from '@dhis2-ui/status-icon'
 import { theme, colors, spacers, sharedPropTypes } from '@dhis2/ui-constants'
-import {
-    IconErrorFilled24,
-    IconWarningFilled24,
-    IconCheckmark24,
-} from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import css from 'styled-jsx/css'
-
-// TODO: extract
-const StatusIcon = ({ error, warning, valid, loading }) => {
-    if (error) {
-        return <IconErrorFilled24 color={theme.error} />
-    }
-    if (warning) {
-        return <IconWarningFilled24 color={theme.warning} />
-    }
-    if (valid) {
-        return <IconCheckmark24 color={theme.valid} />
-    }
-    if (loading) {
-        return <CircularLoader small />
-    }
-
-    return null
-}
-
-StatusIcon.propTypes = {
-    error: PropTypes.bool,
-    loading: PropTypes.bool,
-    valid: PropTypes.bool,
-    warning: PropTypes.bool,
-}
 
 const styles = css`
     .input {

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -10,14 +10,8 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import css from 'styled-jsx/css'
 
-const StatusIcon = ({
-    error,
-    warning,
-    valid,
-    loading,
-    className,
-    defaultTo,
-}) => {
+// TODO: extract
+const StatusIcon = ({ error, warning, valid, loading }) => {
     if (error) {
         return <IconErrorFilled24 color={theme.error} />
     }
@@ -28,19 +22,13 @@ const StatusIcon = ({
         return <IconCheckmark24 color={theme.valid} />
     }
     if (loading) {
-        return <CircularLoader small className={className} />
+        return <CircularLoader small />
     }
 
-    return defaultTo
-}
-
-StatusIcon.defaultProps = {
-    defaultTo: null,
+    return null
 }
 
 StatusIcon.propTypes = {
-    className: PropTypes.string,
-    defaultTo: PropTypes.element,
     error: PropTypes.bool,
     loading: PropTypes.bool,
     valid: PropTypes.bool,
@@ -51,6 +39,7 @@ const styles = css`
     .input {
         display: flex;
         align-items: center;
+        gap: ${spacers.dp8};
     }
 
     input {
@@ -119,12 +108,6 @@ const styles = css`
         border-color: ${colors.grey500};
         color: ${theme.disabled};
         cursor: not-allowed;
-    }
-
-    .status-icon {
-        flex-shrink: 0;
-        flex-grow: 0;
-        margin-left: ${spacers.dp8};
     }
 `
 
@@ -214,15 +197,12 @@ export class Input extends Component {
                         'read-only': readOnly,
                     })}
                 />
-
-                <div className="status-icon">
-                    <StatusIcon
-                        error={error}
-                        valid={valid}
-                        loading={loading}
-                        warning={warning}
-                    />
-                </div>
+                <StatusIcon
+                    error={error}
+                    valid={valid}
+                    loading={loading}
+                    warning={warning}
+                />
 
                 <style jsx>{styles}</style>
                 <style jsx>{`

--- a/components/select/package.json
+++ b/components/select/package.json
@@ -43,6 +43,7 @@
         "@dhis2-ui/layer": "7.14.1",
         "@dhis2-ui/loader": "7.14.1",
         "@dhis2-ui/popper": "7.14.1",
+        "@dhis2-ui/status-icon": "7.14.1",
         "@dhis2/ui-constants": "7.14.1",
         "@dhis2/ui-icons": "7.14.1",
         "classnames": "^2.3.1",

--- a/components/select/src/multi-select/multi-select.js
+++ b/components/select/src/multi-select/multi-select.js
@@ -12,7 +12,8 @@ import { FilterableMenu } from './filterable-menu.js'
 import { Input } from './input.js'
 import { Menu } from './menu.js'
 
-const StatusIcon = ({ error, warning, valid, defaultTo }) => {
+// TODO: extract
+const StatusIcon = ({ error, warning, valid }) => {
     if (error) {
         return <IconErrorFilled24 color={theme.error} />
     }
@@ -23,15 +24,10 @@ const StatusIcon = ({ error, warning, valid, defaultTo }) => {
         return <IconCheckmark24 color={theme.valid} />
     }
 
-    return defaultTo
-}
-
-StatusIcon.defaultProps = {
-    defaultTo: null,
+    return null
 }
 
 StatusIcon.propTypes = {
-    defaultTo: PropTypes.element,
     error: PropTypes.bool,
     valid: PropTypes.bool,
     warning: PropTypes.bool,
@@ -121,10 +117,10 @@ const MultiSelect = ({
                 .root {
                     align-items: center;
                     display: flex;
+                    gap: ${spacers.dp8};
                 }
 
                 .root-input {
-                    margin-right: ${spacers.dp8};
                     flex: 1;
                 }
             `}</style>

--- a/components/select/src/multi-select/multi-select.js
+++ b/components/select/src/multi-select/multi-select.js
@@ -1,37 +1,12 @@
+import { StatusIcon } from '@dhis2-ui/status-icon'
 import { requiredIf } from '@dhis2/prop-types'
-import { theme, spacers, sharedPropTypes } from '@dhis2/ui-constants'
-import {
-    IconErrorFilled24,
-    IconWarningFilled24,
-    IconCheckmark24,
-} from '@dhis2/ui-icons'
+import { spacers, sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Loading as CommonLoading, Select } from '../select/index.js'
 import { FilterableMenu } from './filterable-menu.js'
 import { Input } from './input.js'
 import { Menu } from './menu.js'
-
-// TODO: extract
-const StatusIcon = ({ error, warning, valid }) => {
-    if (error) {
-        return <IconErrorFilled24 color={theme.error} />
-    }
-    if (warning) {
-        return <IconWarningFilled24 color={theme.warning} />
-    }
-    if (valid) {
-        return <IconCheckmark24 color={theme.valid} />
-    }
-
-    return null
-}
-
-StatusIcon.propTypes = {
-    error: PropTypes.bool,
-    valid: PropTypes.bool,
-    warning: PropTypes.bool,
-}
 
 const MultiSelect = ({
     className,

--- a/components/select/src/single-select/single-select.js
+++ b/components/select/src/single-select/single-select.js
@@ -12,7 +12,8 @@ import { FilterableMenu } from './filterable-menu.js'
 import { Input } from './input.js'
 import { Menu } from './menu.js'
 
-const StatusIcon = ({ error, warning, valid, defaultTo }) => {
+// TODO: extract
+const StatusIcon = ({ error, warning, valid }) => {
     if (error) {
         return <IconErrorFilled24 color={theme.error} />
     }
@@ -23,15 +24,10 @@ const StatusIcon = ({ error, warning, valid, defaultTo }) => {
         return <IconCheckmark24 color={theme.valid} />
     }
 
-    return defaultTo
-}
-
-StatusIcon.defaultProps = {
-    defaultTo: null,
+    return null
 }
 
 StatusIcon.propTypes = {
-    defaultTo: PropTypes.element,
     error: PropTypes.bool,
     valid: PropTypes.bool,
     warning: PropTypes.bool,
@@ -121,10 +117,10 @@ const SingleSelect = ({
                 .root {
                     align-items: center;
                     display: flex;
+                    gap: ${spacers.dp8};
                 }
 
                 .root-input {
-                    margin-right: ${spacers.dp8};
                     flex: 1;
                 }
             `}</style>

--- a/components/select/src/single-select/single-select.js
+++ b/components/select/src/single-select/single-select.js
@@ -1,37 +1,12 @@
+import { StatusIcon } from '@dhis2-ui/status-icon'
 import { requiredIf } from '@dhis2/prop-types'
-import { theme, spacers, sharedPropTypes } from '@dhis2/ui-constants'
-import {
-    IconErrorFilled24,
-    IconWarningFilled24,
-    IconCheckmark24,
-} from '@dhis2/ui-icons'
+import { spacers, sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Loading as CommonLoading, Select } from '../select/index.js'
 import { FilterableMenu } from './filterable-menu.js'
 import { Input } from './input.js'
 import { Menu } from './menu.js'
-
-// TODO: extract
-const StatusIcon = ({ error, warning, valid }) => {
-    if (error) {
-        return <IconErrorFilled24 color={theme.error} />
-    }
-    if (warning) {
-        return <IconWarningFilled24 color={theme.warning} />
-    }
-    if (valid) {
-        return <IconCheckmark24 color={theme.valid} />
-    }
-
-    return null
-}
-
-StatusIcon.propTypes = {
-    error: PropTypes.bool,
-    valid: PropTypes.bool,
-    warning: PropTypes.bool,
-}
 
 const SingleSelect = ({
     className,

--- a/components/status-icon/README.md
+++ b/components/status-icon/README.md
@@ -1,0 +1,6 @@
+> :warning:
+> This is currently considered internal, please use `@dhis2/ui`.
+>
+> See the [Getting started
+> guide](https://github.com/dhis2/ui/blob/master/docs/getting-started.md)
+> for more information.

--- a/components/status-icon/d2.config.js
+++ b/components/status-icon/d2.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+    type: 'lib',
+    entryPoints: {
+        lib: 'src/index.js',
+    },
+}

--- a/components/status-icon/package.json
+++ b/components/status-icon/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "@dhis2-ui/text-area",
+    "name": "@dhis2-ui/status-icon",
     "version": "7.14.1",
-    "description": "UI TextArea",
+    "description": "UI StatusIcon",
     "repository": {
         "type": "git",
         "url": "https://github.com/dhis2/ui.git",
-        "directory": "components/text-area"
+        "directory": "components/status-icon"
     },
     "homepage": "https://github.com/dhis2/ui#readme",
     "license": "BSD-3-Clause",
@@ -32,10 +32,7 @@
     },
     "dependencies": {
         "@dhis2/prop-types": "^3.0.0-beta.1",
-        "@dhis2-ui/box": "7.14.1",
-        "@dhis2-ui/field": "7.14.1",
         "@dhis2-ui/loader": "7.14.1",
-        "@dhis2-ui/status-icon": "7.14.1",
         "@dhis2/ui-constants": "7.14.1",
         "@dhis2/ui-icons": "7.14.1",
         "classnames": "^2.3.1",

--- a/components/status-icon/src/index.js
+++ b/components/status-icon/src/index.js
@@ -1,0 +1,1 @@
+export { StatusIcon } from './status-icon.js'

--- a/components/status-icon/src/status-icon.js
+++ b/components/status-icon/src/status-icon.js
@@ -1,0 +1,33 @@
+import { CircularLoader } from '@dhis2-ui/loader'
+import { theme } from '@dhis2/ui-constants'
+import {
+    IconErrorFilled24,
+    IconWarningFilled24,
+    IconCheckmark24,
+} from '@dhis2/ui-icons'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export const StatusIcon = ({ error, warning, valid, loading }) => {
+    if (error) {
+        return <IconErrorFilled24 color={theme.error} />
+    }
+    if (warning) {
+        return <IconWarningFilled24 color={theme.warning} />
+    }
+    if (valid) {
+        return <IconCheckmark24 color={theme.valid} />
+    }
+    if (loading) {
+        return <CircularLoader small />
+    }
+
+    return null
+}
+
+StatusIcon.propTypes = {
+    error: PropTypes.bool,
+    loading: PropTypes.bool,
+    valid: PropTypes.bool,
+    warning: PropTypes.bool,
+}

--- a/components/text-area/src/text-area/text-area.js
+++ b/components/text-area/src/text-area/text-area.js
@@ -1,39 +1,9 @@
-import { CircularLoader } from '@dhis2-ui/loader'
-import { theme, sharedPropTypes } from '@dhis2/ui-constants'
-import {
-    IconErrorFilled24,
-    IconWarningFilled24,
-    IconCheckmark24,
-} from '@dhis2/ui-icons'
+import { StatusIcon } from '@dhis2-ui/status-icon'
+import { sharedPropTypes } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { styles } from './text-area.styles.js'
-
-// TODO: extract
-const StatusIcon = ({ error, warning, valid, loading }) => {
-    if (error) {
-        return <IconErrorFilled24 color={theme.error} />
-    }
-    if (warning) {
-        return <IconWarningFilled24 color={theme.warning} />
-    }
-    if (valid) {
-        return <IconCheckmark24 color={theme.valid} />
-    }
-    if (loading) {
-        return <CircularLoader small />
-    }
-
-    return null
-}
-
-StatusIcon.propTypes = {
-    error: PropTypes.bool,
-    loading: PropTypes.bool,
-    valid: PropTypes.bool,
-    warning: PropTypes.bool,
-}
 
 export class TextArea extends Component {
     textareaRef = React.createRef()

--- a/components/text-area/src/text-area/text-area.js
+++ b/components/text-area/src/text-area/text-area.js
@@ -10,14 +10,8 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { styles } from './text-area.styles.js'
 
-const StatusIcon = ({
-    error,
-    warning,
-    valid,
-    loading,
-    className,
-    defaultTo,
-}) => {
+// TODO: extract
+const StatusIcon = ({ error, warning, valid, loading }) => {
     if (error) {
         return <IconErrorFilled24 color={theme.error} />
     }
@@ -28,19 +22,13 @@ const StatusIcon = ({
         return <IconCheckmark24 color={theme.valid} />
     }
     if (loading) {
-        return <CircularLoader small className={className} />
+        return <CircularLoader small />
     }
 
-    return defaultTo
-}
-
-StatusIcon.defaultProps = {
-    defaultTo: null,
+    return null
 }
 
 StatusIcon.propTypes = {
-    className: PropTypes.string,
-    defaultTo: PropTypes.element,
     error: PropTypes.bool,
     loading: PropTypes.bool,
     valid: PropTypes.bool,
@@ -188,15 +176,12 @@ export class TextArea extends Component {
                         'read-only': readOnly,
                     })}
                 />
-
-                <div className="status-icon">
-                    <StatusIcon
-                        error={error}
-                        valid={valid}
-                        loading={loading}
-                        warning={warning}
-                    />
-                </div>
+                <StatusIcon
+                    error={error}
+                    valid={valid}
+                    loading={loading}
+                    warning={warning}
+                />
 
                 <style jsx>{styles}</style>
                 <style jsx>{`

--- a/components/text-area/src/text-area/text-area.styles.js
+++ b/components/text-area/src/text-area/text-area.styles.js
@@ -4,6 +4,7 @@ import css from 'styled-jsx/css'
 export const styles = css`
     .textarea {
         display: flex;
+        gap: ${spacers.dp8};
     }
     textarea {
         box-sizing: border-box;
@@ -56,11 +57,5 @@ export const styles = css`
         border-color: ${colors.grey500};
         color: ${theme.disabled};
         cursor: not-allowed;
-    }
-
-    .status-icon {
-        flex-grow: 0;
-        flex-shrink: 0;
-        margin-left: ${spacers.dp4};
     }
 `


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/LIBS-80

Replaces the margin between various inputs and their status icons with a flexbox gap. Also extracts the `StatusIcon` component.