### PR TITLE
feat(chip): allow custom margin

### DIFF
--- a/components/chip/src/chip.js
+++ b/components/chip/src/chip.js
@@ -1,4 +1,4 @@
-import { colors, theme, spacers } from '@dhis2/ui-constants'
+import { colors, theme } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -18,6 +18,10 @@ const Chip = ({
     onClick,
     icon,
     dataTest,
+    marginBottom,
+    marginLeft,
+    marginRight,
+    marginTop,
 }) => (
     <span
         onClick={(e) => {
@@ -42,7 +46,6 @@ const Chip = ({
                 display: inline-flex;
                 align-items: center;
                 height: 32px;
-                margin: ${spacers.dp4};
                 border-radius: 16px;
                 background-color: ${colors.grey200};
                 font-size: 14px;
@@ -92,11 +95,23 @@ const Chip = ({
                     0 1px 5px 0 rgba(0, 0, 0, 0.12);
             }
         `}</style>
+        <style jsx>{`
+            span {
+                ${marginBottom && `margin-bottom: ${marginBottom}px;`}
+                ${marginLeft && `margin-left: ${marginLeft}px;`}
+                ${marginRight && `margin-right: ${marginRight}px;`}
+                ${marginTop && `margin-top: ${marginTop}px`}
+            }
+        `}</style>
     </span>
 )
 
 Chip.defaultProps = {
     dataTest: 'dhis2-uicore-chip',
+    marginBottom: 4,
+    marginLeft: 4,
+    marginRight: 4,
+    marginTop: 4,
 }
 
 Chip.propTypes = {
@@ -107,6 +122,14 @@ Chip.propTypes = {
     disabled: PropTypes.bool,
     dragging: PropTypes.bool,
     icon: PropTypes.element,
+    /** `margin-bottom` value, applied in `px`  */
+    marginBottom: PropTypes.number,
+    /** `margin-left` value, applied in `px`  */
+    marginLeft: PropTypes.number,
+    /** `margin-right` value, applied in `px`  */
+    marginRight: PropTypes.number,
+    /** `margin-top` value, applied in `px`  */
+    marginTop: PropTypes.number,
     overflow: PropTypes.bool,
     selected: PropTypes.bool,
     onClick: PropTypes.func,


### PR DESCRIPTION
This PR allows custom margin values to be passed to the `Chip`. The implementation is based upon the proposal below.

---

## Background
Some UI components apply a default margin. For example, the `chip` has a default `margin: 4px`. This was added to provide a reasonable default for the expected usage of a group `chip`s. The alternative, applying no default margin, would mean that in the majority of cases the consumers of UI would need to wrap the `chip` and apply margins.

## Problem
The default margins applied to some components are not always appropriate. In many cases they are, but in other cases they make the component less flexible. This leads to workarounds that are not recommended, like using `className`. @varl and I have discussed alternatives and have a proposed solution.

## Proposed solution
Define a standard way for components to expose a set of `margin` props. Though this might be defined as a _global_ prop, it is not required for every component. It should be manually included for any component where a custom `margin` value may provide extended flexibility.

The proposed props would be:
```
margin: PropTypes.number,
marginBottom: PropTypes.number,
marginLeft: PropTypes.number,
marginRight: PropTypes.number,
marginTop: PropTypes.number,
```

Implementation in a components styles looks like:
```
margin: ${margin}px;
${marginBottom && `margin-bottom: ${marginBottom}px;`}
${marginLeft && `margin-left: ${marginLeft}px;`}
${marginRight && `margin-right: ${marginRight}px;`}
${marginTop && `margin-top: ${marginTop}px`}
```

### Alternatives / Other discussions
- Use `PropTypes.string` instead to allow full css declarations to be passed in. 
  - Values are intentionally restricted to pixels. Though allowing a full css declaration to be passed in would be the most flexible, that is not the intended use of this feature. If full custom css declarations are required (like `margin: auto 1rem 50% unset`), then a wrapper element should be used.
-  Automatically apply the `margin` props to all components
   - Potentially useful, but not necessary to start using this pattern. Also, `margin` is not always an appropriate prop to expose.
- Use a `base` wrapper component with a `margin` prop that wraps every other component. Thus, a `margin` prop doesn't need to be added to any other component.
  - Creates an unecessary additional wrapping element, which creates other issues for accessibility, layout and so on. Doesn't seem worth the tradeoff for the convenience it offers.

# Update

After discussion, the decision was made to defer adding the generic `margin` prop and instead add the 4 direction-specific `margin...` props. This avoids any confusion about specificity and override behaviour. If the need for a generic `margin` prop is shown, it can be added in the future.