### PR TITLE
fix(select): don't render circular loader as flex item in order to preserve dimensions

### DIFF
--- a/components/select/src/select/loading.js
+++ b/components/select/src/select/loading.js
@@ -1,15 +1,19 @@
 import { CircularLoader } from '@dhis2-ui/loader'
 import { colors, spacers, theme } from '@dhis2/ui-constants'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 export const Loading = ({ message, className, dataTest }) => (
-    <div className={className} data-test={dataTest}>
-        <CircularLoader small />
+    <div className={cx(className, 'container')} data-test={dataTest}>
+        <div>
+            <CircularLoader small />
+        </div>
         {message}
         <style jsx>{`
-            div {
+            .container {
                 display: flex;
+                gap: ${spacers.dp16};
                 align-items: center;
                 justify-content: center;
                 color: ${colors.grey700};


### PR DESCRIPTION
Closes https://jira.dhis2.org/browse/LIBS-283

- Ensures circular loader remains a circle even when loading text wraps
- Adds spacing between circular loader and loading text