### PR TITLE
fix(data-table): enable auto-height in flexbox container

### DIFF
--- a/components/table/src/data-table/table-elements/table-scroll-box.js
+++ b/components/table/src/data-table/table-elements/table-scroll-box.js
@@ -14,6 +14,7 @@ export const TableScrollBox = forwardRef(
                     max-height: ${maxHeight};
                     max-width: ${maxWidth};
                     overflow: auto;
+                    flex-grow: 0;
                 }
             `}</style>
         </div>


### PR DESCRIPTION
In the new Event Reports app we display data using our `DataTable` and it’s got to be scrollable, plus adapt to the available width and height. The container is using flexbox, and after playing around with the element inspector a bit, I realised that if I add `flex-grow: 0;` to the `TableScrollBox`, I can get the correct behaviour without having to compute the available height and set it….

So, I am now considering adding that style rule to the component. Obviously, it’s only going to have an effect if it’s placed in a flexbox container, but I think that’s probably OK. If the container isn’t a flexbox, the style rule is a noop.

Could be I’m missing something. Any objections to adding this?