### PR TITLE
fix(transfer): change TransferOption label-proptype to node

### DIFF
--- a/components/transfer/src/transfer-option.js
+++ b/components/transfer/src/transfer-option.js
@@ -76,7 +76,7 @@ TransferOption.defaultProps = {
 }
 
 TransferOption.propTypes = {
-    label: PropTypes.string.isRequired,
+    label: PropTypes.node.isRequired,
     value: PropTypes.string.isRequired,
     className: PropTypes.string,
     dataTest: PropTypes.string,


### PR DESCRIPTION
Simple fix to allow more customisable Transfer-options. This is used in Data Integrations in the Scheduler app (see https://github.com/dhis2/scheduler-app/pull/348). Label is rendered directly, so a PropType of `node`, should just work. 

