### PR TITLE
feat(pagination): add support for pagers without a total

### DIFF
--- a/components/pagination/src/__fixtures__/index.js
+++ b/components/pagination/src/__fixtures__/index.js
@@ -18,3 +18,15 @@ export const atLastPage = {
     total: 1035,
     pageSize: 50,
 }
+
+export const noTotal = {
+    page: 2,
+    pageSize: 50,
+    isLastPage: false,
+}
+
+export const noTotalAtLastPage = {
+    page: 4,
+    pageSize: 50,
+    isLastPage: true,
+}

--- a/components/pagination/src/__tests__/get-item-range.test.js
+++ b/components/pagination/src/__tests__/get-item-range.test.js
@@ -1,0 +1,65 @@
+import * as mockPagers from '../__fixtures__/index.js'
+import { getItemRange } from '../get-item-range.js'
+
+describe('getItemRange', () => {
+    it('calculates the firstItem and lastItem correctly', () => {
+        const { page, pageSize, total } = mockPagers.atTenthPage
+        const { firstItem, lastItem } = getItemRange({
+            page,
+            pageSize,
+            total,
+        })
+
+        expect(firstItem).toEqual(451)
+        expect(lastItem).toEqual(500)
+    })
+
+    it('returns 0 for firstItem and lastItem if the total is 0', () => {
+        const { firstItem, lastItem } = getItemRange({
+            page: 1,
+            pageSize: 50,
+            total: 0,
+        })
+
+        expect(firstItem).toEqual(0)
+        expect(lastItem).toEqual(0)
+    })
+
+    it('uses the total count as lastItem when the last page is reached', () => {
+        const { page, pageSize, total } = mockPagers.atLastPage
+        const { lastItem } = getItemRange({ page, pageSize, total })
+
+        expect(lastItem).toEqual(total)
+    })
+
+    it('handles pagers without totals', () => {
+        const { firstItem, lastItem } = getItemRange({
+            page: 3,
+            pageSize: 50,
+        })
+
+        expect(firstItem).toEqual(101)
+        expect(lastItem).toEqual(150)
+    })
+
+    it('bases the lastItem on the pageLength for pagers without total when the last page is reached', () => {
+        const { lastItem } = getItemRange({
+            page: 3,
+            pageSize: 50,
+            pageLength: 21,
+            isLastPage: true,
+        })
+
+        expect(lastItem).toEqual(121)
+    })
+
+    it('sets lastItem to NaN when on the last page and there is no total or pageLength', () => {
+        const { lastItem } = getItemRange({
+            page: 3,
+            pageSize: 50,
+            isLastPage: true,
+        })
+
+        expect(lastItem).toEqual(NaN)
+    })
+})

--- a/components/pagination/src/__tests__/page-controls.test.js
+++ b/components/pagination/src/__tests__/page-controls.test.js
@@ -1,6 +1,5 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import * as mockPagers from '../__fixtures__/index.js'
 import { PageControls } from '../page-controls.js'
 
 describe('<PageControls />', () => {
@@ -10,7 +9,7 @@ describe('<PageControls />', () => {
         onClick: mockOnClick,
         nextPageText: 'Next',
         previousPageText: 'Previous',
-        ...mockPagers.atTenthPage,
+        page: 10,
     }
 
     beforeEach(() => {
@@ -34,9 +33,7 @@ describe('<PageControls />', () => {
     })
 
     it('disables the previous page button on the first page', () => {
-        const wrapper = shallow(
-            <PageControls {...props} {...mockPagers.atFirstPage} />
-        )
+        const wrapper = shallow(<PageControls {...props} page={1} />)
 
         expect(
             wrapper.find('.button-previous').getElement().props.disabled
@@ -47,24 +44,8 @@ describe('<PageControls />', () => {
         ).toEqual(false)
     })
 
-    it('disables the next page button on the last page for pagers with total', () => {
-        const wrapper = shallow(
-            <PageControls {...props} {...mockPagers.atLastPage} />
-        )
-
-        expect(
-            wrapper.find('.button-previous').getElement().props.disabled
-        ).toEqual(false)
-
-        expect(
-            wrapper.find('.button-next').getElement().props.disabled
-        ).toEqual(true)
-    })
-
-    it('disables the next page button on the last page for pagers without total', () => {
-        const wrapper = shallow(
-            <PageControls {...props} {...mockPagers.noTotalAtLastPage} />
-        )
+    it('disables the next page button on the last page', () => {
+        const wrapper = shallow(<PageControls {...props} isLastPage={true} />)
 
         expect(
             wrapper.find('.button-previous').getElement().props.disabled

--- a/components/pagination/src/__tests__/page-controls.test.js
+++ b/components/pagination/src/__tests__/page-controls.test.js
@@ -47,9 +47,23 @@ describe('<PageControls />', () => {
         ).toEqual(false)
     })
 
-    it('disables the next page button on the last page', () => {
+    it('disables the next page button on the last page for pagers with total', () => {
         const wrapper = shallow(
             <PageControls {...props} {...mockPagers.atLastPage} />
+        )
+
+        expect(
+            wrapper.find('.button-previous').getElement().props.disabled
+        ).toEqual(false)
+
+        expect(
+            wrapper.find('.button-next').getElement().props.disabled
+        ).toEqual(true)
+    })
+
+    it('disables the next page button on the last page for pagers without total', () => {
+        const wrapper = shallow(
+            <PageControls {...props} {...mockPagers.noTotalAtLastPage} />
         )
 
         expect(

--- a/components/pagination/src/__tests__/page-summary.test.js
+++ b/components/pagination/src/__tests__/page-summary.test.js
@@ -1,7 +1,6 @@
 import { shallow } from 'enzyme'
 import React from 'react'
-import * as mockPagers from '../__fixtures__/index.js'
-import { PageSummary, getItemRange } from '../page-summary.js'
+import { PageSummary } from '../page-summary.js'
 import { Pagination } from '../pagination.js'
 
 describe('<PageSummary />', () => {
@@ -10,125 +9,62 @@ describe('<PageSummary />', () => {
         pageSummaryText: Pagination.defaultProps.pageSummaryText,
     }
 
-    describe('pager with total', () => {
-        it('renders without errors', () => {
-            shallow(<PageSummary {...props} {...mockPagers.atTenthPage} />)
-        })
-
-        it('displays the correct information for a first page', () => {
-            const wrapper = shallow(
-                <PageSummary {...props} {...mockPagers.atFirstPage} />
-            )
-            const expectedString = 'Page 1 of 21, items 1-50 of 1035'
-
-            expect(wrapper.find('span').text()).toEqual(expectedString)
-        })
-
-        it('displays the correct information for a last page', () => {
-            const wrapper = shallow(
-                <PageSummary {...props} {...mockPagers.atLastPage} />
-            )
-            const expectedString = 'Page 21 of 21, items 1001-1035 of 1035'
-
-            expect(wrapper.find('span').text()).toEqual(expectedString)
-        })
-
-        it('displays the correct information for a page between first and last', () => {
-            const wrapper = shallow(
-                <PageSummary {...props} {...mockPagers.atTenthPage} />
-            )
-            const expectedString = 'Page 10 of 21, items 451-500 of 1035'
-
-            expect(wrapper.find('span').text()).toEqual(expectedString)
-        })
+    it('renders without errors', () => {
+        shallow(
+            <PageSummary
+                {...props}
+                firstItem={51}
+                lastItem={100}
+                page={2}
+                pageCount={5}
+                total={224}
+            />
+        )
     })
 
-    describe('pager without total', () => {
-        it('renders without errors', () => {
-            shallow(<PageSummary {...props} {...mockPagers.noTotal} />)
-        })
+    it('renders the correct message when both total and lastItem are provided', () => {
+        const wrapper = shallow(
+            <PageSummary
+                {...props}
+                firstItem={51}
+                lastItem={100}
+                page={2}
+                pageCount={5}
+                total={224}
+            />
+        )
+        const expectedString = 'Page 2 of 5, items 51-100 of 224'
 
-        it('displays the correct information', () => {
-            const wrapper = shallow(
-                <PageSummary {...props} {...mockPagers.noTotal} />
-            )
-            const expectedString = 'Page 2, items 51-100'
-
-            expect(wrapper.find('span').text()).toEqual(expectedString)
-        })
-
-        it('displays the correct information for a last page', () => {
-            const wrapper = shallow(
-                <PageSummary {...props} {...mockPagers.noTotalAtLastPage} />
-            )
-            const expectedString = 'Page 4, items 151-200'
-
-            expect(wrapper.find('span').text()).toEqual(expectedString)
-        })
-
-        it('displays the correct information for a last page when pageLength is provided', () => {
-            const wrapper = shallow(
-                <PageSummary
-                    {...props}
-                    {...mockPagers.noTotalAtLastPage}
-                    pageLength={26}
-                />
-            )
-            const expectedString = 'Page 4, items 151-176'
-
-            expect(wrapper.find('span').text()).toEqual(expectedString)
-        })
+        expect(wrapper.find('span').text()).toEqual(expectedString)
     })
 
-    describe('getItemRange', () => {
-        it('calculates the firstItem and lastItem correctly', () => {
-            const { page, pageSize, total } = mockPagers.atTenthPage
-            const { firstItem, lastItem } = getItemRange({
-                page,
-                pageSize,
-                total,
-            })
+    it('renders the correct message when only lastItem is provided', () => {
+        const wrapper = shallow(
+            <PageSummary
+                {...props}
+                firstItem={51}
+                lastItem={100}
+                page={2}
+                pageCount={5}
+            />
+        )
+        const expectedString = 'Page 2, items 51-100'
 
-            expect(firstItem).toEqual(451)
-            expect(lastItem).toEqual(500)
-        })
+        expect(wrapper.find('span').text()).toEqual(expectedString)
+    })
 
-        it('returns 0 for firstItem and lastItem if the total is 0', () => {
-            const { firstItem, lastItem } = getItemRange({
-                page: 1,
-                pageSize: 50,
-                total: 0,
-            })
+    it('renders the correct message when total is missing and lastItem is not a number', () => {
+        const wrapper = shallow(
+            <PageSummary
+                {...props}
+                firstItem={51}
+                lastItem={NaN}
+                page={2}
+                pageCount={5}
+            />
+        )
+        const expectedString = 'Page 2'
 
-            expect(firstItem).toEqual(0)
-            expect(lastItem).toEqual(0)
-        })
-
-        it('uses the total count as lastItem when the last page is reached', () => {
-            const { page, pageSize, total } = mockPagers.atLastPage
-            const { lastItem } = getItemRange({ page, pageSize, total })
-
-            expect(lastItem).toEqual(total)
-        })
-
-        it('handles pagers without totals', () => {
-            const { firstItem, lastItem } = getItemRange({
-                page: 3,
-                pageSize: 50,
-            })
-
-            expect(firstItem).toEqual(101)
-            expect(lastItem).toEqual(150)
-        })
-
-        it('bases the lastItem on the pageLength when the last page is reached', () => {
-            const { lastItem } = getItemRange({
-                page: 3,
-                pageSize: 50,
-                pageLength: 21,
-            })
-
-            expect(lastItem).toEqual(121)
-        })
+        expect(wrapper.find('span').text()).toEqual(expectedString)
     })
 })

--- a/components/pagination/src/__tests__/page-summary.test.js
+++ b/components/pagination/src/__tests__/page-summary.test.js
@@ -9,48 +9,96 @@ describe('<PageSummary />', () => {
         dataTest: 'test',
         pageSummaryText: Pagination.defaultProps.pageSummaryText,
     }
-    it('renders without errors', () => {
-        shallow(<PageSummary {...props} {...mockPagers.atTenthPage} />)
+
+    describe('pager with total', () => {
+        it('renders without errors', () => {
+            shallow(<PageSummary {...props} {...mockPagers.atTenthPage} />)
+        })
+
+        it('displays the correct information for a first page', () => {
+            const wrapper = shallow(
+                <PageSummary {...props} {...mockPagers.atFirstPage} />
+            )
+            const expectedString = 'Page 1 of 21, items 1-50 of 1035'
+
+            expect(wrapper.find('span').text()).toEqual(expectedString)
+        })
+
+        it('displays the correct information for a last page', () => {
+            const wrapper = shallow(
+                <PageSummary {...props} {...mockPagers.atLastPage} />
+            )
+            const expectedString = 'Page 21 of 21, items 1001-1035 of 1035'
+
+            expect(wrapper.find('span').text()).toEqual(expectedString)
+        })
+
+        it('displays the correct information for a page between first and last', () => {
+            const wrapper = shallow(
+                <PageSummary {...props} {...mockPagers.atTenthPage} />
+            )
+            const expectedString = 'Page 10 of 21, items 451-500 of 1035'
+
+            expect(wrapper.find('span').text()).toEqual(expectedString)
+        })
     })
 
-    it('displays the correct information for a first page', () => {
-        const wrapper = shallow(
-            <PageSummary {...props} {...mockPagers.atFirstPage} />
-        )
-        const expectedString = 'Page 1 of 21, items 1-50 of 1035'
+    describe('pager without total', () => {
+        it('renders without errors', () => {
+            shallow(<PageSummary {...props} {...mockPagers.noTotal} />)
+        })
 
-        expect(wrapper.find('span').text()).toEqual(expectedString)
-    })
+        it('displays the correct information', () => {
+            const wrapper = shallow(
+                <PageSummary {...props} {...mockPagers.noTotal} />
+            )
+            const expectedString = 'Page 2, items 51-100'
 
-    it('displays the correct information for a last page', () => {
-        const wrapper = shallow(
-            <PageSummary {...props} {...mockPagers.atLastPage} />
-        )
-        const expectedString = 'Page 21 of 21, items 1001-1035 of 1035'
+            expect(wrapper.find('span').text()).toEqual(expectedString)
+        })
 
-        expect(wrapper.find('span').text()).toEqual(expectedString)
-    })
+        it('displays the correct information for a last page', () => {
+            const wrapper = shallow(
+                <PageSummary {...props} {...mockPagers.noTotalAtLastPage} />
+            )
+            const expectedString = 'Page 4, items 151-200'
 
-    it('displays the correct information for a page between first and last', () => {
-        const wrapper = shallow(
-            <PageSummary {...props} {...mockPagers.atTenthPage} />
-        )
-        const expectedString = 'Page 10 of 21, items 451-500 of 1035'
+            expect(wrapper.find('span').text()).toEqual(expectedString)
+        })
 
-        expect(wrapper.find('span').text()).toEqual(expectedString)
+        it('displays the correct information for a last page when pageLength is provided', () => {
+            const wrapper = shallow(
+                <PageSummary
+                    {...props}
+                    {...mockPagers.noTotalAtLastPage}
+                    pageLength={26}
+                />
+            )
+            const expectedString = 'Page 4, items 151-176'
+
+            expect(wrapper.find('span').text()).toEqual(expectedString)
+        })
     })
 
     describe('getItemRange', () => {
         it('calculates the firstItem and lastItem correctly', () => {
             const { page, pageSize, total } = mockPagers.atTenthPage
-            const { firstItem, lastItem } = getItemRange(page, pageSize, total)
+            const { firstItem, lastItem } = getItemRange({
+                page,
+                pageSize,
+                total,
+            })
 
             expect(firstItem).toEqual(451)
             expect(lastItem).toEqual(500)
         })
 
         it('returns 0 for firstItem and lastItem if the total is 0', () => {
-            const { firstItem, lastItem } = getItemRange(1, 50, 0)
+            const { firstItem, lastItem } = getItemRange({
+                page: 1,
+                pageSize: 50,
+                total: 0,
+            })
 
             expect(firstItem).toEqual(0)
             expect(lastItem).toEqual(0)
@@ -58,9 +106,29 @@ describe('<PageSummary />', () => {
 
         it('uses the total count as lastItem when the last page is reached', () => {
             const { page, pageSize, total } = mockPagers.atLastPage
-            const { lastItem } = getItemRange(page, pageSize, total)
+            const { lastItem } = getItemRange({ page, pageSize, total })
 
             expect(lastItem).toEqual(total)
+        })
+
+        it('handles pagers without totals', () => {
+            const { firstItem, lastItem } = getItemRange({
+                page: 3,
+                pageSize: 50,
+            })
+
+            expect(firstItem).toEqual(101)
+            expect(lastItem).toEqual(150)
+        })
+
+        it('bases the lastItem on the pageLength when the last page is reached', () => {
+            const { lastItem } = getItemRange({
+                page: 3,
+                pageSize: 50,
+                pageLength: 21,
+            })
+
+            expect(lastItem).toEqual(121)
         })
     })
 })

--- a/components/pagination/src/__tests__/pagination.test.js
+++ b/components/pagination/src/__tests__/pagination.test.js
@@ -6,39 +6,60 @@ import { PageSizeSelect } from '../page-size-select.js'
 import { Pagination } from '../pagination.js'
 
 describe('<Pagination />', () => {
-    const props = {
-        ...mockPagers.atTenthPage,
-        onPageChange: () => {},
-        onPageSizeChange: () => {},
-    }
-    it('renders without errors', () => {
-        shallow(<Pagination {...props} />)
+    describe('Pagination with total and totalPages', () => {
+        const props = {
+            ...mockPagers.atTenthPage,
+            onPageChange: () => {},
+            onPageSizeChange: () => {},
+        }
+        it('renders without errors', () => {
+            shallow(<Pagination {...props} />)
+        })
+
+        it('renders a PageSelect and PageSizeSelect by default', () => {
+            const wrapper = shallow(<Pagination {...props} />)
+
+            expect(wrapper.find(PageSelect).length).toEqual(1)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(1)
+        })
+        it('renders without a PageSelect when hidePageSelect is true', () => {
+            const wrapper = shallow(<Pagination {...props} hidePageSelect />)
+
+            expect(wrapper.find(PageSelect).length).toEqual(0)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(1)
+        })
+        it('renders without a PageSizeSelect when hidePageSizeSelect is true', () => {
+            const wrapper = shallow(
+                <Pagination {...props} hidePageSizeSelect />
+            )
+
+            expect(wrapper.find(PageSelect).length).toEqual(1)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(0)
+        })
+        it('renders without PageSelect and PageSizeSelect when both are true', () => {
+            const wrapper = shallow(
+                <Pagination {...props} hidePageSelect hidePageSizeSelect />
+            )
+
+            expect(wrapper.find(PageSelect).length).toEqual(0)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(0)
+        })
     })
+    describe('Pagination without total and totalPages', () => {
+        const props = {
+            ...mockPagers.noTotal,
+            onPageChange: () => {},
+            onPageSizeChange: () => {},
+        }
+        it('renders without errors', () => {
+            shallow(<Pagination {...props} />)
+        })
 
-    it('renders a PageSelect and PageSizeSelect by default', () => {
-        const wrapper = shallow(<Pagination {...props} />)
+        it('renders with a PageSizeSelect but without a PageSelect', () => {
+            const wrapper = shallow(<Pagination {...props} />)
 
-        expect(wrapper.find(PageSelect).length).toEqual(1)
-        expect(wrapper.find(PageSizeSelect).length).toEqual(1)
-    })
-    it('renders without a PageSelect when hidePageSelect is true', () => {
-        const wrapper = shallow(<Pagination {...props} hidePageSelect />)
-
-        expect(wrapper.find(PageSelect).length).toEqual(0)
-        expect(wrapper.find(PageSizeSelect).length).toEqual(1)
-    })
-    it('renders without a PageSizeSelect when hidePageSizeSelect is true', () => {
-        const wrapper = shallow(<Pagination {...props} hidePageSizeSelect />)
-
-        expect(wrapper.find(PageSelect).length).toEqual(1)
-        expect(wrapper.find(PageSizeSelect).length).toEqual(0)
-    })
-    it('renders without PageSelect and PageSizeSelect when both are true', () => {
-        const wrapper = shallow(
-            <Pagination {...props} hidePageSelect hidePageSizeSelect />
-        )
-
-        expect(wrapper.find(PageSelect).length).toEqual(0)
-        expect(wrapper.find(PageSizeSelect).length).toEqual(0)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(1)
+            expect(wrapper.find(PageSelect).length).toEqual(0)
+        })
     })
 })

--- a/components/pagination/src/get-default-page-summary-text.js
+++ b/components/pagination/src/get-default-page-summary-text.js
@@ -1,0 +1,34 @@
+import i18n from './locales/index.js'
+
+const isValidNumber = (input) => typeof input === 'number' && !isNaN(input)
+
+export const getDefaultPageSummaryText = ({
+    firstItem,
+    lastItem,
+    page,
+    pageCount,
+    total,
+}) => {
+    if (isValidNumber(total) && isValidNumber(lastItem)) {
+        return i18n.t(
+            'Page {{page}} of {{pageCount}}, items {{firstItem}}-{{lastItem}} of {{total}}',
+            {
+                page,
+                pageCount,
+                firstItem,
+                lastItem,
+                total,
+            }
+        )
+    }
+
+    if (isValidNumber(lastItem)) {
+        return i18n.t('Page {{page}}, items {{firstItem}}-{{lastItem}}', {
+            page,
+            firstItem,
+            lastItem,
+        })
+    }
+
+    return i18n.t('Page {{page}}', { page })
+}

--- a/components/pagination/src/get-item-range.js
+++ b/components/pagination/src/get-item-range.js
@@ -1,0 +1,35 @@
+export const getItemRange = ({
+    isLastPage,
+    page,
+    pageLength,
+    pageSize,
+    total,
+}) => {
+    // page is 1-based
+    let firstItem = (page - 1) * pageSize + 1
+    let lastItem = firstItem + pageSize - 1
+
+    if (typeof total === 'number') {
+        if (total === 0) {
+            /*
+             * if no items are found, the pager total is 0
+             * and the first and last item should be be 0 too
+             */
+            firstItem = 0
+            lastItem = 0
+        } else if (lastItem > total) {
+            lastItem = total
+        }
+    }
+
+    if (typeof pageLength === 'number') {
+        lastItem = firstItem + pageLength - 1
+    }
+
+    if (isLastPage && isNaN(total) && isNaN(pageLength)) {
+        // impossible to accurately determine the last item
+        lastItem = NaN
+    }
+
+    return { firstItem, lastItem }
+}

--- a/components/pagination/src/page-controls.js
+++ b/components/pagination/src/page-controls.js
@@ -37,7 +37,7 @@ const PageControls = ({
             secondary
             className="button-next"
             small
-            disabled={isLastPage}
+            disabled={!!isLastPage}
             onClick={() => onClick(page + 1)}
             dataTest={`${dataTest}-page-next`}
         >

--- a/components/pagination/src/page-controls.js
+++ b/components/pagination/src/page-controls.js
@@ -19,7 +19,6 @@ const PageControls = ({
     onClick,
     nextPageText,
     page,
-    pageCount,
     previousPageText,
 }) => (
     <div data-test={`${dataTest}-pagecontrols`}>
@@ -38,7 +37,7 @@ const PageControls = ({
             secondary
             className="button-next"
             small
-            disabled={isLastPage || page === pageCount}
+            disabled={isLastPage}
             onClick={() => onClick(page + 1)}
             dataTest={`${dataTest}-page-next`}
         >
@@ -71,7 +70,6 @@ PageControls.propTypes = {
         .isRequired,
     onClick: PropTypes.func.isRequired,
     isLastPage: PropTypes.bool,
-    pageCount: PropTypes.number,
 }
 
 export { PageControls }

--- a/components/pagination/src/page-controls.js
+++ b/components/pagination/src/page-controls.js
@@ -15,6 +15,7 @@ const translate = (prop, interpolationObject) => {
 
 const PageControls = ({
     dataTest,
+    isLastPage,
     onClick,
     nextPageText,
     page,
@@ -37,7 +38,7 @@ const PageControls = ({
             secondary
             className="button-next"
             small
-            disabled={page === pageCount}
+            disabled={isLastPage || page === pageCount}
             onClick={() => onClick(page + 1)}
             dataTest={`${dataTest}-page-next`}
         >
@@ -66,10 +67,11 @@ PageControls.propTypes = {
     nextPageText: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
         .isRequired,
     page: PropTypes.number.isRequired,
-    pageCount: PropTypes.number.isRequired,
     previousPageText: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
         .isRequired,
     onClick: PropTypes.func.isRequired,
+    isLastPage: PropTypes.bool,
+    pageCount: PropTypes.number,
 }
 
 export { PageControls }

--- a/components/pagination/src/page-summary.js
+++ b/components/pagination/src/page-summary.js
@@ -2,7 +2,6 @@ import { colors, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-// TODO: i18n translate
 const translate = (prop, interpolationObject) => {
     if (typeof prop === 'function') {
         return prop(interpolationObject)
@@ -11,51 +10,20 @@ const translate = (prop, interpolationObject) => {
     return prop
 }
 
-const getItemRange = ({ page, pageSize, pageLength, total }) => {
-    // page is 1-based
-    let firstItem = (page - 1) * pageSize + 1
-    let lastItem = firstItem + pageSize - 1
-
-    if (typeof total === 'number') {
-        if (total === 0) {
-            /*
-             * if no items are found, the pager total is 0
-             * and the first and last item should be be 0 too
-             */
-            firstItem = 0
-            lastItem = 0
-        } else if (lastItem > total) {
-            lastItem = total
-        }
-    }
-
-    if (typeof pageLength === 'number') {
-        lastItem = firstItem + pageLength - 1
-    }
-
-    return { firstItem, lastItem }
-}
-
 const PageSummary = ({
     dataTest,
+    firstItem,
+    lastItem,
     page,
     pageCount,
-    pageLength,
-    pageSize,
     pageSummaryText,
     total,
 }) => {
-    const { firstItem, lastItem } = getItemRange({
-        page,
-        pageSize,
-        pageLength,
-        total,
-    })
     const summary = translate(pageSummaryText, {
-        page,
-        pageCount,
         firstItem,
         lastItem,
+        page,
+        pageCount,
         total,
     })
 
@@ -82,12 +50,12 @@ const PageSummary = ({
 PageSummary.propTypes = {
     dataTest: PropTypes.string.isRequired,
     page: PropTypes.number.isRequired,
-    pageSize: PropTypes.number.isRequired,
     pageSummaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
         .isRequired,
+    firstItem: PropTypes.number,
+    lastItem: PropTypes.number,
     pageCount: PropTypes.number,
-    pageLength: PropTypes.number,
     total: PropTypes.number,
 }
 
-export { PageSummary, getItemRange }
+export { PageSummary }

--- a/components/pagination/src/page-summary.js
+++ b/components/pagination/src/page-summary.js
@@ -11,22 +11,26 @@ const translate = (prop, interpolationObject) => {
     return prop
 }
 
-const getItemRange = (page, pageSize, total) => {
-    let firstItem, lastItem
+const getItemRange = ({ page, pageSize, pageLength, total }) => {
+    // page is 1-based
+    let firstItem = (page - 1) * pageSize + 1
+    let lastItem = firstItem + pageSize - 1
 
-    if (total === 0) {
-        // if no items are found, the pager total is 0
-        // and we want to force the first and last item to be 0 too
-        firstItem = 0
-        lastItem = 0
-    } else {
-        // page is 1-based
-        firstItem = (page - 1) * pageSize + 1
-        lastItem = firstItem + pageSize - 1
+    if (typeof total === 'number') {
+        if (total === 0) {
+            /*
+             * if no items are found, the pager total is 0
+             * and the first and last item should be be 0 too
+             */
+            firstItem = 0
+            lastItem = 0
+        } else if (lastItem > total) {
+            lastItem = total
+        }
     }
 
-    if (lastItem > total) {
-        lastItem = total
+    if (typeof pageLength === 'number') {
+        lastItem = firstItem + pageLength - 1
     }
 
     return { firstItem, lastItem }
@@ -36,11 +40,17 @@ const PageSummary = ({
     dataTest,
     page,
     pageCount,
+    pageLength,
     pageSize,
     pageSummaryText,
     total,
 }) => {
-    const { firstItem, lastItem } = getItemRange(page, pageSize, total)
+    const { firstItem, lastItem } = getItemRange({
+        page,
+        pageSize,
+        pageLength,
+        total,
+    })
     const summary = translate(pageSummaryText, {
         page,
         pageCount,
@@ -72,11 +82,12 @@ const PageSummary = ({
 PageSummary.propTypes = {
     dataTest: PropTypes.string.isRequired,
     page: PropTypes.number.isRequired,
-    pageCount: PropTypes.number.isRequired,
     pageSize: PropTypes.number.isRequired,
     pageSummaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.func])
         .isRequired,
-    total: PropTypes.number.isRequired,
+    pageCount: PropTypes.number,
+    pageLength: PropTypes.number,
+    total: PropTypes.number,
 }
 
 export { PageSummary, getItemRange }

--- a/components/pagination/src/pagination.js
+++ b/components/pagination/src/pagination.js
@@ -1,3 +1,4 @@
+import { requiredIf } from '@dhis2/prop-types'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -10,21 +11,23 @@ import { PageSummary } from './page-summary.js'
 const Pagination = ({
     className,
     dataTest,
-    hidePageSizeSelect,
     hidePageSelect,
+    hidePageSizeSelect,
     hidePageSummary,
-    page,
-    pageCount,
-    pageSize,
-    total,
-    pageSizes,
+    isLastPage,
+    nextPageText,
     onPageChange,
     onPageSizeChange,
-    nextPageText,
+    page,
+    pageCount,
+    pageLength,
     pageSelectText,
+    pageSize,
+    pageSizes,
     pageSizeSelectText,
     pageSummaryText,
     previousPageText,
+    total,
 }) => {
     return (
         <div className={cx('container', className)} data-test={dataTest}>
@@ -44,13 +47,14 @@ const Pagination = ({
                     dataTest={dataTest}
                     page={page}
                     pageCount={pageCount}
+                    pageLength={pageLength}
                     pageSize={pageSize}
                     total={total}
                     pageSummaryText={pageSummaryText}
                 />
             )}
             <div className="page-navigation">
-                {!hidePageSelect && (
+                {!hidePageSelect && total && (
                     <PageSelect
                         dataTest={dataTest}
                         pageSelectText={pageSelectText}
@@ -61,6 +65,7 @@ const Pagination = ({
                 )}
                 <PageControls
                     dataTest={dataTest}
+                    isLastPage={isLastPage}
                     nextPageText={nextPageText}
                     page={page}
                     pageCount={pageCount}
@@ -94,29 +99,36 @@ Pagination.defaultProps = {
     pageSelectText: () => i18n.t('Page'),
     pageSizeSelectText: () => i18n.t('Items per page'),
     pageSummaryText: (interpolationObject) =>
-        i18n.t(
-            'Page {{page}} of {{pageCount}}, items {{firstItem}}-{{lastItem}} of {{total}}',
-            interpolationObject
-        ),
+        interpolationObject.total
+            ? i18n.t(
+                  'Page {{page}} of {{pageCount}}, items {{firstItem}}-{{lastItem}} of {{total}}',
+                  interpolationObject
+              )
+            : i18n.t(
+                  'Page {{page}}, items {{firstItem}}-{{lastItem}}',
+                  interpolationObject
+              ),
     previousPageText: () => i18n.t('Previous'),
 }
 
 Pagination.propTypes = {
     page: PropTypes.number.isRequired,
-    pageCount: PropTypes.number.isRequired,
     pageSize: PropTypes.number.isRequired,
-    total: PropTypes.number.isRequired,
     className: PropTypes.string,
     dataTest: PropTypes.string,
     hidePageSelect: PropTypes.bool,
     hidePageSizeSelect: PropTypes.bool,
     hidePageSummary: PropTypes.bool,
+    isLastPage: PropTypes.bool,
     nextPageText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    pageCount: PropTypes.number,
+    pageLength: requiredIf((props) => props.isLastPage, PropTypes.number),
     pageSelectText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     pageSizeSelectText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     pageSizes: PropTypes.arrayOf(PropTypes.string),
     pageSummaryText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     previousPageText: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    total: PropTypes.number,
     onPageChange: PropTypes.func,
     onPageSizeChange: PropTypes.func,
 }

--- a/components/pagination/src/pagination.js
+++ b/components/pagination/src/pagination.js
@@ -65,10 +65,9 @@ const Pagination = ({
                 )}
                 <PageControls
                     dataTest={dataTest}
-                    isLastPage={isLastPage}
+                    isLastPage={isLastPage || page === pageCount}
                     nextPageText={nextPageText}
                     page={page}
-                    pageCount={pageCount}
                     previousPageText={previousPageText}
                     onClick={onPageChange}
                 />

--- a/components/pagination/src/pagination.js
+++ b/components/pagination/src/pagination.js
@@ -2,6 +2,8 @@ import { requiredIf } from '@dhis2/prop-types'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { getDefaultPageSummaryText } from './get-default-page-summary-text.js'
+import { getItemRange } from './get-item-range.js'
 import i18n from './locales/index.js'
 import { PageControls } from './page-controls.js'
 import { PageSelect } from './page-select.js'
@@ -29,6 +31,14 @@ const Pagination = ({
     previousPageText,
     total,
 }) => {
+    const { firstItem, lastItem } = getItemRange({
+        isLastPage,
+        page,
+        pageLength,
+        pageSize,
+        total,
+    })
+
     return (
         <div className={cx('container', className)} data-test={dataTest}>
             {hidePageSizeSelect ? (
@@ -45,12 +55,12 @@ const Pagination = ({
             {!hidePageSummary && (
                 <PageSummary
                     dataTest={dataTest}
+                    firstItem={firstItem}
+                    lastItem={lastItem}
                     page={page}
                     pageCount={pageCount}
-                    pageLength={pageLength}
-                    pageSize={pageSize}
-                    total={total}
                     pageSummaryText={pageSummaryText}
+                    total={total}
                 />
             )}
             <div className="page-navigation">
@@ -97,16 +107,7 @@ Pagination.defaultProps = {
     nextPageText: () => i18n.t('Next'),
     pageSelectText: () => i18n.t('Page'),
     pageSizeSelectText: () => i18n.t('Items per page'),
-    pageSummaryText: (interpolationObject) =>
-        interpolationObject.total
-            ? i18n.t(
-                  'Page {{page}} of {{pageCount}}, items {{firstItem}}-{{lastItem}} of {{total}}',
-                  interpolationObject
-              )
-            : i18n.t(
-                  'Page {{page}}, items {{firstItem}}-{{lastItem}}',
-                  interpolationObject
-              ),
+    pageSummaryText: getDefaultPageSummaryText,
     previousPageText: () => i18n.t('Previous'),
 }
 

--- a/components/pagination/src/pagination.stories.js
+++ b/components/pagination/src/pagination.stories.js
@@ -34,11 +34,9 @@ export default {
     },
     // Default args for stories
     args: {
-        // Fixes 'defaultProps' errors for storybook
-        ...Pagination.defaultProps,
+        ...pagers.atTenthPage,
         onPageChange: logOnPageChange,
         onPageSizeChange: logOnPageSizeChange,
-        ...pagers.atTenthPage,
     },
 }
 
@@ -51,6 +49,12 @@ PagerAtFirstPage.args = { ...pagers.atFirstPage }
 
 export const PagerAtLastPage = Template.bind({})
 PagerAtLastPage.args = { ...pagers.atLastPage }
+
+export const NoTotal = Template.bind({})
+NoTotal.args = { ...pagers.noTotal }
+
+export const NoTotalAtLastPage = Template.bind({})
+NoTotalAtLastPage.args = { ...pagers.noTotalAtLastPage, pageLength: 26 }
 
 export const WithoutPageSizeSelect = Template.bind({})
 WithoutPageSizeSelect.args = { hidePageSizeSelect: true }

--- a/components/pagination/src/pagination.stories.js
+++ b/components/pagination/src/pagination.stories.js
@@ -34,7 +34,6 @@ export default {
     },
     // Default args for stories
     args: {
-        ...pagers.atTenthPage,
         onPageChange: logOnPageChange,
         onPageSizeChange: logOnPageSizeChange,
     },
@@ -43,6 +42,7 @@ export default {
 const Template = (args) => <Pagination {...args} />
 
 export const Default = Template.bind({})
+Default.args = { ...pagers.atTenthPage }
 
 export const PagerAtFirstPage = Template.bind({})
 PagerAtFirstPage.args = { ...pagers.atFirstPage }
@@ -57,25 +57,27 @@ export const NoTotalAtLastPage = Template.bind({})
 NoTotalAtLastPage.args = { ...pagers.noTotalAtLastPage, pageLength: 26 }
 
 export const WithoutPageSizeSelect = Template.bind({})
-WithoutPageSizeSelect.args = { hidePageSizeSelect: true }
+WithoutPageSizeSelect.args = { ...pagers.atTenthPage, hidePageSizeSelect: true }
 
 export const WithoutGoToPageSelect = Template.bind({})
-WithoutGoToPageSelect.args = { hidePageSelect: true }
+WithoutGoToPageSelect.args = { ...pagers.atTenthPage, hidePageSelect: true }
 
 export const WithoutPageSummary = Template.bind({})
-WithoutPageSummary.args = { hidePageSummary: true }
+WithoutPageSummary.args = { ...pagers.atTenthPage, hidePageSummary: true }
 
 export const WithCustomPageSummary = Template.bind({})
 WithCustomPageSummary.args = {
+    ...pagers.atTenthPage,
     pageSummaryText: (interpolationObject) =>
         i18n.t(
-            'Page nr {{page}} of {{pageCount}} pages, items {{firstItem}}-{{lastItem}}, NO TOTAL',
+            'You are at page {{page}} showing items {{firstItem}}-{{lastItem}}, but there are {{pageCount}} pages and {{total}} items',
             interpolationObject
         ),
 }
 
 export const WithoutAnySelect = Template.bind({})
 WithoutAnySelect.args = {
+    ...pagers.atTenthPage,
     ...WithoutGoToPageSelect.args,
     ...WithoutPageSizeSelect.args,
 }

--- a/components/pagination/src/pagination.stories.js
+++ b/components/pagination/src/pagination.stories.js
@@ -56,6 +56,9 @@ NoTotal.args = { ...pagers.noTotal }
 export const NoTotalAtLastPage = Template.bind({})
 NoTotalAtLastPage.args = { ...pagers.noTotalAtLastPage, pageLength: 26 }
 
+export const NoTotalAtLastPageWithoutPageLength = Template.bind({})
+NoTotalAtLastPageWithoutPageLength.args = { ...pagers.noTotalAtLastPage }
+
 export const WithoutPageSizeSelect = Template.bind({})
 WithoutPageSizeSelect.args = { ...pagers.atTenthPage, hidePageSizeSelect: true }
 


### PR DESCRIPTION
This PR adds support to `Pagination` component for pager objects without `total` and `totalPages`. This is relevant because computing the total is expensive and some endpoints have already added support for omitting the totals.

There is some complexity regarding the information we are able still show in the page summary for these pagers without total. 

For example a pager object without a total could look like this:
```
{
    page: 2,
    pageSize: 50,
    isLastPage: false,
}
```
Here we could say `Page 2, items 51-100` and we would know this to be correct, because we know there is a next page, so the current page must have 50 items.

But suppose `isLastPage` would be `false`, i.e.:
```
{
    page: 2,
    pageSize: 50,
    isLastPage: true,
}
```
Now saying `Page 2, items 51-100` is not really correct/accurate. It’s _possible_ that this last page contains exactly 50 items, but not at all likely.

I considered two options to deal with this problem:
1. We could only mention the page number in the page summary, i.e. `Page 2`. This would be the simplest solution but you lose quite a bit of useful info reg. the items numbers, and this info is actually correct for all pages apart from the last one. Because of this I decided not to implement this solution.
2. What I did instead was to add another new (optional) prop to the `Pagination` component, called `pageLength`. When this is provided it will be used to compute the last item and this will be correct. To ensure developers understand they need to populate this prop for pagers without a total, I've made this prop conditionally required when `isLastPage` is `true`. If the prop is not provided, the component will not crash, but simply use the `pageSize` and `page` properties to compute the last item (which could be an incorrect value 🤷‍♂️)