### PR TITLE
fix(SharingDialog): clear search field once access is granted, fix style

### DIFF
--- a/components/sharing-dialog/src/access-add/access-add.js
+++ b/components/sharing-dialog/src/access-add/access-add.js
@@ -1,7 +1,7 @@
 import { Button } from '@dhis2-ui/button'
 import { SingleSelectField, SingleSelectOption } from '@dhis2-ui/select'
 import { useOnlineStatus } from '@dhis2/app-runtime'
-import { colors } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useState, useContext } from 'react'
 import { SharingAutocomplete } from '../autocomplete/index.js'
@@ -86,6 +86,7 @@ export const AccessAdd = ({ onAdd }) => {
                     border-radius: 5px;
                     display: flex;
                     align-items: flex-end;
+                    gap: ${spacers.dp8};
                 }
 
                 .select-wrapper {

--- a/components/sharing-dialog/src/autocomplete/sharing-autocomplete.js
+++ b/components/sharing-dialog/src/autocomplete/sharing-autocomplete.js
@@ -27,11 +27,7 @@ export const SharingAutocomplete = ({ selected, onSelection }) => {
      * this syncs the displayName of the parent selection to the local input state.
      */
 
-    useEffect(() => {
-        if (selected) {
-            setSearch(selected)
-        }
-    }, [selected])
+    useEffect(() => setSearch(selected), [selected])
 
     /**
      * If the search string changes and is truthy, send out a request, otherwise

--- a/components/sharing-dialog/src/features/add-entity.feature
+++ b/components/sharing-dialog/src/features/add-entity.feature
@@ -4,10 +4,11 @@ Feature: Allows users to add entities to the allowed list
         Given a sharing dialog that allows adding <target> entities is visible
         When the user gives <target> <level> access
         Then the <target> should be added to the access list with <level> access
+        And the autocomplete input should be cleared
 
-    Scenarios:
-        | target | level         |
-        | user   | view only     |
-        | user   | view and edit |
-        | group  | view only     |
-        | group  | view and edit |
+            Scenarios:
+            | target | level         |
+            | user   | view only     |
+            | user   | view and edit |
+            | group  | view only     |
+            | group  | view and edit |

--- a/components/sharing-dialog/src/features/add-entity/index.js
+++ b/components/sharing-dialog/src/features/add-entity/index.js
@@ -186,3 +186,7 @@ Then(
         cy.get('@group-item').contains('View and edit').should('be.visible')
     }
 )
+
+Then('the autocomplete input should be cleared', () => {
+    cy.get('form input').invoke('val').should('be.empty')
+})


### PR DESCRIPTION
#### Once an access is granted to a user/group, the search input should be cleared.
Before:
https://user-images.githubusercontent.com/150978/157421634-2a3b09cb-1cb4-455c-80a4-13001bac6054.mov

After:
https://user-images.githubusercontent.com/150978/157423660-adfe43fd-46ff-4dd4-a786-3092f3827d57.mov


#### Style fix, space elements in the form.
Before:
<img width="782" alt="Screenshot 2022-03-09 at 11 18 02" src="https://user-images.githubusercontent.com/150978/157421726-32491a32-e54d-43fa-b634-2c228d7f1e5f.png">

After:
<img width="783" alt="Screenshot 2022-03-09 at 11 25 17" src="https://user-images.githubusercontent.com/150978/157423018-8505d97a-e5a2-4498-abd3-a2be605981cc.png">

