### PR TITLE
fix(pagination): hide page select when only 1 page or too many pages

### DIFF
--- a/components/modal/src/modal/modal.test.js
+++ b/components/modal/src/modal/modal.test.js
@@ -17,7 +17,6 @@ describe('Modal', () => {
         it('has the correct dimension styles when the "small" prop is provided', () => {
             render(<Modal small />)
             const modalEl = screen.getByRole('dialog')
-            console.log('modalEl.outerWidth', modalEl.offsetWidth)
             const style = window.getComputedStyle(modalEl)
 
             expect(style.height).toBe('auto')

--- a/components/pagination/src/__tests__/pagination.test.js
+++ b/components/pagination/src/__tests__/pagination.test.js
@@ -28,6 +28,26 @@ describe('<Pagination />', () => {
             expect(wrapper.find(PageSelect).length).toEqual(0)
             expect(wrapper.find(PageSizeSelect).length).toEqual(1)
         })
+        it('renders without a PageSelect when pageCount is not provided', () => {
+            const wrapper = shallow(
+                <Pagination {...props} pageCount={undefined} />
+            )
+
+            expect(wrapper.find(PageSelect).length).toEqual(0)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(1)
+        })
+        it('renders without a PageSelect when pageCount is 1', () => {
+            const wrapper = shallow(<Pagination {...props} pageCount={1} />)
+
+            expect(wrapper.find(PageSelect).length).toEqual(0)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(1)
+        })
+        it('renders without a PageSelect when pageCount is over 2000', () => {
+            const wrapper = shallow(<Pagination {...props} pageCount={2001} />)
+
+            expect(wrapper.find(PageSelect).length).toEqual(0)
+            expect(wrapper.find(PageSizeSelect).length).toEqual(1)
+        })
         it('renders without a PageSizeSelect when hidePageSizeSelect is true', () => {
             const wrapper = shallow(
                 <Pagination {...props} hidePageSizeSelect />

--- a/components/pagination/src/pagination.js
+++ b/components/pagination/src/pagination.js
@@ -38,6 +38,11 @@ const Pagination = ({
         pageSize,
         total,
     })
+    const showPageSelect =
+        !hidePageSelect &&
+        typeof pageCount === 'number' &&
+        pageCount > 1 &&
+        pageCount <= 2000
 
     return (
         <div className={cx('container', className)} data-test={dataTest}>
@@ -64,7 +69,7 @@ const Pagination = ({
                 />
             )}
             <div className="page-navigation">
-                {!hidePageSelect && total && (
+                {showPageSelect && (
                     <PageSelect
                         dataTest={dataTest}
                         pageSelectText={pageSelectText}

--- a/components/pagination/src/pagination.js
+++ b/components/pagination/src/pagination.js
@@ -10,6 +10,8 @@ import { PageSelect } from './page-select.js'
 import { PageSizeSelect } from './page-size-select.js'
 import { PageSummary } from './page-summary.js'
 
+const MAX_PAGE_COUNT = 2000
+
 const Pagination = ({
     className,
     dataTest,
@@ -42,7 +44,7 @@ const Pagination = ({
         !hidePageSelect &&
         typeof pageCount === 'number' &&
         pageCount > 1 &&
-        pageCount <= 2000
+        pageCount <= MAX_PAGE_COUNT
 
     return (
         <div className={cx('container', className)} data-test={dataTest}>


### PR DESCRIPTION
The main reason for doing this PR is because I remember seeing the page-select completely freezing the browser when there was a huge volume of data. Suppose there are 1,500,000 records and the page size is 50, then the page select would be dynamically populated with 30,000 options and the browser would freeze.  Navigating from page to page is not going to help users find the record they were looking for when there are this many records either. By introducing this max page count limit for showing the page-select, we prevent the browser from freezing...

I see this more of a safety catch type of fix because really if we are dealing with this many records a pager with totals is probably going to cause performance issues on the server as well, so it shouldn't really happen.

Additionally, I realised it's a bit silly to show a page select when there is only one page to select.

And I thought it made more sense to use the `pageCount` prop instead of the `total` prop to compute the visibility because that prop is actually used by the page-select.

(and then there is also a completely unrelated change in this PR: I realised there was a console log in one of the tests)