### PR TITLE
fix(sharing-dialog): support eventVisualization and interpretation types TECH-1037

### DIFF
--- a/components/sharing-dialog/src/constants.js
+++ b/components/sharing-dialog/src/constants.js
@@ -21,3 +21,5 @@ export const SHARE_TARGET_GROUP = 'SHARE_TARGET_GROUP'
 
 export const VISUALIZATION = 'visualization'
 export const DASHBOARD = 'dashboard'
+export const EVENT_VISUALIZATION = 'eventVisualization'
+export const INTERPRETATION = 'interpretation'

--- a/components/sharing-dialog/src/sharing-dialog.js
+++ b/components/sharing-dialog/src/sharing-dialog.js
@@ -7,6 +7,8 @@ import {
     ACCESS_VIEW_AND_EDIT,
     VISUALIZATION,
     DASHBOARD,
+    EVENT_VISUALIZATION,
+    INTERPRETATION,
 } from './constants.js'
 import { FetchingContext } from './fetching-context/index.js'
 import {
@@ -191,7 +193,12 @@ SharingDialog.propTypes = {
     /** The id of the object to share */
     id: PropTypes.string.isRequired,
     /** The type of object to share */
-    type: PropTypes.oneOf([VISUALIZATION, DASHBOARD]).isRequired,
+    type: PropTypes.oneOf([
+        VISUALIZATION,
+        DASHBOARD,
+        EVENT_VISUALIZATION,
+        INTERPRETATION,
+    ]).isRequired,
     /** Used to seed the component with data to show whilst loading */
     initialSharingSettings: PropTypes.shape({
         allowPublic: PropTypes.bool.isRequired,

--- a/components/sharing-dialog/src/tabs/tabbed-content.js
+++ b/components/sharing-dialog/src/tabs/tabbed-content.js
@@ -10,6 +10,8 @@ import {
     ACCESS_VIEW_AND_EDIT,
     VISUALIZATION,
     DASHBOARD,
+    EVENT_VISUALIZATION,
+    INTERPRETATION,
 } from '../constants.js'
 import i18n from '../locales/index.js'
 
@@ -102,7 +104,12 @@ TabbedContent.propTypes = {
         ACCESS_VIEW_ONLY,
         ACCESS_VIEW_AND_EDIT,
     ]).isRequired,
-    type: PropTypes.oneOf([VISUALIZATION, DASHBOARD]).isRequired,
+    type: PropTypes.oneOf([
+        VISUALIZATION,
+        DASHBOARD,
+        EVENT_VISUALIZATION,
+        INTERPRETATION,
+    ]).isRequired,
     users: PropTypes.arrayOf(
         PropTypes.shape({
             access: PropTypes.oneOf([


### PR DESCRIPTION
Solves [TECH-1037](https://dhis2.atlassian.net/browse/TECH-1037).

`eventVisualization` and `interpretation` are now passed as types to the `SharingDialog` component.
This PR resolves the warnings about invalid prop type.

Before:
![Screenshot 2022-03-14 at 11 33 35](https://user-images.githubusercontent.com/150978/158561793-a2a8b1e1-da0a-44d5-aca6-3559b7eb0647.png)

