### PR TITLE
fix(transfer): do not pass name to input so we don't get duplicate ids on the page

### DIFF
--- a/components/transfer/src/filter.js
+++ b/components/transfer/src/filter.js
@@ -11,7 +11,6 @@ export const Filter = ({ dataTest, filter, onChange, label, placeholder }) => (
                 dataTest={`${dataTest}-input`}
                 type="search"
                 placeholder={placeholder}
-                name={dataTest}
                 value={filter}
                 onChange={onChange}
             />


### PR DESCRIPTION
Currently if we have several `Transfer` components on a page we get a warning:
```Found 3 elements with non-unique id #dhis2-uicore-transfer-filter:```

This is because:
a) In `components/transfer/src/filter.js` we pass `name={dataTest}` to our `Input` component
b) Our `Input` component uses the `name` to set as `id`

I think just removing the name prop from the `Input` rendered by the (Transfer) `Filter` makes most sense here, because not populating the input id with the name is going to break the semantic link between the input and the label.
