### PR TITLE
fix(modal): restore auto scroll styles

### DIFF
--- a/components/modal/src/modal/modal.js
+++ b/components/modal/src/modal/modal.js
@@ -72,8 +72,8 @@ export const Modal = ({
                     padding: 24px;
                     display: flex;
                     flex-flow: column;
-                    max-width: 100%;
-                    max-height: 100%;
+                    max-width: calc(100vw - ${2 * spacersNum.dp64}px);
+                    max-height: calc(100vh - ${2 * spacersNum.dp64}px);
                 }
             `}</style>
         </Layer>


### PR DESCRIPTION
I caused a regression in https://github.com/dhis2/ui/pull/1013. This PR restores the old styles.

The problem I was trying to solve in the app will start popping up again, but at least the basic auto-overflow functionality will be restored. You can see the regression I caused [here](https://ui.dhis2.nu/demo/?path=/story/layout-modal--middle-scrollable).