### PR TITLE
fix: improve selected option icon spacing for select components

### DIFF
--- a/components/select/src/single-select/selection.js
+++ b/components/select/src/single-select/selection.js
@@ -35,6 +35,7 @@ const Selection = ({ options, selected, className }) => {
                     width: ${spacers.dp16};
                     height: ${spacers.dp16};
                     overflow: hidden;
+                    flex-shrink: 0;
                 }
             `}</style>
         </div>


### PR DESCRIPTION
- https://github.com/dhis2/notes/discussions/333
- https://dhis2.atlassian.net/browse/LIBS-312
- https://codesandbox.io/s/suspicious-mountain-x4izzr?file=/src/App.js
- https://dhis2.slack.com/archives/CBM8LNEQM/p1650887322458659

### The issue

As you can see in the screenshot below, the icons are cut off because of the default browser styles of `flex-shrink: 1`:

![Screenshot from 2022-04-26 09-42-40](https://user-images.githubusercontent.com/7355199/165248500-e549154b-0af7-430a-84f0-6a20826554f4.png)

After the proposed fix (setting `flex-shrink: 0`), the icon area no longer shrinks and remains at 16 x 16:

![Screenshot from 2022-04-26 09-43-29](https://user-images.githubusercontent.com/7355199/165248507-e51fe1cd-1f18-405e-aa74-95409db858e1.png)

Because the icon area is 16 x 16, icons larger than that will be cut off. That was already the case before this PR. We could look into accomodating other icon sizes as well in a separate PR. First I think we should address https://dhis2.atlassian.net/browse/LIBS-312 though, and clearly document this bit of API.