### PR TITLE
fix: increase prefix spacing so icon is closer to the option text

### DIFF
--- a/components/select/src/select/input-prefix.js
+++ b/components/select/src/select/input-prefix.js
@@ -14,7 +14,7 @@ const InputPrefix = ({ prefix, className, dataTest }) => {
             <style jsx>{`
                 div {
                     color: ${colors.grey600};
-                    padding-right: ${spacers.dp4};
+                    padding-right: ${spacers.dp12};
                     font-size: 14px;
                     user-select: none;
                 }


### PR DESCRIPTION
Before this fix:

![before](https://user-images.githubusercontent.com/7355199/165294893-02136971-20e8-4c94-a564-2aa560257462.png)

After the fix:

![after](https://user-images.githubusercontent.com/7355199/165294906-c2739952-8d4d-40dc-b729-22ccacd925b8.png)
