### PR TITLE
fix: prevent SharingDialog from displaying id as modal name (LIBS-322)

### DIFF
--- a/components/sharing-dialog/src/sharing-dialog.js
+++ b/components/sharing-dialog/src/sharing-dialog.js
@@ -159,7 +159,13 @@ export const SharingDialog = ({
 
     return (
         <FetchingContext.Provider value={mutating || fetching}>
-            <Modal onClose={onClose} name={object.displayName || object.name}>
+            <Modal
+                onClose={onClose}
+                name={
+                    (object.displayName !== object.id && object.displayName) ||
+                    (object.name !== object.id && object.name)
+                }
+            >
                 <TabbedContent
                     id={id}
                     users={users}

--- a/components/sharing-dialog/src/sharing-dialog.stories.js
+++ b/components/sharing-dialog/src/sharing-dialog.stories.js
@@ -108,6 +108,18 @@ const customData = {
     },
 }
 
+const customDataIdAsName = {
+    ...customDefaultData,
+    sharing: {
+        ...customDefaultData.sharing,
+        object: {
+            ...customDefaultData.sharing.object,
+            name: customDefaultData.sharing.object.id,
+            displayName: customDefaultData.sharing.object.id,
+        },
+    },
+}
+
 const customDataDisabledAccess = {
     ...customData,
     sharing: {
@@ -185,6 +197,13 @@ export const WithName = (args) => (
     </CustomDataProvider>
 )
 WithName.storyName = 'With name'
+
+export const WithIdAsName = (args) => (
+    <CustomDataProvider data={customDataIdAsName}>
+        <SharingDialog {...args} />
+    </CustomDataProvider>
+)
+WithIdAsName.storyName = 'With id as name'
 
 export const WithDisabledAccess = (args) => (
     <CustomDataProvider data={customDataDisabledAccess}>


### PR DESCRIPTION
Fixes [LIBS-322](https://dhis2.atlassian.net/browse/LIBS-322)

`SharingDialog`: Prevents `id` from being used as the `name` of the modal

Below is an example from the provided story, where `name` and `displayName` resemble the `id`, which results in the title just being "Sharing and access":

```
object: {
    displayName: 'sharing-test',
    externalAccess: false,
    id: 'sharing-test',
    name: 'sharing-test',
    publicAccess: '--------',
    userAccesses: [],
    userGroupAccesses: []
}
```

_before_
![image](https://user-images.githubusercontent.com/12590483/167586252-8a203181-6282-4e64-aed4-4e4e8ad54262.png)


_after_
![image](https://user-images.githubusercontent.com/12590483/167585818-c63cb049-3d9c-4161-bb5f-fba3e2c48d10.png)
