### PR TITLE
fix(forms): provide a clearer error message if username is invalid

### DIFF
--- a/collections/forms/src/validators/dhis2Username.js
+++ b/collections/forms/src/validators/dhis2Username.js
@@ -5,7 +5,7 @@ const USERNAME_PATTERN =
     /^(?=.{4,255}$)(?![_.@])(?!.*[_.@]{2})[a-z0-9._@]+(?<![_.@])$/
 
 const invalidUsernameMessage = i18n.t(
-    'Please provide a username between 4 and 255 characters'
+    'Please provide a lowercase username between 4 and 255 characters long and possibly separated by . _ @ or #'
 )
 
 const dhis2Username = (value) =>


### PR DESCRIPTION
Relates to [DHIS2-13283](https://jira.dhis2.org/browse/DHIS2-13283)

---

### Description

It became apparent that a few of the constraints we have imposed on usernames were not reflected in the error message. The result was that users would see that they entered an invalid user name, but it wouldn't be clear which parts weren't allowed.