### PR TITLE
fix(chip): accept strings and numbers for margin props

### DIFF
--- a/components/chip/src/__tests__/chip.test.js
+++ b/components/chip/src/__tests__/chip.test.js
@@ -1,0 +1,38 @@
+import { screen, render } from '@testing-library/react'
+import React from 'react'
+import { Chip } from '../chip.js'
+
+describe('<Chip />', () => {
+    it('accepts numerical margin props', () => {
+        render(
+            <Chip
+                marginBottom={8}
+                marginLeft={8}
+                marginRight={8}
+                marginTop={8}
+            />
+        )
+        const chip = screen.getByTestId('dhis2-uicore-chip')
+
+        expect(chip).toHaveStyle('margin-bottom: 8px')
+        expect(chip).toHaveStyle('margin-left: 8px')
+        expect(chip).toHaveStyle('margin-right: 8px')
+        expect(chip).toHaveStyle('margin-top: 8px')
+    })
+    it('accepts string margin props', () => {
+        render(
+            <Chip
+                marginBottom="8px"
+                marginLeft="8px"
+                marginRight="8px"
+                marginTop="8px"
+            />
+        )
+        const chip = screen.getByTestId('dhis2-uicore-chip')
+
+        expect(chip).toHaveStyle('margin-bottom: 8px')
+        expect(chip).toHaveStyle('margin-left: 8px')
+        expect(chip).toHaveStyle('margin-right: 8px')
+        expect(chip).toHaveStyle('margin-top: 8px')
+    })
+})

--- a/components/chip/src/chip.js
+++ b/components/chip/src/chip.js
@@ -6,6 +6,9 @@ import { Content } from './content.js'
 import { Icon } from './icon.js'
 import { Remove } from './remove.js'
 
+const getMarginValue = (margin) =>
+    typeof margin === 'number' ? margin + 'px' : margin
+
 const Chip = ({
     selected,
     dense,
@@ -97,10 +100,10 @@ const Chip = ({
         `}</style>
         <style jsx>{`
             span {
-                ${marginBottom && `margin-bottom: ${marginBottom}px;`}
-                ${marginLeft && `margin-left: ${marginLeft}px;`}
-                ${marginRight && `margin-right: ${marginRight}px;`}
-                ${marginTop && `margin-top: ${marginTop}px`}
+                margin-bottom: ${getMarginValue(marginBottom)};
+                margin-left: ${getMarginValue(marginLeft)};
+                margin-right: ${getMarginValue(marginRight)};
+                margin-top: ${getMarginValue(marginTop)};
             }
         `}</style>
     </span>
@@ -122,14 +125,14 @@ Chip.propTypes = {
     disabled: PropTypes.bool,
     dragging: PropTypes.bool,
     icon: PropTypes.element,
-    /** `margin-bottom` value, applied in `px`  */
-    marginBottom: PropTypes.number,
-    /** `margin-left` value, applied in `px`  */
-    marginLeft: PropTypes.number,
-    /** `margin-right` value, applied in `px`  */
-    marginRight: PropTypes.number,
-    /** `margin-top` value, applied in `px`  */
-    marginTop: PropTypes.number,
+    /** `margin-bottom` value, applied in `px` when number is provided  */
+    marginBottom: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    /** `margin-left` value, applied in `px` when number is provided  */
+    marginLeft: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    /** `margin-right` value, applied in `px` when number is provided  */
+    marginRight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    /** `margin-top` value, applied in `px` when number is provided  */
+    marginTop: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     overflow: PropTypes.bool,
     selected: PropTypes.bool,
     onClick: PropTypes.func,

--- a/components/chip/src/remove.js
+++ b/components/chip/src/remove.js
@@ -1,7 +1,7 @@
 import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { css, resolve } from 'styled-jsx/css'
+import css from 'styled-jsx/css'
 
 function CancelOutline({ className }) {
     return (
@@ -44,11 +44,11 @@ const containerStyle = css`
     }
 `
 
-const removeIcon = resolve`
+const removeIcon = css.resolve`
     svg {
         fill: ${colors.grey600};
-		    height: 16px;
-		    width: 16px;
+        height: 16px;
+        width: 16px;
         cursor: pointer;
         opacity: 1;
         pointer-events: all;


### PR DESCRIPTION
The chip component now accepts strings and numbers for its margin props. We chose this approach because we typically accept strings for CSS attribute props, but this component only accepted numbers. Letting the component _only_ accept strings only would have represented a breaking change, so to prevent this we now accept both strings and numbers.