### PR TITLE
docs: remove autogenerated breadcrumb

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -26,6 +26,7 @@ const config = {
                     sidebarPath: require.resolve('./sidebars.js'),
                     editUrl: 'https://github.com/dhis2/ui',
                     routeBasePath: '/',
+                    breadcrumbs: false,
                 },
                 blog: false,
                 theme: {


### PR DESCRIPTION
### Description

This PR removes the breadcrumb component that was automatically added to generated documentation in Docusaurus beta 16. Breadcrumbs provide no value in our documentation because there are no section-homepages.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added
---

### Screenshots

Before: 
![image](https://user-images.githubusercontent.com/33054985/175946281-f605b6c8-0c06-4446-b79b-916f46de5c1a.png)

After:
![image](https://user-images.githubusercontent.com/33054985/175946580-8af8ab57-9225-46af-80d5-fbef2579a4ea.png)


