### PR TITLE
fix(forms): allow upper case characters in dhis2 user name

### DIFF
--- a/collections/forms/src/validators/__tests__/dhis2Username.test.js
+++ b/collections/forms/src/validators/__tests__/dhis2Username.test.js
@@ -49,6 +49,8 @@ describe('validator: dhis2Username', () => {
         testValidatorValues(dhis2Username, undefined, [
             'v@lid_user.name',
             '123another_v@lid_usern@me',
+            'UPPER_CASE',
+            'lower@ca.se',
         ])
 
         testValidatorValues(dhis2Username, invalidUsernameMessage, [

--- a/collections/forms/src/validators/dhis2Username.js
+++ b/collections/forms/src/validators/dhis2Username.js
@@ -2,10 +2,10 @@ import i18n from '../locales/index.js'
 import { isEmpty, isString } from './helpers/index.js'
 
 const USERNAME_PATTERN =
-    /^(?=.{4,255}$)(?![_.@])(?!.*[_.@]{2})[a-z0-9._@]+(?<![_.@])$/
+    /^(?=.{4,255}$)(?![_.@])(?!.*[_.@]{2})[a-zA-Z0-9._@]+(?<![_.@])$/
 
 const invalidUsernameMessage = i18n.t(
-    'Please provide a lowercase username between 4 and 255 characters long and possibly separated by . _ @ or #'
+    'Please provide a username between 4 and 255 characters long and possibly separated by . _ @ or #'
 )
 
 const dhis2Username = (value) =>


### PR DESCRIPTION
Implements [DHIS2-13446](https://jira.dhis2.org/browse/DHIS2-13446)

---

### Description

We recently implemented a new validation regex on both the server as well as the client, but it turned out to be too restrictive. We are now relaxing things a bit and allowing for lowercase characters too.