### PR TITLE
fix(validators): ensure integer validator rejects any decimal separator

### DIFF
--- a/collections/forms/src/validators/__tests__/integer.test.js
+++ b/collections/forms/src/validators/__tests__/integer.test.js
@@ -21,9 +21,10 @@ describe('validator: integer', () => {
         ])
     })
 
-    describe('rejects other data types', () => {
+    describe('rejects other data types and leading zeros', () => {
         testValidatorValues(integer, invalidIntegerMessage, [
             'text',
+            '014',
             true,
             {},
             [],
@@ -36,6 +37,9 @@ describe('validator: integer', () => {
             0.23456,
             5.987,
             1e-12,
+            '4.0',
+            '4.000',
+            '4,0',
             '0.23456',
             '5.987',
             '1e-12',

--- a/collections/forms/src/validators/helpers/index.js
+++ b/collections/forms/src/validators/helpers/index.js
@@ -3,8 +3,6 @@ export const isEmpty = (value) =>
 
 export const isString = (value) => typeof value === 'string'
 
-export const isInteger = (value) => Number.isSafeInteger(value)
-
 export const isNumber = (value) => typeof value === 'number'
 
 export const isNumeric = (value) =>

--- a/collections/forms/src/validators/integer.js
+++ b/collections/forms/src/validators/integer.js
@@ -1,12 +1,19 @@
 import i18n from '../locales/index.js'
-import { isEmpty, isInteger, isNumeric, toNumber } from './helpers/index.js'
+import { isEmpty, isNumeric, toNumber } from './helpers/index.js'
 
 const invalidIntegerMessage = i18n.t(
     'Please provide a round number without decimals'
 )
 
+// Regex accepts only digits (no decimals even if it is trailing like 4.0)
+// it also rejects a leading 0 (i.e 04) as this is rejected by backend
+const INTEGER_PATTERN = /^(-?[1-9]\d*|0)$/
+
 const integer = (value) =>
-    isEmpty(value) || (isNumeric(value) && isInteger(toNumber(value)))
+    isEmpty(value) ||
+    (INTEGER_PATTERN.test(value) &&
+        isNumeric(value) &&
+        Number.isSafeInteger(toNumber(value)))
         ? undefined
         : invalidIntegerMessage
 


### PR DESCRIPTION
Implements [TECH-1230](https://dhis2.atlassian.net/browse/TECH-1230)

---

### Description

with the current implementation, a value such as `4.0` would be accepted by the integer validator but the API rejects it. This brings the client-side validator inline with the API implementation.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added
