### PR TITLE
fix(tab): update hover style

### DIFF
--- a/components/tab/src/tab/tab.js
+++ b/components/tab/src/tab/tab.js
@@ -44,8 +44,6 @@ const Tab = ({
                 font-size: 14px;
                 line-height: 20px;
 
-                transition: all 150ms ease-in-out;
-                transition-property: color, background-color;
                 cursor: pointer;
             }
 
@@ -61,7 +59,6 @@ const Tab = ({
                 left: 0;
                 height: 4px;
                 width: 100%;
-                transition: background-color 150ms ease-in-out;
                 background-color: transparent;
             }
 
@@ -89,20 +86,30 @@ const Tab = ({
             }
 
             button:hover {
-                background-color: ${colors.grey100};
+                color: ${colors.grey900};
             }
 
-            button:active {
-                /* Briefly highlight clicked tab */
-                background-color: ${colors.grey200};
+            button:hover::after {
+                background-color: ${colors.grey600};
+                height: 2px;
+            }
+
+            button:active::after {
+                background-color: ${colors.grey800};
             }
 
             button.selected {
-                color: ${theme.primary700};
+                color: ${theme.primary800};
             }
 
             button.selected::after {
                 background-color: ${theme.primary700};
+                transition: background-color 150ms ease-in-out;
+            }
+
+            button.selected:hover::after {
+                background-color: ${theme.primary700};
+                height: 4px;
             }
 
             button.selected > :global(svg) {


### PR DESCRIPTION
Partly implements [UX-106](https://dhis2.atlassian.net/browse/UX-106)

---

### Description

This PR adjusts the tab hover style. The previous style had an issue of looking possibly "greyed out" or disabled. The updated hover style avoids using a grey background. The active style is also updated to avoid a flash of grey background, which is unecessarily distracting. The selected text color is darkened a shade, for contrast (this could've been it's own PR, actually, but perhaps it can be bundled here).
`transition`s are also removed for hover to reduce unnecessary motion, using them only for changing selected tabs.

Note that the hover style is a supporting signifier to indicate interaction. The mouse cursor change is the main signifier.

---

### Checklist

-   [X] API docs are generated
-   [X] Tests were added
-   [X] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Before:
![SCR-20220817-fsc](https://user-images.githubusercontent.com/33054985/185084452-b00fde02-96ad-4044-b816-8dc467f30597.png)

After:
![SCR-20220817-frj](https://user-images.githubusercontent.com/33054985/185084470-7e79d570-7ff4-4372-872b-1190eadf9094.png)

