### PR TITLE
fix(selection-bar): change menu alignment

### DIFF
--- a/components/selector-bar/src/selector-bar-item/selector-bar-item.js
+++ b/components/selector-bar/src/selector-bar-item/selector-bar-item.js
@@ -65,7 +65,7 @@ export const SelectorBarItem = ({
                 >
                     <Popper
                         reference={buttonRef}
-                        placement="bottom-end"
+                        placement="bottom-start"
                         modifiers={[offsetModifier]}
                     >
                         <Card>{children}</Card>


### PR DESCRIPTION
### Description

This PR changes the placement of menus opened by `selection-bar-item`s, from `bottom-end` to `bottom-start`.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

