### PR TITLE
fix(flyout-menu): ensure div scrolls when setting a max height or width

### DIFF
--- a/components/menu/src/flyout-menu/flyout-menu.js
+++ b/components/menu/src/flyout-menu/flyout-menu.js
@@ -41,6 +41,7 @@ const FlyoutMenu = ({
                     max-width: ${maxWidth};
                     max-height: ${maxHeight};
                     padding: ${spacers.dp4} 0;
+                    overflow: auto;
                 }
             `}</style>
         </div>


### PR DESCRIPTION
See [this Slack thread](https://dhis2.slack.com/archives/CBM8LNEQM/p1663596021414889)