### PR TITLE
fix(forms): allow usernames to contain single hyphens

### DIFF
--- a/collections/forms/src/validators/__tests__/dhis2Username.test.js
+++ b/collections/forms/src/validators/__tests__/dhis2Username.test.js
@@ -21,33 +21,37 @@ describe('validator: dhis2Username', () => {
         ])
     })
 
-    describe('does not allow usernames to start with _, . or @', () => {
+    describe('does not allow usernames to start with _, -, . or @', () => {
         testValidatorValues(dhis2Username, invalidUsernameMessage, [
             '_xxx',
+            '-xxx',
             '.xxx',
             '@xxx',
         ])
     })
 
-    describe('does not allow usernames to end with _, . or @', () => {
+    describe('does not allow usernames to end with _, -, . or @', () => {
         testValidatorValues(dhis2Username, invalidUsernameMessage, [
             'xxx_',
+            'xxx-',
             'xxx.',
             'xxx@',
         ])
     })
 
-    describe('does not allow usernames to contain __, .. or @@', () => {
+    describe('does not allow usernames to contain __, --, .. or @@', () => {
         testValidatorValues(dhis2Username, invalidUsernameMessage, [
-            '__xx',
-            '..xx',
-            '@@xx',
+            'xx__xx',
+            'xx--xx',
+            'xx..xx',
+            'xx@@xx',
         ])
     })
 
     describe('constrains characters in usernames to [a-z0-9._@]', () => {
         testValidatorValues(dhis2Username, undefined, [
             'v@lid_user.name',
+            'v@lid-user.name',
             '123another_v@lid_usern@me',
             'UPPER_CASE',
             'lower@ca.se',

--- a/collections/forms/src/validators/dhis2Username.js
+++ b/collections/forms/src/validators/dhis2Username.js
@@ -2,10 +2,10 @@ import i18n from '../locales/index.js'
 import { isEmpty, isString } from './helpers/index.js'
 
 const USERNAME_PATTERN =
-    /^(?=.{4,255}$)(?![_.@])(?!.*[_.@]{2})[a-zA-Z0-9._@]+(?<![_.@])$/
+    /^(?=.{4,255}$)(?![_\-.@])(?!.*[_\-.@]{2})[a-zA-Z0-9._\-@]+(?<![_\-.@])$/
 
 const invalidUsernameMessage = i18n.t(
-    'Please provide a username between 4 and 255 characters long and possibly separated by . _ @ or #'
+    'Please provide a username between 4 and 255 characters long and possibly separated by . _ - or @'
 )
 
 const dhis2Username = (value) =>


### PR DESCRIPTION
Same as with `_`, `@` and `.` , we should allow `-`, but only single ones and not at the username’s start or end.

Some related JIRA issues:
- [DHIS2-13824](https://dhis2.atlassian.net/browse/DHIS2-13824) (current issue)
- [DHIS2-13768](https://dhis2.atlassian.net/browse/DHIS2-13768) (backend, not completely right)
- [DHIS2-13823](https://dhis2.atlassian.net/browse/DHIS2-13823) (backend, additional fix)