### PR TITLE
feat: allow alerts to be undismissable [LIBS-360]

### DIFF
--- a/components/alert/src/alert-bar/action.js
+++ b/components/alert/src/alert-bar/action.js
@@ -5,7 +5,9 @@ import React, { Component } from 'react'
 class Action extends Component {
     onClick = (event) => {
         this.props.onClick(event)
-        this.props.hide(event)
+        if (this.props.hideOnClick) {
+            this.props.hide(event)
+        }
     }
 
     render() {
@@ -26,9 +28,14 @@ class Action extends Component {
     }
 }
 
+Action.defaultProps = {
+    hideOnClick: true
+}
+
 Action.propTypes = {
     dataTest: PropTypes.string.isRequired,
     hide: PropTypes.func.isRequired,
+    hideOnClick: PropTypes.boolean.isRequired,
     label: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired,
 }

--- a/components/alert/src/alert-bar/alert-bar.js
+++ b/components/alert/src/alert-bar/alert-bar.js
@@ -18,6 +18,7 @@ const AlertBar = ({
     hidden,
     icon,
     permanent,
+    dismissable,
     success,
     warning,
     onHidden,
@@ -127,10 +128,10 @@ const AlertBar = ({
                 hide={runHideAnimation}
                 dataTest={dataTest}
             />
-            <Dismiss
+            {dismissable && <Dismiss
                 onClick={runHideAnimation}
                 dataTest={`${dataTest}-dismiss`}
-            />
+            />}
 
             <style jsx>{styles}</style>
         </div>
@@ -146,6 +147,7 @@ AlertBar.defaultProps = {
     duration: 8000,
     dataTest: 'dhis2-uicore-alertbar',
     icon: true,
+    dismissable: true,
 }
 
 AlertBar.propTypes = {
@@ -165,6 +167,7 @@ AlertBar.propTypes = {
      */
     icon: iconPropType,
     permanent: PropTypes.bool,
+    dismissable: PropTypes.bool,
     success: alertTypePropType,
     /** Alert bars with `warning` will not autohide */
     warning: alertTypePropType,


### PR DESCRIPTION
Implements [LIBS-360](https://dhis2.atlassian.net/browse/LIBS-360)

---

### Description

This implements an additional `dismissible` flag in the AlertBar props which optionally disables the "dismiss" X button

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

_supporting text_
