### PR TITLE
chore: add linting scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
         "lint:staged": "d2-style check --staged",
         "test": "d2-app-scripts test",
         "start": "yarn workspace ui-storybook start",
-        "start:docs": "yarn workspace ui-docusaurus start"
+        "start:docs": "yarn workspace ui-docusaurus start",
+        "link:app-runtime": "yarn link @dhis2/app-runtime @dhis2/app-service-alerts @dhis2/app-service-config @dhis2/app-service-data @dhis2/app-service-offline",
+        "unlink:app-runtime": "yarn unlink @dhis2/app-runtime @dhis2/app-service-alerts @dhis2/app-service-config @dhis2/app-service-data @dhis2/app-service-offline"
     },
     "dependencies": {
         "@babel/parser": "^7.17.0",


### PR DESCRIPTION
### What problem does this solve

When working recently on a feature it was difficult to set up a local development workflow across multiple repos. Allowing a workflow across multiple repos locally allows for early feedback on development work - helping to see changes made locally while reducing the need to publish repos to see how implementation of library might effect another  that depends on it.

### What this PR presents

This is something I put together to just help me work locally for change across `UI` and `app-runtime` - The question here is would this be useful to anyone else?

This PR is also dependent on changes in the other [PR on the `app-runtime` repo](https://github.com/dhis2/app-runtime/pull/1282) 

I used `yarn link` to create locally linked repos for `ui` and `app-runtime` - links have to be established in all the packages in the dependency monorepo and then all have to be consumed in dependent repo.

With this workflow to link the repos

1. You run `yarn link:all` in app-runtime
2. In `UI` you run in `yarn link:app-runtime`
3. In app-runtime, when you make changes running `yarn build` and those changes should be available in the `UI` repo

To unlink the repos

1. In `UI` you run in `yarn unlink:app-runtime`
2. In `UI` run `yarn install --force` to reinstall the original libs that the linking replaced
3. In `app-runtime` run `yarn unlink:all`

### Considerations

- This will only work across `ui` and `app-runtime`
- There are lots of different packages in `ui` - I've only seen this work in the packages I cared about for the HeaderBar work I was doing and I don't know if it will work for all packages in `ui`
- With differences in dependency versions across `ui` and `app-runtime` this might stop this work
- I wasn't able to get linking to work across `ui`, `app-runtime` and `app-platform` - this might have been a dependency issue as stated above


