### PR TITLE
fix(sharing-dialog): variable initialization error [DHIS2-14029]

### DIFF
--- a/components/sharing-dialog/src/cascade-sharing/controls.js
+++ b/components/sharing-dialog/src/cascade-sharing/controls.js
@@ -38,7 +38,7 @@ export const Controls = ({ id, entityAmount }) => {
      * so we're using the engine directly as a workaround.
      */
 
-    const engine = useDataEngine(mutation)
+    const engine = useDataEngine()
     const [called, setCalled] = useState(false)
     const [mutating, setMutating] = useState(false)
     const [error, setError] = useState(null)


### PR DESCRIPTION
Implements [DHIS2-14029](https://dhis2.atlassian.net/browse/DHIS2-14029)

---

### Description

Fixes an `Uncaught ReferenceError: Cannot access 'mutation' before initialization` bug that crashes a consuming app. The `useDataEngine` hook doesn't accept any parameters so it's safe to remove there, and the `mutation` object is used below at `engine.mutate()`

---

### Checklist

-   [X] API docs are generated
-   [X] Tests were added
-   [X] Storybook demos were added
