### PR TITLE
fix(sharing-dialog): fix crash when using cascade sharing

### DIFF
--- a/components/sharing-dialog/src/cascade-sharing/controls.js
+++ b/components/sharing-dialog/src/cascade-sharing/controls.js
@@ -38,7 +38,7 @@ export const Controls = ({ id, entityAmount }) => {
      * so we're using the engine directly as a workaround.
      */
 
-    const engine = useDataEngine(mutation)
+    const engine = useDataEngine()
     const [called, setCalled] = useState(false)
     const [mutating, setMutating] = useState(false)
     const [error, setError] = useState(null)


### PR DESCRIPTION
Implements [JIRA_ISSUE_ID](https://dhis2.atlassian.net/browse/JIRA_ISSUE_ID)

---

### Description

The mutation definition was passed to `useDataEngine` hook, but it was defined after the `engine` initialisation.
I suspect it was left there when replacing `useDataMutation` with `useDataEngine`.

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Crash happening when clicking on the cascade sharing tab:


After the fix:

