### PR TITLE
fix: field-related component styling adjustments

### DIFF
--- a/components/field/src/field/field.js
+++ b/components/field/src/field/field.js
@@ -1,7 +1,7 @@
 import { Box } from '@dhis2-ui/box'
 import { Help } from '@dhis2-ui/help'
 import { Label } from '@dhis2-ui/label'
-import { sharedPropTypes, spacers } from '@dhis2/ui-constants'
+import { sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -31,10 +31,7 @@ const Field = ({
             </Label>
         )}
 
-        <Box
-            dataTest={`${dataTest}-content`}
-            marginTop={label ? spacers.dp4 : '0'}
-        >
+        <Box dataTest={`${dataTest}-content`} marginTop={label ? '2px' : '0'}>
             {children}
         </Box>
 

--- a/components/help/src/help.js
+++ b/components/help/src/help.js
@@ -23,7 +23,6 @@ const Help = ({ children, valid, error, warning, className, dataTest }) => (
                 font-size: 12px;
                 line-height: 14px;
                 color: ${theme.default};
-                cursor: help;
             }
 
             .valid {

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -27,7 +27,7 @@ const styles = css`
         outline: 0;
         border: 1px solid ${colors.grey500};
         border-radius: 3px;
-        box-shadow: inset 0 1px 2px 0 rgba(48, 54, 60, 0.1);
+        box-shadow: inset 0 0 1px 0 rgba(48, 54, 60, 0.1);
         text-overflow: ellipsis;
     }
 

--- a/components/label/src/label.js
+++ b/components/label/src/label.js
@@ -1,4 +1,5 @@
 import { Required } from '@dhis2-ui/required'
+import { colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -9,7 +10,8 @@ const styles = css`
         display: block;
         box-sizing: border-box;
         font-size: 14px;
-        line-height: 24px;
+        line-height: 19px;
+        color: ${colors.grey900};
         padding: 0;
     }
 


### PR DESCRIPTION
### Description

This PR makes minor adjustments to the `Field`, `Input`, `Help` and `Label` components. The adjustments are styling and placement. The `cursor: help;` hover style was removed from the `Help` component, as this had caused confusion a few times and was not offering useful info.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._
