### PR TITLE
feat(selection-bar-item): [LIBS-371] display only and clear selection callback 

### DIFF
--- a/collections/ui/API.md
+++ b/collections/ui/API.md
@@ -1863,15 +1863,17 @@ import { SelectorBarItem } from '@dhis2/ui'
 
 |Name|Type|Default|Required|Description|
 |---|---|---|---|---|
-|children|any||*||
 |label|string||*||
-|noValueMessage|string||*||
-|open|boolean||*||
-|setOpen|function||*||
+|children|any||||
 |className|string||||
 |dataTest|string|`'dhis2-ui-selectorbaritem'`|||
 |disabled|boolean||||
+|displayOnly|boolean||||
+|noValueMessage|string||||
+|open|boolean||||
+|setOpen|function||||
 |value|string||||
+|onClearSelectionClick|function||||
 
 ### SharingDialog
 

--- a/components/selector-bar/API.md
+++ b/components/selector-bar/API.md
@@ -37,12 +37,14 @@ import { SelectorBarItem } from '@dhis2-ui/selector-bar'
 
 |Name|Type|Default|Required|Description|
 |---|---|---|---|---|
-|children|any||*||
 |label|string||*||
-|noValueMessage|string||*||
-|open|boolean||*||
-|setOpen|function||*||
+|children|any||||
 |className|string||||
 |dataTest|string|`'dhis2-ui-selectorbaritem'`|||
 |disabled|boolean||||
+|displayOnly|boolean||||
+|noValueMessage|string||||
+|open|boolean||||
+|setOpen|function||||
 |value|string||||
+|onClearSelectionClick|function||||

--- a/components/selector-bar/src/selector-bar-item/features/toggle-children/index.js
+++ b/components/selector-bar/src/selector-bar-item/features/toggle-children/index.js
@@ -9,7 +9,7 @@ Given('the selector bar item is open', () => {
 })
 
 When('the user opens the selector bar item', () => {
-    cy.contains('Selection bar item', { selector: 'button' }).click()
+    cy.get('[data-test="dhis2-ui-selectorbaritem-toggle-icon"]').click()
 })
 
 When('the user closes the selector bar item', () => {

--- a/components/selector-bar/src/selector-bar-item/features/toggle-children/index.js
+++ b/components/selector-bar/src/selector-bar-item/features/toggle-children/index.js
@@ -9,7 +9,7 @@ Given('the selector bar item is open', () => {
 })
 
 When('the user opens the selector bar item', () => {
-    cy.get('[data-test="dhis2-ui-selectorbaritem-toggle-icon"]').click()
+    cy.contains('Selection bar item', { selector: 'button' }).click()
 })
 
 When('the user closes the selector bar item', () => {

--- a/components/selector-bar/src/selector-bar-item/selector-bar-item.js
+++ b/components/selector-bar/src/selector-bar-item/selector-bar-item.js
@@ -47,8 +47,13 @@ export const SelectorBarItem = ({
     return (
         <button
             ref={buttonRef}
-            className={cx('selector-bar-item', className)}
+            className={cx(
+                'selector-bar-item',
+                className,
+                !displayOnly ? 'pointer' : ''
+            )}
             disabled={disabled}
+            onClick={() => setOpen && setOpen(true)}
             data-test={dataTest}
         >
             <span className="label">{label}</span>
@@ -59,7 +64,10 @@ export const SelectorBarItem = ({
                     {value && onClearSelectionClick && (
                         <span
                             className="clear-icon"
-                            onClick={onClearSelectionClick}
+                            onClick={(evt) => {
+                                evt.stopPropagation()
+                                onClearSelectionClick()
+                            }}
                             data-test={`${dataTest}-clear-icon`}
                         >
                             <IconCross16 />
@@ -69,11 +77,7 @@ export const SelectorBarItem = ({
             )}
 
             {!displayOnly && (
-                <span
-                    className="toggle-icon"
-                    onClick={() => setOpen(true)}
-                    data-test={`${dataTest}-toggle-icon`}
-                >
+                <span className="toggle-icon">
                     <Icon />
                 </span>
             )}
@@ -114,6 +118,10 @@ export const SelectorBarItem = ({
                     box-shadow: 0px 0px 0px 1px ${colors.grey400};
                 }
 
+                .selector-bar-item.pointer {
+                    cursor: pointer;
+                }
+
                 .selector-bar-item:disabled {
                     cursor: not-allowed;
                 }
@@ -145,7 +153,6 @@ export const SelectorBarItem = ({
                     margin-left: ${spacers.dp4};
                     height: 100%;
                     align-items: center;
-                    cursor: pointer;
                 }
             `}</style>
         </button>

--- a/components/selector-bar/src/selector-bar-item/selector-bar-item.js
+++ b/components/selector-bar/src/selector-bar-item/selector-bar-item.js
@@ -46,7 +46,7 @@ export const SelectorBarItem = ({
             className={cx(
                 'selector-bar-item',
                 className,
-                !displayOnly ? 'pointer' : ''
+                !displayOnly ? 'openable' : ''
             )}
             disabled={disabled}
             onClick={() => setOpen && setOpen(true)}
@@ -122,7 +122,7 @@ export const SelectorBarItem = ({
                     box-shadow: 0px 0px 0px 1px ${colors.grey400};
                 }
 
-                .selector-bar-item.pointer {
+                .selector-bar-item.openable {
                     cursor: pointer;
                 }
 

--- a/components/selector-bar/src/selector-bar-item/selector-bar-item.js
+++ b/components/selector-bar/src/selector-bar-item/selector-bar-item.js
@@ -2,7 +2,11 @@ import { Card } from '@dhis2-ui/card'
 import { Layer } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
 import { colors, spacers } from '@dhis2/ui-constants'
-import { IconChevronUp24, IconChevronDown24 } from '@dhis2/ui-icons'
+import {
+    IconChevronUp24,
+    IconChevronDown24,
+    IconCross16,
+} from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
@@ -29,11 +33,13 @@ export const SelectorBarItem = ({
     className,
     dataTest,
     disabled,
+    displayOnly,
     label,
     noValueMessage,
     open,
     setOpen,
     value,
+    onClearSelectionClick,
 }) => {
     const buttonRef = useRef()
     const Icon = open ? IconChevronUp24 : IconChevronDown24
@@ -43,18 +49,30 @@ export const SelectorBarItem = ({
             ref={buttonRef}
             className={cx('selector-bar-item', className)}
             disabled={disabled}
-            onClick={() => setOpen(true)}
             data-test={dataTest}
         >
             <span className="label">{label}</span>
 
             {!disabled && (
-                <span className="value">{value || noValueMessage}</span>
+                <>
+                    <span className="value">{value || noValueMessage}</span>
+                    {value && onClearSelectionClick && (
+                        <span
+                            className="clear-icon"
+                            onClick={onClearSelectionClick}
+                            data-test={`${dataTest}-clear-icon`}
+                        >
+                            <IconCross16 />
+                        </span>
+                    )}
+                </>
             )}
 
-            <span className="toggle-icon">
-                <Icon />
-            </span>
+            {!displayOnly && (
+                <span className="toggle-icon" onClick={() => setOpen(true)}>
+                    <Icon />
+                </span>
+            )}
 
             {open && (
                 <Layer
@@ -76,7 +94,6 @@ export const SelectorBarItem = ({
             <style jsx>{`
                 .selector-bar-item {
                     display: flex;
-                    cursor: pointer;
                     background: none;
                     height: 40px;
                     align-items: center;
@@ -105,11 +122,26 @@ export const SelectorBarItem = ({
                     padding-left: ${spacers.dp8};
                 }
 
+                .clear-icon {
+                    display: flex;
+                    margin-left: ${spacers.dp4};
+                    align-items: center;
+                    background: ${colors.grey400};
+                    color: ${colors.white};
+                    border-radius: 50%;
+                    cursor: pointer;
+                }
+
+                .clear-icon:hover {
+                    background: ${colors.grey500};
+                }
+
                 .toggle-icon {
                     display: flex;
                     margin-left: ${spacers.dp4};
                     height: 100%;
                     align-items: center;
+                    cursor: pointer;
                 }
             `}</style>
         </button>
@@ -121,13 +153,15 @@ SelectorBarItem.defaultProps = {
 }
 
 SelectorBarItem.propTypes = {
-    children: PropTypes.any.isRequired,
     label: PropTypes.string.isRequired,
-    noValueMessage: PropTypes.string.isRequired,
-    open: PropTypes.bool.isRequired,
-    setOpen: PropTypes.func.isRequired,
+    children: PropTypes.any,
     className: PropTypes.string,
     dataTest: PropTypes.string,
     disabled: PropTypes.bool,
+    displayOnly: PropTypes.bool,
+    noValueMessage: PropTypes.string,
+    open: PropTypes.bool,
+    setOpen: PropTypes.func,
     value: PropTypes.string,
+    onClearSelectionClick: PropTypes.func,
 }

--- a/components/selector-bar/src/selector-bar-item/selector-bar-item.js
+++ b/components/selector-bar/src/selector-bar-item/selector-bar-item.js
@@ -2,11 +2,7 @@ import { Card } from '@dhis2-ui/card'
 import { Layer } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
 import { colors, spacers } from '@dhis2/ui-constants'
-import {
-    IconChevronUp24,
-    IconChevronDown24,
-    IconCross16,
-} from '@dhis2/ui-icons'
+import { IconChevronUp24, IconChevronDown24 } from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
@@ -70,7 +66,15 @@ export const SelectorBarItem = ({
                             }}
                             data-test={`${dataTest}-clear-icon`}
                         >
-                            <IconCross16 />
+                            <svg
+                                width="14"
+                                height="14"
+                                viewBox="0 0 14 14"
+                                fill="none"
+                                xmlns="http://www.w3.org/2000/svg"
+                            >
+                                <path d="M7 14C10.866 14 14 10.866 14 7C14 3.13401 10.866 0 7 0C3.13401 0 0 3.13401 0 7C0 10.866 3.13401 14 7 14ZM4.29289 4.29289C4.68342 3.90237 5.31658 3.90237 5.70711 4.29289L7 5.58579L8.29289 4.29289C8.68342 3.90237 9.31658 3.90237 9.70711 4.29289C10.0976 4.68342 10.0976 5.31658 9.70711 5.70711L8.41421 7L9.70711 8.29289C10.0976 8.68342 10.0976 9.31658 9.70711 9.70711C9.31658 10.0976 8.68342 10.0976 8.29289 9.70711L7 8.41421L5.70711 9.70711C5.31658 10.0976 4.68342 10.0976 4.29289 9.70711C3.90237 9.31658 3.90237 8.68342 4.29289 8.29289L5.58579 7L4.29289 5.70711C3.90237 5.31658 3.90237 4.68342 4.29289 4.29289Z" />
+                            </svg>
                         </span>
                     )}
                 </>
@@ -136,16 +140,17 @@ export const SelectorBarItem = ({
 
                 .clear-icon {
                     display: flex;
-                    margin-left: ${spacers.dp4};
                     align-items: center;
-                    background: ${colors.grey400};
-                    color: ${colors.white};
-                    border-radius: 50%;
+                    margin-left: ${spacers.dp4};
+                    padding: ${spacers.dp4};
                     cursor: pointer;
                 }
+                .clear-icon svg path {
+                    fill: ${colors.grey500};
+                }
 
-                .clear-icon:hover {
-                    background: ${colors.grey500};
+                .clear-icon:hover svg path {
+                    fill: ${colors.grey700};
                 }
 
                 .toggle-icon {

--- a/components/selector-bar/src/selector-bar-item/selector-bar-item.js
+++ b/components/selector-bar/src/selector-bar-item/selector-bar-item.js
@@ -69,7 +69,11 @@ export const SelectorBarItem = ({
             )}
 
             {!displayOnly && (
-                <span className="toggle-icon" onClick={() => setOpen(true)}>
+                <span
+                    className="toggle-icon"
+                    onClick={() => setOpen(true)}
+                    data-test={`${dataTest}-toggle-icon`}
+                >
                     <Icon />
                 </span>
             )}

--- a/components/selector-bar/src/selector-bar/__stories__/keep-org-unit-expanded.js
+++ b/components/selector-bar/src/selector-bar/__stories__/keep-org-unit-expanded.js
@@ -28,6 +28,9 @@ export const KeepOrgUnitExpanded = (
                     noValueMessage="Choose an organisation unit"
                     open={orgUnitOpen}
                     setOpen={setOrgUnitOpen}
+                    onClearSelectionClick={() => {
+                        setOrgUnit(null)
+                    }}
                 >
                     <div
                         style={{

--- a/components/selector-bar/src/selector-bar/__stories__/with-right-hand-side-content.js
+++ b/components/selector-bar/src/selector-bar/__stories__/with-right-hand-side-content.js
@@ -53,6 +53,9 @@ export const WithAdditionalContent = (
                 noValueMessage="Choose a workflow"
                 open={workflowOpen}
                 setOpen={setWorkflowOpen}
+                onClearSelectionClick={() => {
+                    setWorkflow(null)
+                }}
             >
                 <MenuSelect
                     values={workflows}
@@ -76,6 +79,9 @@ export const WithAdditionalContent = (
                 noValueMessage="Choose an organisation unit"
                 open={orgUnitOpen}
                 setOpen={setOrgUnitOpen}
+                onClearSelectionClick={() => {
+                    setOrgUnit(null)
+                }}
             >
                 <OrgUnitSelect
                     selected={orgUnit ? [orgUnit.path] : []}

--- a/components/selector-bar/src/selector-bar/__stories__/with-some-inputs.js
+++ b/components/selector-bar/src/selector-bar/__stories__/with-some-inputs.js
@@ -80,6 +80,9 @@ export const WithSomeInputs = (
                 displayOnly={true}
                 label="Person"
                 value="John doe"
+                onClearSelectionClick={() => {
+                    alert('This selection would be cleared')
+                }}
             />
         </SelectorBar>
     )

--- a/components/selector-bar/src/selector-bar/__stories__/with-some-inputs.js
+++ b/components/selector-bar/src/selector-bar/__stories__/with-some-inputs.js
@@ -37,6 +37,9 @@ export const WithSomeInputs = (
                 noValueMessage="Choose a workflow"
                 open={workflowOpen}
                 setOpen={setWorkflowOpen}
+                onClearSelectionClick={() => {
+                    setWorkflow(null)
+                }}
             >
                 <MenuSelect
                     values={workflows}
@@ -60,6 +63,9 @@ export const WithSomeInputs = (
                 noValueMessage="Choose an organisation unit"
                 open={orgUnitOpen}
                 setOpen={setOrgUnitOpen}
+                onClearSelectionClick={() => {
+                    setOrgUnit(null)
+                }}
             >
                 <OrgUnitSelect
                     selected={orgUnit ? [orgUnit.path] : []}
@@ -70,6 +76,11 @@ export const WithSomeInputs = (
                     }}
                 />
             </SelectorBarItem>
+            <SelectorBarItem
+                displayOnly={true}
+                label="Person"
+                value="John doe"
+            />
         </SelectorBar>
     )
 }

--- a/components/selector-bar/src/selector-bar/selector-bar.test.js
+++ b/components/selector-bar/src/selector-bar/selector-bar.test.js
@@ -89,4 +89,36 @@ describe('SelectorBar', () => {
         const extraContent = screen.getByText('Foobar')
         expect(extraContent).not.toBeNull()
     })
+
+    it('should render the displayOnly value', () => {
+        render(
+            <SelectorBar>
+                <SelectorBarItem
+                    displayOnly={true}
+                    label="Person"
+                    value="John doe"
+                />
+            </SelectorBar>
+        )
+
+        const value = screen.getByText('John doe')
+        expect(value).not.toBeNull()
+    })
+
+    it('should render the cross icon', () => {
+        render(
+            <SelectorBar>
+                <SelectorBarItem
+                    label="label"
+                    value="selected value"
+                    onClearSelectionClick={noop}
+                />
+            </SelectorBar>
+        )
+
+        const clearIcon = screen.getByTestId(
+            'dhis2-ui-selectorbaritem-clear-icon'
+        )
+        expect(clearIcon).not.toBeNull()
+    })
 })


### PR DESCRIPTION
Implements [LIBS-371](https://dhis2.atlassian.net/browse/LIBS-371)

---

### Description

Allow clearing of single selections from `SelectionBarItem` component.
Add a `displayOnly` SelectionBarItem component
[Figma prototype](https://www.figma.com/proto/9zvqbQKtrWIElNQ8ZYxyha/capture-context-selector?page-id=0%3A1&node-id=3%3A3435&viewport=1740%2C62%2C0.28&scaling=min-zoom&starting-point-node-id=3%3A1134) 

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added
---

### Screenshots

<img width="726" alt="Screenshot 2022-11-18 at 12 23 47" src="https://user-images.githubusercontent.com/6817073/202696379-031a291f-4239-4d20-9318-682a3943cc98.png">
