### PR TITLE
fix(menu): adjust visual styles

### DIFF
--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -50,7 +50,7 @@ const MenuItem = ({
                     disabled,
                     dense,
                     active: active || showSubMenu,
-                    'with-chevron': chevron,
+                    'with-chevron': children || chevron,
                 })}
                 ref={menuItemRef}
                 data-test={dataTest}

--- a/components/menu/src/menu-item/menu-item.styles.js
+++ b/components/menu/src/menu-item/menu-item.styles.js
@@ -8,18 +8,12 @@ export default css`
         padding: 0;
         cursor: pointer;
         list-style: none;
-        transition: background-color 150ms ease-in-out;
         background-color: ${colors.white};
         color: ${colors.grey900};
         fill: ${colors.grey900};
-        font-size: 15px;
-        line-height: 18px;
-        user-select: none;
-    }
-
-    li.dense {
         font-size: 14px;
         line-height: 16px;
+        user-select: none;
     }
 
     li:hover {
@@ -28,7 +22,7 @@ export default css`
 
     li:active,
     li.active {
-        background-color: ${colors.grey400};
+        background-color: ${colors.grey300};
     }
 
     li.destructive {
@@ -59,8 +53,8 @@ export default css`
         display: inline-flex;
         flex-grow: 1;
         align-items: center;
-        padding: 0 ${spacers.dp24};
-        min-height: 48px;
+        padding: 0 ${spacers.dp16};
+        min-height: 40px;
         text-decoration: none;
         color: inherit;
     }
@@ -88,23 +82,26 @@ export default css`
 
     .label {
         flex-grow: 1;
-        padding: 15px 0;
+        padding: ${spacers.dp12} 0;
     }
 
     li.dense .label {
-        padding: 8px 0;
+        padding: ${spacers.dp8} 0;
     }
 
     .icon {
         flex-grow: 0;
-        margin-right: ${spacers.dp16};
+        margin-right: ${spacers.dp12};
         width: 24px;
         height: 24px;
     }
 
     .chevron {
+        display: flex;
+        align-items: center;
         flex-grow: 0;
-        margin-left: ${spacers.dp48};
+        margin-left: ${spacers.dp24};
+        margin-right: -${spacers.dp12};
     }
 
     li.dense .icon {

--- a/components/menu/src/menu-item/menu-item.styles.js
+++ b/components/menu/src/menu-item/menu-item.styles.js
@@ -101,7 +101,6 @@ export default css`
         align-items: center;
         flex-grow: 0;
         margin-left: ${spacers.dp24};
-        margin-right: -${spacers.dp12};
     }
 
     li.dense .icon {

--- a/components/menu/src/menu-section-header/menu-section-header.js
+++ b/components/menu/src/menu-section-header/menu-section-header.js
@@ -26,17 +26,16 @@ const MenuSectionHeader = ({
             }
             h6 {
                 margin: 0;
-                padding: ${spacers.dp8} ${spacers.dp24} ${spacers.dp12}
-                    ${spacers.dp24};
-                font-size: 15px;
+                padding: ${spacers.dp8} ${spacers.dp16} ${spacers.dp8}
+                    ${spacers.dp16};
+                font-size: 13px;
                 line-height: 16px;
                 font-weight: 500;
-                color: ${colors.grey600};
+                color: ${colors.grey700};
             }
             li.dense h6 {
-                font-size: 14px;
-                line-height: 16px;
-                padding: ${spacers.dp8} ${spacers.dp12} 6px ${spacers.dp12};
+                padding: ${spacers.dp8} ${spacers.dp12} ${spacers.dp4}
+                    ${spacers.dp12};
             }
         `}</style>
     </li>


### PR DESCRIPTION
Implements [UX-122](https://dhis2.atlassian.net/browse/UX-122).

---

### Description

This PR makes visual style adjustments to the `MenuItem` and `MenuSectionHeader` components. These are minor changes based on seeing the components in use.

---

### Known issues

-   [x] Using a negative margin to pull the `Chevron` further to the right on items with children. Feels like a hack?

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._
