### PR TITLE
fix: wrap app names

### DIFF
--- a/components/header-bar/src/apps.js
+++ b/components/header-bar/src/apps.js
@@ -80,7 +80,6 @@ function Item({ name, path, img }) {
                     justify-content: center;
                     width: 96px;
                     margin: 8px;
-                    padding: 8px;
                     border-radius: 12px;
                     text-decoration: none;
                     cursor: pointer;
@@ -100,10 +99,12 @@ function Item({ name, path, img }) {
                 img {
                     width: 48px;
                     height: 48px;
+                    margin: 8px;
                     cursor: pointer;
                 }
 
                 div {
+                    overflow-wrap: anywhere;
                     margin-top: 14px;
                     color: rgba(0, 0, 0, 0.87);
                     font-size: 12px;


### PR DESCRIPTION
Implements [DHIS2-8651](https://dhis2.atlassian.net/browse/DHIS2-8651)

---

### Description

This is a fix to break app names when they have long names (typical in languages like Norwegian)

---

### Known issues

-   no known issues

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

I don't think these are relevant for this ticket?

---

### Screenshots

**Before**
<img width="374" alt="image" src="https://user-images.githubusercontent.com/18490902/204804683-75281c08-cc4e-466f-8e57-78b3b7b338c9.png">

**After**
<img width="358" alt="image" src="https://user-images.githubusercontent.com/18490902/204804776-3d100440-5e0f-40e0-aa6c-181829de9b77.png">

Notes:
- I have used `overflow-wrap: anywhere` rather than `word-break: break-all` (as suggested in the ticket), as `word-break: break-all` would break anywhere (where as `overflow-wrap: anywhere` tries to break at work boundaries):
<img width="341" alt="image" src="https://user-images.githubusercontent.com/18490902/204804900-7cbaad12-95eb-4125-83f5-f5ef224d0147.png">
- I have removed the padding from the anchor and instead put a margin on the img, so that the text can flow to the boundary of the anchor element. I did this to eliminate word breaks looking like they were occurring with lots of whitespace around them (e.g. with databehandling app below):
<img width="355" alt="image" src="https://user-images.githubusercontent.com/18490902/204805560-a0de4304-5d9e-4ab1-9e1e-4396b22b01ac.png">
 