### PR TITLE
docs: fix noticebox error example

### DIFF
--- a/docs/docs/components/notice-box.md
+++ b/docs/docs/components/notice-box.md
@@ -62,10 +62,10 @@ A notice box shows important information about a situation.
 -   Use to alert the user to a problem that isn't blocking the current workflow.
 -   If possible, offer an [action](#actions) to help the user fix the problem.
 
-#### Critical
+#### Error
 
 <Demo>
-    <NoticeBox critical title="Analytics tables failed">
+    <NoticeBox error title="Analytics tables failed">
         There isn't any data because there was a problem generating analytics tables.
         <br/><Button small secondary>Go to analytics tables</Button>
     </NoticeBox>


### PR DESCRIPTION
### Description

This PR fixes a documentation example for the `NoticeBox`, which was previously showing the wrong type.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._