### PR TITLE
feat(select): use selection value as a label as fallback in production

### DIFF
--- a/components/select/src/multi-select/__tests__/selection-list.test.js
+++ b/components/select/src/multi-select/__tests__/selection-list.test.js
@@ -8,13 +8,20 @@ describe('<SelectionList />', () => {
     const env = process.env
 
     beforeEach(() => {
+        // Ensure process.env is also reset for cached modules
         jest.resetModules()
-        jest.spyOn(console, 'error').mockImplementation(() => {})
         process.env = { ...env }
+
+        // Allow spying on console.error and silence rendering errors
+        jest.spyOn(console, 'error').mockImplementation(() => {})
     })
 
     afterEach(() => {
+        // Restore process.env to original state
         process.env = env
+
+        // Restore all mocks back to original values
+        jest.restoreAllMocks()
     })
 
     describe('production', () => {
@@ -54,7 +61,6 @@ describe('<SelectionList />', () => {
 
         it('log an error for a selection that is not in the options', () => {
             process.env.NODE_ENV = 'production'
-            const spy = jest.spyOn(console, 'error')
             const options = <MultiSelectOption key="1" label="one" value="1" />
             const selected = ['value']
 
@@ -67,11 +73,9 @@ describe('<SelectionList />', () => {
                 />
             )
 
-            expect(spy).toHaveBeenCalledWith(
+            expect(console.error).toHaveBeenCalledWith(
                 'There is no option with the value: "value". Make sure that all the values passed to the selected prop match the value of an existing option.'
             )
-
-            spy.mockRestore()
         })
     })
 

--- a/components/select/src/multi-select/__tests__/selection-list.test.js
+++ b/components/select/src/multi-select/__tests__/selection-list.test.js
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { MultiSelectOption } from '../../multi-select-option/index.js'
+import { SelectionList } from '../selection-list.js'
+import '@testing-library/jest-dom'
+
+describe('<SelectionList />', () => {
+    const env = process.env
+
+    beforeEach(() => {
+        jest.resetModules()
+        jest.spyOn(console, 'error').mockImplementation(() => {})
+        process.env = { ...env }
+    })
+
+    afterEach(() => {
+        process.env = env
+    })
+
+    describe('production', () => {
+        it('should not throw an error for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'production'
+            const options = <MultiSelectOption key="1" label="one" value="1" />
+            const selected = ['value']
+
+            expect(() => {
+                render(
+                    <SelectionList
+                        selected={selected}
+                        options={options}
+                        disabled={false}
+                        onChange={() => {}}
+                    />
+                )
+            }).not.toThrow()
+        })
+
+        it('should show the selection for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'production'
+            const options = <MultiSelectOption key="1" label="one" value="1" />
+            const selected = ['value']
+
+            const { getByText } = render(
+                <SelectionList
+                    selected={selected}
+                    options={options}
+                    disabled={false}
+                    onChange={() => {}}
+                />
+            )
+
+            expect(getByText(selected)).toBeInTheDocument()
+        })
+
+        it('log an error for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'production'
+            const spy = jest.spyOn(console, 'error')
+            const options = <MultiSelectOption key="1" label="one" value="1" />
+            const selected = ['value']
+
+            render(
+                <SelectionList
+                    selected={selected}
+                    options={options}
+                    disabled={false}
+                    onChange={() => {}}
+                />
+            )
+
+            expect(spy).toHaveBeenCalledWith(
+                'There is no option with the value: "value". Make sure that all the values passed to the selected prop match the value of an existing option.'
+            )
+
+            spy.mockRestore()
+        })
+    })
+
+    describe('not production', () => {
+        it('should throw an error for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'development'
+            const options = <MultiSelectOption key="1" label="one" value="1" />
+            const selected = ['value']
+
+            expect(() => {
+                render(
+                    <SelectionList
+                        selected={selected}
+                        options={options}
+                        disabled={false}
+                        onChange={() => {}}
+                    />
+                )
+            }).toThrow(
+                'There is no option with the value: "value". Make sure that all the values passed to the selected prop match the value of an existing option.'
+            )
+        })
+    })
+})

--- a/components/select/src/multi-select/selection-list.js
+++ b/components/select/src/multi-select/selection-list.js
@@ -15,6 +15,7 @@ const createRemoveHandler =
 const SelectionList = ({ selected, onChange, disabled, options }) => (
     <React.Fragment>
         {selected.map((value) => {
+            const isProduction = process.env.NODE_ENV === 'production'
             const selectedOption = findOptionChild(value, options)
 
             if (!selectedOption) {
@@ -22,11 +23,23 @@ const SelectionList = ({ selected, onChange, disabled, options }) => (
                     `There is no option with the value: "${value}". ` +
                     'Make sure that all the values passed to the selected ' +
                     'prop match the value of an existing option.'
-                throw new Error(message)
+
+                if (isProduction) {
+                    // Don't crash the app if in production
+                    console.error(message)
+                } else {
+                    // Throw error if not in production for maximum visibility
+                    throw new Error(message)
+                }
             }
 
-            // The chip should be disabled if the option or the select are disabled
-            const isDisabled = selectedOption.props.disabled || disabled
+            const isDisabled = selectedOption
+                ? // The chip should be disabled if the option or the select are disabled
+                  selectedOption.props.disabled || disabled
+                : // If there is no selected option, just look at the select
+                  disabled
+            // Use the selected value if we do not have a label
+            const label = selectedOption ? selectedOption.props.label : value
 
             // Create an onRemove handler, but only if it's not disabled
             const onRemove = isDisabled
@@ -48,7 +61,7 @@ const SelectionList = ({ selected, onChange, disabled, options }) => (
                     overflow
                     dense
                 >
-                    {selectedOption.props.label}
+                    {label}
                 </Chip>
             )
         })}

--- a/components/select/src/single-select/__tests__/selection.test.js
+++ b/components/select/src/single-select/__tests__/selection.test.js
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { SingleSelectOption } from '../../single-select-option/index.js'
+import { Selection } from '../selection.js'
+import '@testing-library/jest-dom'
+
+describe('<Selection />', () => {
+    const env = process.env
+
+    beforeEach(() => {
+        jest.resetModules()
+        jest.spyOn(console, 'error').mockImplementation(() => {})
+        process.env = { ...env }
+    })
+
+    afterEach(() => {
+        process.env = env
+    })
+
+    describe('production', () => {
+        it('should not throw an error for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'production'
+            const options = <SingleSelectOption key="1" label="one" value="1" />
+            const selected = 'value'
+
+            expect(() => {
+                render(
+                    <Selection
+                        selected={selected}
+                        options={options}
+                        disabled={false}
+                        onChange={() => {}}
+                    />
+                )
+            }).not.toThrow()
+        })
+
+        it('should show the selection for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'production'
+            const options = <SingleSelectOption key="1" label="one" value="1" />
+            const selected = 'value'
+
+            const { getByText } = render(
+                <Selection
+                    selected={selected}
+                    options={options}
+                    disabled={false}
+                    onChange={() => {}}
+                />
+            )
+
+            expect(getByText(selected)).toBeInTheDocument()
+        })
+
+        it('log an error for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'production'
+            const spy = jest.spyOn(console, 'error')
+            const options = <SingleSelectOption key="1" label="one" value="1" />
+            const selected = 'value'
+
+            render(
+                <Selection
+                    selected={selected}
+                    options={options}
+                    disabled={false}
+                    onChange={() => {}}
+                />
+            )
+
+            expect(spy).toHaveBeenCalledWith(
+                'There is no option with the value: "value". Make sure that the value passed to the selected prop matches the value of an existing option.'
+            )
+
+            spy.mockRestore()
+        })
+    })
+
+    describe('not production', () => {
+        it('should throw an error for a selection that is not in the options', () => {
+            process.env.NODE_ENV = 'development'
+            const options = <SingleSelectOption key="1" label="one" value="1" />
+            const selected = 'value'
+
+            expect(() => {
+                render(
+                    <Selection
+                        selected={selected}
+                        options={options}
+                        disabled={false}
+                        onChange={() => {}}
+                    />
+                )
+            }).toThrow(
+                'There is no option with the value: "value". Make sure that the value passed to the selected prop matches the value of an existing option.'
+            )
+        })
+    })
+})

--- a/components/select/src/single-select/__tests__/selection.test.js
+++ b/components/select/src/single-select/__tests__/selection.test.js
@@ -8,13 +8,20 @@ describe('<Selection />', () => {
     const env = process.env
 
     beforeEach(() => {
+        // Ensure process.env is also reset for cached modules
         jest.resetModules()
-        jest.spyOn(console, 'error').mockImplementation(() => {})
         process.env = { ...env }
+
+        // Allow spying on console.error and silence rendering errors
+        jest.spyOn(console, 'error').mockImplementation(() => {})
     })
 
     afterEach(() => {
+        // Restore process.env to original state
         process.env = env
+
+        // Restore all mocks back to original values
+        jest.restoreAllMocks()
     })
 
     describe('production', () => {
@@ -54,7 +61,6 @@ describe('<Selection />', () => {
 
         it('log an error for a selection that is not in the options', () => {
             process.env.NODE_ENV = 'production'
-            const spy = jest.spyOn(console, 'error')
             const options = <SingleSelectOption key="1" label="one" value="1" />
             const selected = 'value'
 
@@ -67,11 +73,9 @@ describe('<Selection />', () => {
                 />
             )
 
-            expect(spy).toHaveBeenCalledWith(
+            expect(console.error).toHaveBeenCalledWith(
                 'There is no option with the value: "value". Make sure that the value passed to the selected prop matches the value of an existing option.'
             )
-
-            spy.mockRestore()
         })
     })
 

--- a/components/select/src/single-select/selection.js
+++ b/components/select/src/single-select/selection.js
@@ -5,6 +5,7 @@ import React from 'react'
 import { findOptionChild } from '../select/index.js'
 
 const Selection = ({ options, selected, className }) => {
+    const isProduction = process.env.NODE_ENV === 'production'
     const selectedOption = findOptionChild(selected, options)
 
     if (!selectedOption) {
@@ -12,11 +13,19 @@ const Selection = ({ options, selected, className }) => {
             `There is no option with the value: "${selected}". ` +
             'Make sure that the value passed to the selected ' +
             'prop matches the value of an existing option.'
-        throw new Error(message)
+
+        if (isProduction) {
+            // Don't crash the app if in production
+            console.error(message)
+        } else {
+            // Throw error if not in production for maximum visibility
+            throw new Error(message)
+        }
     }
 
-    const icon = selectedOption.props.icon
-    const label = selectedOption.props.label
+    const icon = selectedOption && selectedOption.props.icon
+    // Use the selected value if we do not have a label
+    const label = selectedOption ? selectedOption.props.label : selected
 
     return (
         <div className={cx(className, 'root')}>


### PR DESCRIPTION
https://dhis2.atlassian.net/browse/LIBS-401

Currently this doesn't show the value in the dropdown, only in the input. That means it can be programmatically selected, but once the selection is removed the user can't select it again through the dropdown. Made the most sense to me since it isn't part of the options, so this way it fails gracefully in production, but doesn't behave too weirdly.