### PR TITLE
feat(noticebox): valid component style 

### DIFF
--- a/components/notice-box/src/features/accepts_children/index.js
+++ b/components/notice-box/src/features/accepts_children/index.js
@@ -6,7 +6,7 @@ Given('a NoticeBox receives a message as children', () => {
 })
 
 Then('the message is visible', () => {
-    cy.get('[data-test="dhis2-uicore-noticebox-message"]')
+    cy.get('[data-test="dhis2-uicore-noticebox-content-message"]')
         .contains('The noticebox content')
         .should('be.visible')
 })

--- a/components/notice-box/src/features/accepts_title/index.js
+++ b/components/notice-box/src/features/accepts_title/index.js
@@ -6,7 +6,7 @@ Given('a NoticeBox receives a title prop', () => {
 })
 
 Then('the title is visible', () => {
-    cy.get('[data-test="dhis2-uicore-noticebox-title"]')
+    cy.get('[data-test="dhis2-uicore-noticebox-content-title"]')
         .contains('The noticebox title')
         .should('be.visible')
 })

--- a/components/notice-box/src/notice-box-content.js
+++ b/components/notice-box/src/notice-box-content.js
@@ -1,0 +1,34 @@
+import { spacers } from '@dhis2/ui-constants'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { NoticeBoxMessage } from './notice-box-message.js'
+import { NoticeBoxTitle } from './notice-box-title.js'
+
+export const NoticeBoxContent = ({ children, dataTest, title }) => {
+    return (
+        <div data-test={dataTest}>
+            <NoticeBoxTitle title={title} dataTest={`${dataTest}-title`} />
+            <NoticeBoxMessage dataTest={`${dataTest}-message`}>
+                {children}
+            </NoticeBoxMessage>
+            <style jsx>{`
+                div {
+                    display: flex;
+                    flex-direction: column;
+                    gap: ${spacers.dp8};
+                    padding-top: 3px;
+                }
+            `}</style>
+        </div>
+    )
+}
+
+NoticeBoxContent.defaultProps = {
+    dataTest: 'dhis2-uicore-noticebox-content',
+}
+
+NoticeBoxContent.propTypes = {
+    children: PropTypes.node,
+    dataTest: PropTypes.string,
+    title: PropTypes.string,
+}

--- a/components/notice-box/src/notice-box-icon.js
+++ b/components/notice-box/src/notice-box-icon.js
@@ -4,14 +4,20 @@ import {
     IconErrorFilled24,
     IconWarningFilled24,
     IconInfoFilled24,
+    IconCheckmarkCircle24,
 } from '@dhis2/ui-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-export const NoticeBoxIcon = ({ warning, error, dataTest }) => {
+export const NoticeBoxIcon = ({ valid, warning, error, dataTest }) => {
     // Info is the default icon
     let color = colors.blue900
     let Icon = IconInfoFilled24
+
+    if (valid) {
+        color = colors.green700
+        Icon = IconCheckmarkCircle24
+    }
 
     if (warning) {
         color = colors.yellow700
@@ -29,6 +35,7 @@ export const NoticeBoxIcon = ({ warning, error, dataTest }) => {
 
             <style jsx>{`
                 margin-right: ${spacers.dp12};
+                height: ${spacers.dp24};
             `}</style>
         </div>
     )
@@ -36,6 +43,7 @@ export const NoticeBoxIcon = ({ warning, error, dataTest }) => {
 
 NoticeBoxIcon.propTypes = {
     dataTest: PropTypes.string.isRequired,
-    error: mutuallyExclusive(['error', 'warning'], PropTypes.bool),
-    warning: mutuallyExclusive(['error', 'warning'], PropTypes.bool),
+    error: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
+    valid: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
+    warning: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
 }

--- a/components/notice-box/src/notice-box-message.js
+++ b/components/notice-box/src/notice-box-message.js
@@ -15,7 +15,7 @@ export const NoticeBoxMessage = ({ children, dataTest }) => {
                 div {
                     color: ${colors.grey900};
                     font-size: 14px;
-                    line-height: 20px;
+                    line-height: 19px;
                 }
             `}</style>
         </div>

--- a/components/notice-box/src/notice-box-title.js
+++ b/components/notice-box/src/notice-box-title.js
@@ -1,4 +1,4 @@
-import { colors, spacers } from '@dhis2/ui-constants'
+import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
@@ -15,8 +15,8 @@ export const NoticeBoxTitle = ({ title, dataTest }) => {
                     color: ${colors.grey900};
                     font-size: 14px;
                     font-weight: 500;
-                    line-height: 20px;
-                    margin: 0 0 ${spacers.dp12} 0;
+                    line-height: 19px;
+                    margin: 0;
                 }
             `}</style>
         </h6>

--- a/components/notice-box/src/notice-box.js
+++ b/components/notice-box/src/notice-box.js
@@ -14,14 +14,16 @@ export const NoticeBox = ({
     title,
     warning,
     error,
+    valid,
 }) => {
-    const classnames = cx(className, 'root', { warning, error })
+    const classnames = cx(className, 'root', { warning, error, valid })
 
     return (
         <div className={classnames} data-test={dataTest}>
             <NoticeBoxIcon
                 error={error}
                 warning={warning}
+                valid={valid}
                 dataTest={`${dataTest}-icon`}
             />
             <div>
@@ -49,6 +51,11 @@ export const NoticeBox = ({
                     background: ${colors.red050};
                     border: 2px solid ${colors.red500};
                 }
+
+                .root.valid {
+                    background: ${colors.green050};
+                    border: 1px solid ${colors.green200};
+                }
             `}</style>
         </div>
     )
@@ -62,9 +69,11 @@ NoticeBox.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
-    /** Applies 'error' message styles. Mutually exclusive with the `warning` prop */
-    error: mutuallyExclusive(['error', 'warning'], PropTypes.bool),
+    /** Applies 'error' message styles. Mutually exclusive with the `error` and `warning` prop */
+    error: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
+    /** Applies 'error' message styles. Mutually exclusive with the `error` and `warning` prop */
     title: PropTypes.string,
-    /** Applies 'warning' message styles. Mutually exclusive with the `error` prop */
-    warning: mutuallyExclusive(['error', 'warning'], PropTypes.bool),
+    valid: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
+    /** Applies 'error' message styles. Mutually exclusive with the `error` and `warning` prop */
+    warning: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
 }

--- a/components/notice-box/src/notice-box.js
+++ b/components/notice-box/src/notice-box.js
@@ -70,11 +70,11 @@ NoticeBox.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
-    /** Applies 'error' message styles. Mutually exclusive with the `error` and `warning` prop */
+    /** Applies 'error' message styles. Mutually exclusive with the `valid` and `warning` props */
     error: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
-    /** Applies 'error' message styles. Mutually exclusive with the `error` and `warning` prop */
     title: PropTypes.string,
+    /** Applies 'valid' message styles. Mutually exclusive with the `error` and `warning` props */
     valid: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
-    /** Applies 'error' message styles. Mutually exclusive with the `error` and `warning` prop */
+    /** Applies 'warning' message styles. Mutually exclusive with the `error` and `valid` props */
     warning: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
 }

--- a/components/notice-box/src/notice-box.js
+++ b/components/notice-box/src/notice-box.js
@@ -3,9 +3,8 @@ import { spacers, colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { NoticeBoxContent } from './notice-box-content.js'
 import { NoticeBoxIcon } from './notice-box-icon.js'
-import { NoticeBoxMessage } from './notice-box-message.js'
-import { NoticeBoxTitle } from './notice-box-title.js'
 
 export const NoticeBox = ({
     className,
@@ -27,10 +26,12 @@ export const NoticeBox = ({
                 dataTest={`${dataTest}-icon`}
             />
             <div>
-                <NoticeBoxTitle title={title} dataTest={`${dataTest}-title`} />
-                <NoticeBoxMessage dataTest={`${dataTest}-message`}>
+                <NoticeBoxContent
+                    title={title}
+                    dataTest={`${dataTest}-content`}
+                >
                     {children}
-                </NoticeBoxMessage>
+                </NoticeBoxContent>
             </div>
 
             <style jsx>{`

--- a/components/notice-box/src/notice-box.stories.js
+++ b/components/notice-box/src/notice-box.stories.js
@@ -35,6 +35,7 @@ export default {
     argTypes: {
         error: { ...sharedPropTypes.statusArgType },
         warning: { ...sharedPropTypes.statusArgType },
+        valid: { ...sharedPropTypes.statusArgType },
     },
 }
 
@@ -45,6 +46,16 @@ export const Default = (args) => (
     </NoticeBox>
 )
 Default.args = { title: 'Your database was updated in the last 24 hours' }
+
+export const Valid = (args) => (
+    <NoticeBox {...args}>
+        Programs using these rules are updated automatically.
+    </NoticeBox>
+)
+Valid.args = {
+    valid: true,
+    title: 'Program rules exported successfully',
+}
 
 export const Warning = (args) => (
     <NoticeBox {...args}>

--- a/components/notice-box/src/notice-box.stories.js
+++ b/components/notice-box/src/notice-box.stories.js
@@ -89,3 +89,11 @@ export const WithALongTitle = (args) => (
     <NoticeBox {...args}>The title text will wrap</NoticeBox>
 )
 WithALongTitle.args = { error: true, title: text }
+
+export const WithoutTitle = () => (
+    <NoticeBox>This noticebox does not have a title.</NoticeBox>
+)
+
+export const TitleOnly = () => (
+    <NoticeBox title="This noticebox has only a title"></NoticeBox>
+)

--- a/docs/docs/components/notice-box.md
+++ b/docs/docs/components/notice-box.md
@@ -39,6 +39,7 @@ A notice box shows important information about a situation.
 | `info`    | Default. Use for important, but not problematic or critical information. |
 | `warning` | Use for problems that require user attention, but are non-critical       |
 | `error`   | Use for critical problems or errors that relate to the current context.  |
+| `valid`   | Use for positive information, like successful or completed processes.    |
 
 #### Information
 
@@ -73,6 +74,17 @@ A notice box shows important information about a situation.
 
 -   Use to alert the user to a problem or error that's blocking the current workflow.
 -   If possible, offer an [action](#actions) to help the user fix the problem.
+
+#### Valid
+
+<Demo>
+    <NoticeBox valid title="Password reset successfully">
+        Your password has been reset. You can log in with your username and password.
+    </NoticeBox>
+</Demo>
+
+-   Use to inform the user that an important action is complete, or the process was successful.
+-   Only use when the information needs to stay on screen. In most `valid` cases, using an [alert bar](./alertbar.md) is a better choice.
 
 ### Format
 


### PR DESCRIPTION
Implements [UX-134](https://dhis2.atlassian.net/browse/UX-134) and [UX-135](https://dhis2.atlassian.net/browse/UX-135)

---

### Description

This PR makes changes to the noticebox component:
- adds a `valid` style for positive, success-type messages.
- adjusts the spacing of the `title` and `message`, so they appear vertically centered with the icon regardless of whether only the title, only the message, or both are present.
    - this required introducing a new wrapper component, `notice-box-content`, rather that leak the styles into the root component.
---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

[UX-134]: https://dhis2.atlassian.net/browse/UX-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UX-135]: https://dhis2.atlassian.net/browse/UX-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ