### PR TITLE
fix: bump multi-calendar-dates to avoid jest error

### DIFF
--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -35,7 +35,7 @@
         "@dhis2-ui/input": "8.10.0",
         "@dhis2-ui/layer": "8.10.0",
         "@dhis2-ui/popper": "8.10.0",
-        "@dhis2/multi-calendar-dates": "1.0.0-alpha.17",
+        "@dhis2/multi-calendar-dates": "1.0.0-alpha.18",
         "@dhis2/prop-types": "^3.1.2",
         "@dhis2/ui-constants": "8.10.0",
         "@dhis2/ui-icons": "8.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,10 +2586,10 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/multi-calendar-dates@1.0.0-alpha.17":
-  version "1.0.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-alpha.17.tgz#d3fa19ef38ed85040d4798edc96911a15321b90a"
-  integrity sha512-fwjQo3PEAZbEP6NDWUSQjAQlFxGPc1NWW9Hu13QGhTv1MvMu7EazbsH57n26qZVp2AROdxVPpXUKWv5AEuKWng==
+"@dhis2/multi-calendar-dates@1.0.0-alpha.18":
+  version "1.0.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-alpha.18.tgz#341176f1ffb0a4663dd5b882e587403d6dc7fbda"
+  integrity sha512-0m8HcH3j7/FRXdZ+tgnnFjDdoC05JEKsm6XH7m+JZOJlfWshNTrYU5l1JzFumiNO3teFkBS/uFgSZHu7UbKeng==
   dependencies:
     "@js-temporal/polyfill" "^0.4.2"
     classnames "^2.3.2"


### PR DESCRIPTION
bumps `multi-calendar-dates` to version that emits both cjs and es modules to support cjs generally, but more specifically, to avoid having to add `transformIgnorePatterns` to the `jest` configuration of libraries that consume multi-calendar-dates either directly, or through the dhis/ui library.

related to https://github.com/dhis2/multi-calendar-dates/pull/10
