### PR TITLE
fix: include .md extension for relative links

### DIFF
--- a/docs/docs/components/calendar-input.md
+++ b/docs/docs/components/calendar-input.md
@@ -117,7 +117,7 @@ Ethiopic calendar (with narrow day names, short day names and localised to Engli
 
 ## API Reference
 
-The component takes the same props as [the calendar](./calendar) component, as well as the props for [InputField](./inputfield) that are relevant to an input of type `text`.
+The component takes the same props as [the calendar](./calendar.md) component, as well as the props for [InputField](./inputfield.md) that are relevant to an input of type `text`.
 
 It adds one property `clearable` which is a boolean. If set to true, it adds a clear button to delete the selected date.
 


### PR DESCRIPTION
Relative links without the .md extension break when there is a trailing slash in the browser URL:

`https://ui.dhis2.nu/components/calendar-input` + `./calendar` => `https://ui.dhis2.nu/components/calendar` `https://ui.dhis2.nu/components/calendar-input/` + `./calendar` => `https://ui.dhis2.nu/components/calendar-input/calendar`

Docusaurus should handle this for us properly by resolving absolute link targets when the source file references another .md in the source (bonus: this should also work when browsing the docs source on github)

See https://github.com/facebook/docusaurus/issues/2298

Implements [JIRA_ISSUE_ID](https://dhis2.atlassian.net/browse/JIRA_ISSUE_ID)

---

### Description

_text_

---

### Known issues

-   [ ] _issue_

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

_supporting text_
