### PR TITLE
fix(calendar): design adjustments

### DIFF
--- a/components/calendar/src/calendar/calendar-table-cell.js
+++ b/components/calendar/src/calendar/calendar-table-cell.js
@@ -49,6 +49,9 @@ export const CalendarTableCell = ({ day, cellSize, selectedDate }) => {
                     background-color: ${dayHoverBackgroundColor};
                     text-decoration: underline;
                 }
+                button:active {
+                    background-color: ${colors.grey300};
+                }
                 button.isSelected,
                 button.otherMonth.isSelected {
                     background-color: ${selectedDayBackgroundColor};

--- a/components/calendar/src/calendar/calendar-table-cell.js
+++ b/components/calendar/src/calendar/calendar-table-cell.js
@@ -1,4 +1,4 @@
-import { colors, spacers } from '@dhis2/ui-constants'
+import { colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -43,7 +43,6 @@ export const CalendarTableCell = ({ day, cellSize, selectedDate }) => {
                     border: 2px solid transparent;
                     border-radius: 3px;
                     background: none;
-                    margin: ${spacers.dp2};
                     color: ${colors.grey900};
                 }
                 button:hover {

--- a/components/calendar/src/calendar/calendar-table-cell.js
+++ b/components/calendar/src/calendar/calendar-table-cell.js
@@ -56,7 +56,21 @@ export const CalendarTableCell = ({ day, cellSize, selectedDate }) => {
                     color: white;
                 }
                 button.isToday {
-                    text-decoration: underline;
+                    position: relative;
+                }
+                button.isToday::after {
+                    content: '';
+                    position: absolute;
+                    transform: translateX(-50%);
+                    height: 4px;
+                    width: 4px;
+                    bottom: 2px;
+                    left: 50%;
+                    border-radius: 100%;
+                    background-color: ${colors.teal600};
+                }
+                button.isSelected.isToday::after {
+                    background-color: ${colors.teal200};
                 }
                 button.otherMonth {
                     color: ${colors.grey600};

--- a/components/calendar/src/calendar/calendar-table-days-header.js
+++ b/components/calendar/src/calendar/calendar-table-days-header.js
@@ -25,6 +25,7 @@ export const CalendarTableDaysHeader = ({ weekDayLabels }) => {
                     background: none;
                     font-size: 0.85em;
                     border: none;
+                    cursor: default;
                 }
                 tr {
                     border: none;

--- a/components/calendar/src/calendar/navigation-container.js
+++ b/components/calendar/src/calendar/navigation-container.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../locales/index.js'
 
-const chevronColor = colors.grey600
 const wrapperBorderColor = colors.grey300
 const headerBackground = colors.grey050
 
@@ -14,8 +13,14 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
     const NextIcon =
         languageDirection === 'ltr' ? IconChevronRight16 : IconChevronLeft16
 
-    const { currMonth, currYear, nextMonth, nextYear, prevMonth, prevYear } =
-        pickerOptions
+    const {
+        currMonth,
+        currYear,
+        nextMonth,
+        nextYear,
+        prevMonth,
+        prevYear,
+    } = pickerOptions
 
     return (
         <>
@@ -29,7 +34,7 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
                             aria-label={`${i18n.t(`Go to ${prevMonth.label}`)}`}
                             type="button"
                         >
-                            <PreviousIcon color={chevronColor} />
+                            <PreviousIcon />
                         </button>
                     </div>
                     <div className="curr">
@@ -43,7 +48,7 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
                             aria-label={`${i18n.t(`Go to ${nextMonth.label}`)}`}
                             type="button"
                         >
-                            <NextIcon color={chevronColor} />
+                            <NextIcon />
                         </button>
                     </div>
                 </div>
@@ -55,7 +60,7 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
                             aria-label={`${i18n.t('Go to previous year')}`}
                             type="button"
                         >
-                            <PreviousIcon color={chevronColor} />
+                            <PreviousIcon />
                         </button>
                     </div>
                     <div className="curr">
@@ -68,7 +73,7 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
                             aria-label={`${i18n.t('Go to next year')}`}
                             type="button"
                         >
-                            <NextIcon color={chevronColor} />
+                            <NextIcon />
                         </button>
                     </div>
                 </div>
@@ -102,12 +107,28 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
                 .prev button,
                 .next button {
                     padding: ${spacers.dp4};
+                    height: 24px;
+                    width: 24px;
+                    color: ${colors.grey600};
+                    border-radius: 3px;
+                }
+
+                .prev button svg,
+                .next button svg {
+                    width: 16px;
+                    height: 16px;
                 }
 
                 .prev:hover button,
                 .next:hover button {
                     background-color: ${colors.grey200};
+                    color: ${colors.grey900};
                     cursor: pointer;
+                }
+
+                .prev button:active,
+                .next button:active {
+                    background-color: ${colors.grey300};
                 }
 
                 .label {

--- a/components/calendar/src/calendar/navigation-container.js
+++ b/components/calendar/src/calendar/navigation-container.js
@@ -13,14 +13,8 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
     const NextIcon =
         languageDirection === 'ltr' ? IconChevronRight16 : IconChevronLeft16
 
-    const {
-        currMonth,
-        currYear,
-        nextMonth,
-        nextYear,
-        prevMonth,
-        prevYear,
-    } = pickerOptions
+    const { currMonth, currYear, nextMonth, nextYear, prevMonth, prevYear } =
+        pickerOptions
 
     return (
         <>
@@ -139,7 +133,6 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
                 }
 
                 .navigation-container {
-                    height: ${spacers.dp36};
                     gap: ${spacers.dp8};
                     padding: ${spacers.dp4};
                     display: flex;

--- a/components/calendar/src/calendar/navigation-container.js
+++ b/components/calendar/src/calendar/navigation-container.js
@@ -84,6 +84,7 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
                     width: 100%;
                     align-items: center;
                     justify-content: center;
+                    cursor: default;
                 }
 
                 .month .curr,


### PR DESCRIPTION
### Description

This PR makes some minor design changes to the `Calendar` component:
- Use default cursor when hovering day name, months, and years labels.
- Adjust styling for previous and next navigation buttons
- Adjust styling of `Today` to prevent conflict with day hover style.
- Remove a couple of invalid `spacer` variables that weren't being applied and are not needed.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._