### PR TITLE
fix(organisation-unit-tree): silence static query warning

### DIFF
--- a/components/organisation-unit-tree/src/organisation-unit-tree/use-root-org-data/use-root-org-data.js
+++ b/components/organisation-unit-tree/src/organisation-unit-tree/use-root-org-data/use-root-org-data.js
@@ -26,7 +26,7 @@ export const createRootQuery = (ids) =>
  * @returns {Object}
  */
 export const useRootOrgData = (ids, { isUserDataViewFallback } = {}) => {
-    const query = createRootQuery(ids)
+    const query = useMemo(() => createRootQuery(ids), [ids])
     const variables = { isUserDataViewFallback }
     const rootOrgUnits = useDataQuery(query, {
         variables,


### PR DESCRIPTION
### Description

Workaround for silencing the warning about queries not being static.
It was initially suggested by @amcgee and it's used in other places.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

This is the console log in from the storybook org unit example when expanding the root node (before the fix):

<img width="1032" alt="Screenshot 2023-03-21 at 11 33 53" src="https://user-images.githubusercontent.com/150978/226581965-6bdc5482-0801-4245-8948-f5eaba47cf7d.png">


