### PR TITLE
chore(deps): add i18n dependency

### DIFF
--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -27,6 +27,7 @@
     },
     "peerDependencies": {
         "react": "^16.8",
+        "@dhis2/d2-i18n": "^1",
         "react-dom": "^16.8",
         "styled-jsx": "^4"
     },
@@ -47,6 +48,7 @@
         "build"
     ],
     "devDependencies": {
+        "@dhis2/d2-i18n": "^1.1.0",
         "react": "16.13",
         "react-dom": "16.13",
         "styled-jsx": "^4.0.1"


### PR DESCRIPTION
Without this dependency, the `yarn setup` command from the project root will fail with the following error message:
```
Module not found: Error: Can't resolve '../locales/index.js' in '/Users/hendrik/Apps/ui/components/calendar/src/calendar-input'
```