### PR TITLE
feat: add dataTest prop to icons

### DIFF
--- a/icons/svgr.config.js
+++ b/icons/svgr.config.js
@@ -13,6 +13,7 @@ module.exports = {
     // Pass the color prop on to the root svg node
     svgProps: {
         color: '{color}',
+        ['data-test']: '{dataTest}',
     },
 
     // Compress svgs

--- a/icons/templates/icon-template.js
+++ b/icons/templates/icon-template.js
@@ -12,15 +12,16 @@ function template(
     const tpl = template.smart({ plugins })
 
     return tpl.ast`
-        ${imports}
         import PropTypes from 'prop-types'
+        ${imports}
 
-        function ${componentName}({ color }) {
+        function ${componentName}({ color, dataTest }) {
             return ${jsx};
         }
 
         ${componentName}.propTypes = {
             color: PropTypes.string,
+            dataTest: PropTypes.string,
         }
 
         ${exports}


### PR DESCRIPTION
After running `yarn build`, the generated components now look like this:

```jsx
import PropTypes from 'prop-types'
import * as React from 'react'

function SvgAdd16({ color, dataTest }) {
    return (
        <svg
            height={16}
            viewBox="0 0 16 16"
            width={16}
            xmlns="http://www.w3.org/2000/svg"
            color={color}
            data-test={dataTest}
        >
            <path
                d="M8 2a1 1 0 011 1v4h4a1 1 0 010 2H9v4a1 1 0 01-2 0V9H3a1 1 0 110-2h4V3a1 1 0 011-1z"
                fill="currentColor"
                fillRule="evenodd"
            />
        </svg>
    )
}

SvgAdd16.propTypes = {
    color: PropTypes.string,
    dataTest: PropTypes.string,
}
export default SvgAdd16
```
