### PR TITLE
feat(menu): add prop to open flyout menu on hover

### DIFF
--- a/components/menu/src/flyout-menu/features/toggles_submenus_on_hover.feature
+++ b/components/menu/src/flyout-menu/features/toggles_submenus_on_hover.feature
@@ -1,0 +1,9 @@
+Feature: The FlyoutMenu toggles SubMenus
+
+    Scenario: a FlyoutMenu with two SubMenus and openSubmenuOnHover enabled
+        Given a FlyoutMenu with two SubMenus is rendered
+        When the user hovers the first SubMenu anchor
+        Then first SubMenu is visible
+        When the user hovers the second SubMenu anchor
+        Then second SubMenu is visible
+        And the first SubMenu is not rendered

--- a/components/menu/src/flyout-menu/features/toggles_submenus_on_hover/index.js
+++ b/components/menu/src/flyout-menu/features/toggles_submenus_on_hover/index.js
@@ -1,0 +1,26 @@
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a FlyoutMenu with two SubMenus is rendered', () => {
+    cy.visitStory('FlyoutMenu', 'Toggles Sub Menus On Hover')
+    cy.get('[data-test="dhis2-uicore-menu"]').should('be.visible')
+})
+
+When('the user hovers the first SubMenu anchor', () => {
+    cy.contains('Item 1').trigger('mouseover')
+})
+
+Then('first SubMenu is visible', () => {
+    cy.contains('SubMenu 1').should('be.visible')
+})
+
+When('the user hovers the second SubMenu anchor', () => {
+    cy.contains('Item 2').trigger('mouseover')
+})
+
+Then('second SubMenu is visible', () => {
+    cy.contains('SubMenu 2').should('be.visible')
+})
+
+Then('the first SubMenu is not rendered', () => {
+    cy.contains('SubMenu 1').should('not.exist')
+})

--- a/components/menu/src/flyout-menu/flyout-menu.js
+++ b/components/menu/src/flyout-menu/flyout-menu.js
@@ -10,6 +10,7 @@ const FlyoutMenu = ({
     dense,
     maxHeight,
     maxWidth,
+    openSubmenuOnHover,
 }) => {
     const [openedSubMenu, setOpenedSubMenu] = useState(null)
     const toggleSubMenu = (index) => {
@@ -25,6 +26,7 @@ const FlyoutMenu = ({
                         ? cloneElement(child, {
                               showSubMenu: openedSubMenu === index,
                               toggleSubMenu: toggleSubMenu.bind(this, index),
+                              openSubmenuOnHover: !!openSubmenuOnHover,
                           })
                         : child
                 )}
@@ -63,6 +65,7 @@ FlyoutMenu.propTypes = {
     dense: PropTypes.bool,
     maxHeight: PropTypes.string,
     maxWidth: PropTypes.string,
+    openSubmenuOnHover: PropTypes.bool,
 }
 
 export { FlyoutMenu }

--- a/components/menu/src/flyout-menu/flyout-menu.stories.e2e.js
+++ b/components/menu/src/flyout-menu/flyout-menu.stories.e2e.js
@@ -24,6 +24,13 @@ export const TogglesSubMenus = () => (
     </FlyoutMenu>
 )
 
+export const TogglesSubMenusOnHover = () => (
+    <FlyoutMenu openSubmenuOnHover>
+        <MenuItem label="Item 1">SubMenu 1</MenuItem>
+        <MenuItem label="Item 2">SubMenu 2</MenuItem>
+    </FlyoutMenu>
+)
+
 export const DefaultPosition = () => <MenuItemSubMenuPositions />
 export const FlippedPosition = () => (
     <div>

--- a/components/menu/src/flyout-menu/flyout-menu.stories.js
+++ b/components/menu/src/flyout-menu/flyout-menu.stories.js
@@ -114,7 +114,41 @@ export const WithSubMenus = (args) => (
 WithSubMenus.parameters = {
     docs: {
         description: {
-            story: 'See this demo in the Canvas tab for proper alignment of sub menus.',
+            story:
+                'See this demo in the Canvas tab for proper alignment of sub menus.',
+        },
+    },
+}
+
+export const WithHoverableSubMenus = (args) => (
+    <FlyoutMenu {...args}>
+        <MenuItem label="Item 1" />
+        <MenuItem label="Item 2">
+            <MenuItem label="Item 2 a" />
+            <MenuItem label="Item 2 b">
+                <MenuItem label="Item 2 b i" />
+                <MenuItem label="Item 2 b ii" />
+            </MenuItem>
+            <MenuItem label="Item 2 c" />
+        </MenuItem>
+        <MenuItem label="Item 3" />
+        <MenuItem label="Item 4">
+            <MenuItem label="Item 4 a" />
+            <MenuItem label="Item 4 b">
+                <MenuItem label="Item 4 b i" />
+                <MenuItem label="Item 4 b ii" />
+            </MenuItem>
+            <MenuItem label="Item 4 c" />
+        </MenuItem>
+        <MenuItem label="Item 5" />
+    </FlyoutMenu>
+)
+WithHoverableSubMenus.args = { openSubmenuOnHover: true }
+WithHoverableSubMenus.parameters = {
+    docs: {
+        description: {
+            story:
+                'See this demo in the Canvas tab for proper alignment of sub menus.',
         },
     },
 }
@@ -152,7 +186,8 @@ export const WithVariousChildren = (args) => (
 WithVariousChildren.parameters = {
     docs: {
         description: {
-            story: 'See this demo in the Canvas tab for proper alignment of sub menus.',
+            story:
+                'See this demo in the Canvas tab for proper alignment of sub menus.',
         },
     },
 }

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -22,6 +22,7 @@ const createOnClickHandler =
         onClick && onClick({ value }, evt)
         toggleSubMenu && toggleSubMenu()
     }
+    
 const MenuItem = ({
     href,
     onClick,
@@ -35,6 +36,7 @@ const MenuItem = ({
     active,
     dataTest,
     chevron,
+    openSubmenuOnHover,
     value,
     label,
     showSubMenu,
@@ -68,6 +70,11 @@ const MenuItem = ({
                               })
                             : undefined
                     }
+                    onMouseEnter={
+                        openSubmenuOnHover && !disabled
+                            ? toggleSubMenu
+                            : undefined
+                    }
                 >
                     {icon && <span className="icon">{icon}</span>}
 
@@ -85,7 +92,12 @@ const MenuItem = ({
             {children && showSubMenu && (
                 <Portal>
                     <Popper placement="right-start" reference={menuItemRef}>
-                        <FlyoutMenu dense={dense}>{children}</FlyoutMenu>
+                        <FlyoutMenu
+                            dense={dense}
+                            openSubmenuOnHover={openSubmenuOnHover}
+                        >
+                            {children}
+                        </FlyoutMenu>
                     </Popper>
                 </Portal>
             )}
@@ -116,6 +128,8 @@ MenuItem.propTypes = {
     icon: PropTypes.node,
     /** Text in the menu item */
     label: PropTypes.node,
+    /** When true, nested menu items will show when hovering the paren menu */
+    openSubmenuOnHover: PropTypes.bool,
     /** When true, nested menu items are shown in a Popper */
     showSubMenu: PropTypes.bool,
     /** For using menu item as a link */


### PR DESCRIPTION
### Description

This PR adds the `openSubmenuOnHover` prop to the `FlyoutMenu` and `MenuItem` component. When this prop is added menus will open by hovering *instead of clicking*.

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

---
