### PR TITLE
translation: add translation for selector-bar

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -37,6 +37,13 @@ source_lang  = en
 type         = PO
 minimum_perc = 0
 
+[o:hisp-uio:p:app-component-ui:r:selector-bar]
+file_filter   = components/selector-bar/i18n/<lang>.po
+source_file   = components/selector-bar/i18n/en.pot
+source_lang  = en
+type          = POT
+minimum_perc  = 0
+
 [o:hisp-uio:p:app-component-ui:r:sharing-dialog]
 file_filter  = components/sharing-dialog/i18n/<lang>.po
 source_file  = components/sharing-dialog/i18n/en.pot


### PR DESCRIPTION
Adds `selector-bar` as a resource.


---

### Description

Would it be possible to do this so all components are included, instead of having to manually add each component to the config?


---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

