### PR TITLE
fix: update input-type component styles

### DIFF
--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -22,6 +22,7 @@ const styles = css`
         color: ${colors.grey900};
         background-color: white;
 
+        padding: 11px 12px;
         max-height: 40px;
 
         outline: 0;
@@ -33,6 +34,7 @@ const styles = css`
 
     input.dense {
         max-height: 32px;
+        padding: 7px 8px;
     }
 
     input:focus {

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -22,7 +22,7 @@ const styles = css`
         color: ${colors.grey900};
         background-color: white;
 
-        padding: 12px 11px 10px;
+        max-height: 40px;
 
         outline: 0;
         border: 1px solid ${colors.grey500};
@@ -32,7 +32,7 @@ const styles = css`
     }
 
     input.dense {
-        padding: 8px 11px 6px;
+        max-height: 32px;
     }
 
     input:focus {

--- a/components/select/src/multi-select/multi-select.stories.js
+++ b/components/select/src/multi-select/multi-select.stories.js
@@ -135,6 +135,14 @@ WithInitialFocus.args = { initialFocus: true }
 WithInitialFocus.parameters = { docs: { disable: true } }
 WithInitialFocus.storyName = 'With initialFocus'
 
+export const Dense = WithOptionsTemplate.bind({})
+Dense.args = { dense: true, placeholder: 'Dense sized multi select' }
+Dense.storyName = 'Dense'
+
+export const DenseWithSelections = WithOptionsTemplate.bind({})
+DenseWithSelections.args = { dense: true, selected: ['1', '2'] }
+DenseWithSelections.storyName = 'Dense with selections'
+
 export const Empty = EmptyTemplate.bind({})
 
 export const EmptyWithEmptyText = EmptyTemplate.bind({})

--- a/components/select/src/select/input-wrapper.js
+++ b/components/select/src/select/input-wrapper.js
@@ -78,7 +78,7 @@ const InputWrapper = ({
                 }
 
                 .root.dense {
-                    padding: 4px 8px;
+                    padding: 2px 8px;
                     min-height: 32px;
                 }
 

--- a/components/select/src/select/input-wrapper.js
+++ b/components/select/src/select/input-wrapper.js
@@ -48,7 +48,7 @@ const InputWrapper = ({
                     display: flex;
                     min-height: 40px;
                     padding: 6px 12px;
-                    box-shadow: inset 0 1px 2px 0 rgba(48, 54, 60, 0.1);
+                    box-shadow: inset 0 0 1px 0 rgba(48, 54, 60, 0.1);
                 }
 
                 .root:not(.disabled):focus,

--- a/components/select/src/single-select/single-select.stories.js
+++ b/components/select/src/single-select/single-select.stories.js
@@ -133,6 +133,10 @@ WithInitialFocus.args = { initialFocus: true }
 WithInitialFocus.parameters = { docs: { disable: true } }
 WithInitialFocus.storyName = 'With initialFocus'
 
+export const Dense = WithOptionsTemplate.bind({})
+Dense.args = { dense: true, placeholder: 'Dense sized select' }
+Dense.storyName = 'Dense'
+
 export const Empty = EmptyTemplate.bind({})
 
 export const EmptyWithEmptyText = EmptyTemplate.bind({})

--- a/components/text-area/src/text-area/text-area.styles.js
+++ b/components/text-area/src/text-area/text-area.styles.js
@@ -15,17 +15,16 @@ export const styles = css`
 
         border: 1px solid ${colors.grey500};
         border-radius: 3px;
-        box-shadow: inset 0 0 0 1px rgba(102, 113, 123, 0.15),
-            inset 0 1px 2px 0 rgba(102, 113, 123, 0.1);
+        box-shadow: inset 0 0 1px 0 rgba(48, 54, 60, 0.1);
         outline: 0;
 
         font-size: 14px;
-        line-height: 16px;
+        line-height: 17px;
         user-select: text;
     }
 
     textarea.dense {
-        padding: 4px 12px;
+        padding: 6px 8px;
     }
 
     textarea:focus {


### PR DESCRIPTION
### Description

This PR updates styles for input-type components. Existing styles were inconsistent or buggy. 

Overview of changes:
- `Input` was 1px taller in Firefox at both `regular` and `dense` sizes. I've resorted to `max-height` to fix this, as nothing else worked.
    - I can't imagine using `max-height` being problematic because this is always a single line input, but just want to check this is OK?
- `SingleSelect` and `MultiSelect` `dense` sizes changed from `34px` to the correct `32px`.
- Adjusted some `box-shadow`s.
- `Textarea` padding, lineheight updated.
- Added some storybook demos for easier testing.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._
