### PR TITLE
fix(transfer): do not assume selected can be mapped

### DIFF
--- a/components/transfer/src/transfer.js
+++ b/components/transfer/src/transfer.js
@@ -138,14 +138,21 @@ export const Transfer = ({
      * Extract the selected options. Can't use `options.filter`
      * because we need to keep the order of `selected`
      */
-    const pickedOptions = actualFilterPickedCallback(
-        selected
-            .map((value) => options.find((option) => value === option.value))
-            // filter -> in case a selected value has been provided
-            // that does not exist as option
-            .filter(identity),
-        actualFilterPicked
-    )
+    let pickedOptions = []
+
+    // Only map if selected is an array
+    if (Array.isArray(selected)) {
+        pickedOptions = actualFilterPickedCallback(
+            selected
+                .map((value) =>
+                    options.find((option) => value === option.value)
+                )
+                // filter -> in case a selected value has been provided
+                // that does not exist as option
+                .filter(identity),
+            actualFilterPicked
+        )
+    }
 
     /*
      * Source options highlighting:


### PR DESCRIPTION
This fixes a catch-22 I'm encountering with the transfer in combination with final-form. The transfer expects `selected` to be an array (i.e. not undefined). I think it would be good to make it more robust and not assume that selected is passed.

To fix the above in an app it's not too much trouble to supply an `initialValue` for a field with final-form, which is what I did initially. The problem is that an initialValue on a final-form field overrides the form's `initialValues` property.

Passing initialValues to a form is how you'd commonly seed a form with values if it's an edit form. So supplying an initialValue to the transfer based field fixes the transfer crashing if selected is not present, but it breaks the initialValues workflow for seeding an entire form with server-side values.

Now I could continue fixing this in the app with more convoluted solutions, but I thought I'd fix it at the source.