### PR TITLE
fix: select-field not showing in correct place

### DIFF
--- a/components/select/src/select/menu-wrapper.js
+++ b/components/select/src/select/menu-wrapper.js
@@ -13,7 +13,7 @@ const MenuWrapper = ({
     selectRef,
 }) => {
     return (
-        <Layer onBackdropClick={onClick} transparent>
+        <Layer onBackdropClick={onClick} transparent disablePortal>
             <Popper
                 reference={selectRef}
                 placement="bottom-start"

--- a/components/select/src/single-select-field/features/can_show_conditionally.feature
+++ b/components/select/src/single-select-field/features/can_show_conditionally.feature
@@ -1,0 +1,7 @@
+Feature: Position of SelectField
+
+    Scenario: Keeps position when parent is hidden initially
+        Given a Select is hidden initially
+        When someone hovers over it to show it
+        And clicks the select
+        Then the select dropdown should be in the correct position

--- a/components/select/src/single-select-field/features/can_show_conditionally/index.js
+++ b/components/select/src/single-select-field/features/can_show_conditionally/index.js
@@ -1,0 +1,24 @@
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor'
+
+Given('a Select is hidden initially', () => {
+    cy.visitStory('SingleSelectField', 'With hidden parent')
+})
+
+When('someone hovers over it to show it', () => {
+    cy.get('.container .hiddenSelect').invoke('attr', 'style', 'display: block')
+})
+
+When('clicks the select', () => {
+    cy.get('[data-test="dhis2-uicore-select"]').click()
+})
+
+Then('the select dropdown should be in the correct position', () => {
+    cy.get('[data-test="hoverable-select-field"]').should('be.visible')
+    cy.get('[data-test="dhis2-uicore-singleselectoption"]').should(
+        ($selectField) => {
+            const { top, left } = $selectField.offset()
+            expect(top).to.be.greaterThan(0)
+            expect(left).to.be.greaterThan(0)
+        }
+    )
+})

--- a/components/select/src/single-select-field/single-select-field.e2e.stories.js
+++ b/components/select/src/single-select-field/single-select-field.e2e.stories.js
@@ -43,3 +43,42 @@ export const WithFilterable = () => (
 )
 export const WithLoading = () => <SingleSelectField loading />
 export const WithoutOptions = () => <SingleSelectField />
+
+export const WithHiddenParent = () => {
+    return (
+        <>
+            <div className="container">
+                <div className="hoverSpan">
+                    <span>Hover over me</span>
+                    <div className="hiddenSelect">
+                        <SingleSelectField
+                            dataTest="hoverable-select-field"
+                            label="Choose something"
+                            onChange={() => {}}
+                        >
+                            <SingleSelectOption value="1" label="one" />
+                            <SingleSelectOption value="2" label="two" />
+                        </SingleSelectField>
+                    </div>
+                </div>
+            </div>
+            <style jsx>{`
+                .container {
+                    width: 100%;
+                    height: 100%;
+                    display: flex;
+                    flex-direction: column;
+                    align-items: center;
+                    justify-content: center;
+                    font-size: 1rem;
+                }
+                .hiddenSelect {
+                    display: none;
+                }
+                .hoverSpan:hover .hiddenSelect {
+                    display: block;
+                }
+            `}</style>
+        </>
+    )
+}


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/LIBS-532

This fix involves disabling portal for the Select Menu Wrapper. 

###  Other explored solutions
I looked mainly at ensuring the ref is updated before when the parent is show, by using a callback ref (similar to [this](https://react.dev/reference/react-dom/components/common#ref-callback) and [this](https://legacy.reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node)). But there were complications, the first is that this technique works only with functional componet, I tried the class-based version of it but that didn't work. I tried converting the component into a functional one, and quickly got into a rabbit hole.

## Screenshot

https://github.com/dhis2/ui/assets/1014725/e9d75595-015d-4a20-83c6-6352294da4d1

