### PR TITLE
fix: pass through props for DataTableCell (DHIS2-15767)

### DIFF
--- a/components/table/src/data-table/data-table-cell.js
+++ b/components/table/src/data-table/data-table-cell.js
@@ -27,6 +27,7 @@ export const DataTableCell = forwardRef(
             valid,
             width,
             onClick,
+            ...props
         },
         ref
     ) => {
@@ -36,6 +37,7 @@ export const DataTableCell = forwardRef(
                 : TableDataCell
         return (
             <TableCell
+                {...props}
                 active={active}
                 align={align}
                 backgroundColor={backgroundColor}


### PR DESCRIPTION
Relates to [DHIS2-15767](https://dhis2.atlassian.net/browse/DHIS2-15767)
Required by https://github.com/dhis2/line-listing-app/pull/427

---

### Description
_Background_
Using a `Tooltip` in a `DataTable` is currently quite tricky, as the table itself relies on a strict DOM structure of `DataTableBody` -> `DataTableRow` -> `DataTableCell`, so nothing else can easily be added into that structure. To wrap a `Tooltip` around an element without any additional side-effect elements the wrapped component (’DataTableCell`) needs to implement a few props, such as ’onMouseOver’, ’onMouseOut’ and ’ref’. Currently the `DataTableCell` doesn't pass through the former two of these.

_Solution_
`DataTableCell` will now pass through `props` to its underlying `TableCell` component, so that the props will be featured in e.g. the `td` of a `TableDataCell`. This enables the use of `Tooltip`.

_Example_
```
<DataTableRow>
    <Tooltip
        content={'Some tooltip content'}
    >
        {({ onMouseOver, onMouseOut, ref }) => (
            <DataTableCell
                onMouseOver={onMouseOver}
                onMouseOut={onMouseOut}
                ref={ref}
            >
                Some cell content
            </DataTableCell>
        )}
    </Tooltip>
</DataTableRow>
```

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

### Screenshots

![image](https://github.com/dhis2/ui/assets/12590483/72d28025-8f75-45f4-9325-c57da5fff519)


[DHIS2-15767]: https://dhis2.atlassian.net/browse/DHIS2-15767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ