### PR TITLE
fix(pagination): add row padding on small screens and demo stories

### DIFF
--- a/components/pagination/src/pagination.js
+++ b/components/pagination/src/pagination.js
@@ -1,4 +1,5 @@
 import { requiredIf } from '@dhis2/prop-types'
+import { spacers } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -100,6 +101,7 @@ const Pagination = ({
                 .container {
                     display: flex;
                     flex-wrap: wrap;
+                    row-gap: ${spacers.dp4};
                 }
                 .spacer {
                     flex-grow: 1;

--- a/components/pagination/src/pagination.stories.js
+++ b/components/pagination/src/pagination.stories.js
@@ -87,3 +87,15 @@ WithoutAnySelect.args = {
     ...WithoutGoToPageSelect.args,
     ...WithoutPageSizeSelect.args,
 }
+
+const InBox = ({ boxWidth, ...args }) => (
+    <div style={{ width: boxWidth }}>
+        <Pagination {...args} />
+    </div>
+)
+
+export const MediumWidth = InBox.bind({})
+MediumWidth.args = { ...pagers.atTenthPage, boxWidth: 500 }
+
+export const NarrowWidth = InBox.bind({})
+NarrowWidth.args = { ...pagers.atTenthPage, boxWidth: 100 }


### PR DESCRIPTION
Relates to [DHIS2-15465](https://dhis2.atlassian.net/browse/DHIS2-15465)

---

### Description

This is a very unobtrusive PR that only adds a `row-gap` CSS rule to the pagination container to prevent the button "rows" touching when the pagination container is narrow. Implementation was discussed with Joe.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_NB: API docs and tests weren't relevant for this PR._

---

### Screenshots

**BEFORE**
<img width="515" alt="Screenshot 2023-09-14 at 12 28 09" src="https://github.com/dhis2/ui/assets/353236/690b98b1-e7ae-4f76-8100-24cd50df5d15">


**AFTER**
<img width="514" alt="Screenshot 2023-09-14 at 12 26 31" src="https://github.com/dhis2/ui/assets/353236/3bd277c7-f5bc-4f9a-92b3-45767017c42b">

[DHIS2-15465]: https://dhis2.atlassian.net/browse/DHIS2-15465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ