### PR TITLE
fix(portal): get default mount node at execution time

### DIFF
--- a/components/portal/src/portal.js
+++ b/components/portal/src/portal.js
@@ -10,15 +10,17 @@ import { createPortal } from 'react-dom'
  * template.
  *
  * As a fallback, portals will be attached to the document body.
+ *
+ * This needs to be a function so that it works in tests as well.
  */
-const defaultNode =
+const getDefaultNode = () =>
     document.getElementById('dhis2-portal-root') || document.body
 
 export const Portal = ({ children, node, disable }) => {
     const [mountNode, setMountNode] = useState(null)
 
     useEffect(() => {
-        setMountNode(node || defaultNode)
+        setMountNode(node || getDefaultNode())
     }, [node])
 
     if (disable) {


### PR DESCRIPTION
### Description

So far the default mount node was defined directly in the module, not when the portal was rendered. When running jest tests, the portal won't be in the current DOM as the mount node that's supposed to be used has changed.

-   [x] ~~API docs are generated~~
    - Not necessary
-   [x] ~~Tests were added~~
    - I couldn't reproduce the issue in this repository, the jest test actually passed
-   [x] ~~Storybook demos were added~~
    - Not necessary