### PR TITLE
fix: minor type fixes

### DIFF
--- a/components/input/types/index.d.ts
+++ b/components/input/types/index.d.ts
@@ -16,8 +16,8 @@ export type InputType =
     | 'search'
 
 export interface InputEventPayload {
-    value?: string
-    name?: string
+    value: string | undefined
+    name: string | undefined
 }
 
 export type InputEventHandler<Event extends React.SyntheticEvent> = (

--- a/components/organisation-unit-tree/types/index.d.ts
+++ b/components/organisation-unit-tree/types/index.d.ts
@@ -2,14 +2,14 @@ import * as React from 'react'
 
 export type OrganisationUnitTreeRoots = string | string[]
 
-interface OrganisationUnitNode {
+export interface OrganisationUnitNode {
     id: string
     displayName: string
     children?: number
     path: string
 }
 
-interface OrganisationUnitEventPayload extends OrganisationUnitNode {
+export interface OrganisationUnitEventPayload extends OrganisationUnitNode {
     checked: boolean
     selected: string[]
 }

--- a/components/radio/types/index.d.ts
+++ b/components/radio/types/index.d.ts
@@ -1,12 +1,12 @@
 import * as React from 'react'
 
-type RadioEventPayload = {
+export type RadioEventPayload = {
     value?: string
     name?: string
     checked: boolean
 }
 
-type RadioEventHandler<Event extends React.SyntheticEvent> = (
+export type RadioEventHandler<Event extends React.SyntheticEvent> = (
     payload: RadioEventPayload,
     event: Event
 ) => void

--- a/components/select/types/index.d.ts
+++ b/components/select/types/index.d.ts
@@ -19,22 +19,16 @@ type SelectEventHandler<
     Event extends React.SyntheticEvent
 > = (payload: T, event: Event) => void
 
-export type SelectOnBlurHandler<T extends BaseEventPayload> = SelectEventHandler<
-    T,
-    LayerBackdropClickEvent
->
-export type SelectOnFocusHandler<T extends BaseEventPayload> = SelectEventHandler<
-    T,
-    React.FocusEvent<HTMLDivElement>    
->
+export type SelectOnBlurHandler<T extends BaseEventPayload> =
+    SelectEventHandler<T, LayerBackdropClickEvent>
+export type SelectOnFocusHandler<T extends BaseEventPayload> =
+    SelectEventHandler<T, React.FocusEvent<HTMLDivElement>>
 export type SelectKeyHandler<T extends BaseEventPayload> = SelectEventHandler<
     T,
     React.KeyboardEvent<HTMLDivElement>
 >
-export type SelectChangeHandler<T extends BaseEventPayload> = SelectEventHandler<
-    T,
-    React.MouseEvent
->
+export type SelectChangeHandler<T extends BaseEventPayload> =
+    SelectEventHandler<T, React.MouseEvent>
 
 export interface MultiSelectProps {
     children?: React.ReactNode

--- a/components/select/types/index.d.ts
+++ b/components/select/types/index.d.ts
@@ -5,10 +5,12 @@ import { CheckboxProps } from '@dhis2-ui/checkbox'
 interface BaseEventPayload {
     selected: string | string[]
 }
-interface SingleSelectEventPayload extends BaseEventPayload {
+
+export interface SingleSelectEventPayload extends BaseEventPayload {
     selected: string
 }
-interface MultiSelectEventPayload extends BaseEventPayload {
+
+export interface MultiSelectEventPayload extends BaseEventPayload {
     selected: string[]
 }
 
@@ -17,19 +19,19 @@ type SelectEventHandler<
     Event extends React.SyntheticEvent
 > = (payload: T, event: Event) => void
 
-type SelectOnBlurHandler<T extends BaseEventPayload> = SelectEventHandler<
+export type SelectOnBlurHandler<T extends BaseEventPayload> = SelectEventHandler<
     T,
     LayerBackdropClickEvent
 >
-type SelectOnFocusHandler<T extends BaseEventPayload> = SelectEventHandler<
+export type SelectOnFocusHandler<T extends BaseEventPayload> = SelectEventHandler<
     T,
-    React.FocusEvent<HTMLDivElement>
+    React.FocusEvent<HTMLDivElement>    
 >
-type SelectKeyHandler<T extends BaseEventPayload> = SelectEventHandler<
+export type SelectKeyHandler<T extends BaseEventPayload> = SelectEventHandler<
     T,
     React.KeyboardEvent<HTMLDivElement>
 >
-type SelectChangeHandler<T extends BaseEventPayload> = SelectEventHandler<
+export type SelectChangeHandler<T extends BaseEventPayload> = SelectEventHandler<
     T,
     React.MouseEvent
 >

--- a/components/transfer/types/index.d.ts
+++ b/components/transfer/types/index.d.ts
@@ -54,7 +54,7 @@ export interface TransferProps {
 
 export const Transfer: React.FC<TransferProps>
 
-type TransferOptionOnClickProp = (payload: { value: string }) => void
+export type TransferOptionOnClickProp = (payload: { value: string }) => void
 
 export interface TransferOptionRenderProps extends TransferOption {
     highlighted: boolean


### PR DESCRIPTION

### Description

- Make `value` and `name` required in `InputEventPayload` - but keep them being able to be undefined.
- Export more handlers and payloads. Useful to get the type when eg. consuming the components. 

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

_supporting text_
