### PR TITLE
feat(button): add destructive, secondary button type

### DIFF
--- a/components/button/src/button/button.js
+++ b/components/button/src/button/button.js
@@ -100,11 +100,9 @@ Button.propTypes = {
      */
     dataTest: PropTypes.string,
     /**
-     * Indicates that the button makes potentially dangerous
-     * deletions or data changes.
-     * Mutually exclusive with `primary` and `secondary` props
+     * Applies 'destructive' button appearance, implying a dangerous action.
      */
-    destructive: sharedPropTypes.buttonVariantPropType,
+    destructive: PropTypes.bool,
     /** Applies a greyed-out appearance and makes the button non-interactive  */
     disabled: PropTypes.bool,
     /** An icon element to display inside the button */
@@ -121,15 +119,13 @@ Button.propTypes = {
      */
     name: PropTypes.string,
     /**
-     * Applies 'primary' button appearance.
-     * Mutually exclusive with `destructive` and `secondary` props
+     * Applies 'primary' button appearance, implying the most important action.
      */
-    primary: sharedPropTypes.buttonVariantPropType,
+    primary: PropTypes.bool,
     /**
      * Applies 'secondary' button appearance.
-     * Mutually exclusive with `primary` and `destructive` props
      */
-    secondary: sharedPropTypes.buttonVariantPropType,
+    secondary: PropTypes.bool,
     /** Makes the button small. Mutually exclusive with `large` prop */
     small: sharedPropTypes.sizePropType,
     /** Tab index for focusing the button with a keyboard */

--- a/components/button/src/button/button.stories.js
+++ b/components/button/src/button/button.stories.js
@@ -108,6 +108,12 @@ Destructive.parameters = {
         },
     },
 }
+export const DestructiveSecondary = Template.bind({})
+DestructiveSecondary.args = {
+    destructive: true,
+    secondary: true,
+    name: 'Destructive secondary button',
+}
 
 export const Disabled = (args) => (
     <>

--- a/components/button/src/button/button.styles.js
+++ b/components/button/src/button/button.styles.js
@@ -187,6 +187,35 @@ export default css`
         fill: ${colors.white};
     }
 
+    .destructive.secondary {
+        border-color: rgba(74, 87, 104, 0.25);
+        background: transparent;
+        color: ${colors.red700};
+        fill: ${colors.red700};
+        font-weight: 400;
+    }
+
+    .destructive.secondary:hover {
+        border-color: ${colors.red600};
+        background: ${colors.red050};
+        color: ${colors.red800};
+        fill: ${colors.red800};
+    }
+
+    .destructive.secondary:active,
+    .destructive.secondary:active:focus {
+        background: ${colors.red100};
+        border-color: ${colors.red700};
+        box-shadow: none;
+    }
+
+    .destructive.secondary:disabled {
+        background: transparent;
+        border-color: rgba(74, 87, 104, 0.25);
+        color: rgba(183, 28, 28, 0.6);
+        fill: rgba(183, 28, 28, 0.6);
+    }
+
     .icon-only {
         padding: 0 0 0 5px;
     }

--- a/constants/src/shared-prop-types.js
+++ b/constants/src/shared-prop-types.js
@@ -21,28 +21,6 @@ export const statusArgType = {
 }
 
 /**
- * Button variant propType
- * @return {PropType} Mutually exclusive variants:
- * primary/secondary/destructive
- */
-export const buttonVariantPropType = mutuallyExclusive(
-    ['primary', 'secondary', 'destructive'],
-    PropTypes.bool
-)
-export const buttonVariantArgType = {
-    // No description because it should be set for the component description
-    table: {
-        type: {
-            summary: 'bool',
-            detail: "'primary', 'secondary', and 'destructive' are mutually exclusive props",
-        },
-    },
-    control: {
-        type: 'boolean',
-    },
-}
-
-/**
  * Size variant propType
  * @return {PropType} Mutually exclusive variants:
  * small/large

--- a/docs/docs/components/button.md
+++ b/docs/docs/components/button.md
@@ -32,7 +32,7 @@ Buttons are used to trigger actions. There are different button variants that ar
 | ------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `Basic`       | Default. Will suit the majority of actions on a page.                                                                      |
 | `Primary`     | Use for the most important action on a page, like a _Save data_ button in a form. Only use one `primary` button on a page. |
-| `Secondary`   | Use for less important actions, usually in combination with other buttons.                                                 |
+| `Secondary`   | Use for less important actions, usually in combination with other buttons. Can be applied to `Destructive`.                |
 | `Destructive` | Only for primary-type actions that will delete or destroy something. Don't use several on a single page.                   |
 
 #### Basic
@@ -67,12 +67,16 @@ Buttons are used to trigger actions. There are different button variants that ar
 #### Destructive
 
 <Demo>
-    <Button destructive>Destructive button</Button>
+    <div class="stacked-examples-horizontal">
+        <Button destructive>Destructive button</Button>
+        <Button destructive secondary>Destructive secondary button</Button>
+    </div>
 </Demo>
 
 -   Only use for primary-type actions that will destroy data.
 -   Don't use if the action will only remove an item from the current context.
 -   Only use a one `destructive` button per page.
+-   `Destructive secondary` can be used more than once per page for less important destructive actions.
 
 ### Format
 


### PR DESCRIPTION
Implements [LIBS-544](https://dhis2.atlassian.net/browse/LIBS-544) / [UX-157](https://dhis2.atlassian.net/browse/UX-157)

---

### Description

This PR implements, or allows, buttons that are both `destructive` and `secondary`. `secondary` prop is now used as a modifier rather than a standalone type, as it can be applied to both `basic` and `destructive` types. (Using `secondary` alone is considered a modifier applied to the default `basic` type.) 

In order to allow this, the `secondary` prop is no longer part of the shared prop types provided by UI constants.

Question: is this a breaking change? I believe all button usages are unaffected by this change, but I'm not sure if changing `PropType` definitions always counts as a breaking change.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

![image](https://github.com/dhis2/ui/assets/33054985/3bda8a03-ef67-46bf-bd1c-e200dcc3a137)




[LIBS-544]: https://dhis2.atlassian.net/browse/LIBS-544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UX-157]: https://dhis2.atlassian.net/browse/UX-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ