### PR TITLE
ci: update publishing workflow

### DIFF
--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -134,9 +134,10 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   token: ${{env.GH_TOKEN}}
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 16
+                  cache: 'yarn'
 
             - uses: actions/download-artifact@v2
               with:
@@ -145,7 +146,6 @@ jobs:
             - run: ./scripts/extract-artifact.sh
 
             # ensure that d2-app-scripts is available
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - uses: dhis2/action-semantic-release@master


### PR DESCRIPTION
Update workflow to fix some of the deprecations. Based on https://github.com/dhis2/workflows/blob/master/ci/dhis2-verify-lib.yml