### PR TITLE
feat: menu item suffix

### DIFF
--- a/components/menu/src/menu-item/features/accepts_suffix.feature
+++ b/components/menu/src/menu-item/features/accepts_suffix.feature
@@ -1,0 +1,5 @@
+Feature: The MenuItem accepts a suffix prop
+
+    Scenario: MenuItem renders supplied suffix
+        Given a MenuItem supplied with a suffix is rendered
+        Then the suffix will be visible

--- a/components/menu/src/menu-item/features/accepts_suffix/index.js
+++ b/components/menu/src/menu-item/features/accepts_suffix/index.js
@@ -1,0 +1,10 @@
+import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+
+Given('a MenuItem supplied with a suffix is rendered', () => {
+    cy.visitStory('MenuItem', 'With Suffix')
+    cy.get('[data-test="dhis2-uicore-menuitem"]').should('be.visible')
+})
+
+Then('the suffix will be visible', () => {
+    cy.contains('Suffix').should('be.visible')
+})

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -39,6 +39,7 @@ const MenuItem = ({
     label,
     showSubMenu,
     toggleSubMenu,
+    suffix,
 }) => {
     const menuItemRef = useRef()
 
@@ -72,6 +73,8 @@ const MenuItem = ({
                     {icon && <span className="icon">{icon}</span>}
 
                     <span className="label">{label}</span>
+
+                    {suffix && <span className="suffix">{suffix}</span>}
 
                     {(chevron || children) && (
                         <span className="chevron">
@@ -118,6 +121,8 @@ MenuItem.propTypes = {
     label: PropTypes.node,
     /** When true, nested menu items are shown in a Popper */
     showSubMenu: PropTypes.bool,
+    /** A supporting element shown at the end of the menu item */
+    suffix: PropTypes.node,
     /** For using menu item as a link */
     target: PropTypes.string,
     /** On click, this function is called (without args) */

--- a/components/menu/src/menu-item/menu-item.stories.e2e.js
+++ b/components/menu/src/menu-item/menu-item.stories.e2e.js
@@ -25,3 +25,5 @@ export const WithTarget = () => (
 export const WithIcon = () => (
     <MenuItem icon={<div>Icon</div>} label="Menu item" />
 )
+
+export const WithSuffix = () => <MenuItem suffix="Suffix" label="Menu item" />

--- a/components/menu/src/menu-item/menu-item.stories.js
+++ b/components/menu/src/menu-item/menu-item.stories.js
@@ -1,3 +1,4 @@
+import { Tag } from '@dhis2/ui'
 import { colors } from '@dhis2/ui-constants'
 import {
     IconApps24,
@@ -95,6 +96,13 @@ Suffix.args = {
     label: 'Open in Data Visualizer',
     icon: <IconVisualizationColumn24 color={colors.grey600} />,
     suffix: <IconLaunch16 color={colors.grey600} />,
+}
+
+export const SuffixAndChevron = Template.bind({})
+SuffixAndChevron.args = {
+    label: 'Security notifications',
+    chevron: true,
+    suffix: <Tag>3</Tag>,
 }
 
 export const OnClick = (args) => (

--- a/components/menu/src/menu-item/menu-item.stories.js
+++ b/components/menu/src/menu-item/menu-item.stories.js
@@ -1,4 +1,9 @@
-import { IconApps24 } from '@dhis2/ui-icons'
+import { colors } from '@dhis2/ui-constants'
+import {
+    IconApps24,
+    IconVisualizationColumn24,
+    IconLaunch16,
+} from '@dhis2/ui-icons'
 import React, { useState } from 'react'
 import { Menu } from '../index.js'
 import { MenuItem } from './menu-item.js'
@@ -83,6 +88,13 @@ Icon.parameters = {
             story: 'A menu item can include an icon to help the user understand or recognize the option. An icon should support the menu item text and be simple enough to be understood in a dense UI. Icons add a lot of visual noise a menu, so only include them where they will help the user. Do not include icons only for visual reasons, the icon must functionally support the users understanding. Do not use complex icons. All menu items in a single menu do not need to have icons.',
         },
     },
+}
+
+export const Suffix = Template.bind({})
+Suffix.args = {
+    label: 'Open in Data Visualizer',
+    icon: <IconVisualizationColumn24 color={colors.grey600} />,
+    suffix: <IconLaunch16 color={colors.grey600} />,
 }
 
 export const OnClick = (args) => (

--- a/components/menu/src/menu-item/menu-item.styles.js
+++ b/components/menu/src/menu-item/menu-item.styles.js
@@ -96,6 +96,12 @@ export default css`
         height: 24px;
     }
 
+    .suffix {
+        display: flex;
+        align-items: center;
+        margin-left: ${spacers.dp8};
+    }
+
     .chevron {
         display: flex;
         align-items: center;

--- a/docs/docs/components/menu.md
+++ b/docs/docs/components/menu.md
@@ -3,7 +3,7 @@ title: Menu
 ---
 
 import { Demo } from '@site/src/components/DemoComponent.jsx'
-import { FlyoutMenu, MenuItem, MenuDivider, MenuSectionHeader, IconSave24, IconDelete24, IconShare24, IconEdit24 } from '@dhis2/ui'
+import { FlyoutMenu, MenuItem, MenuDivider, MenuSectionHeader, IconSave24, IconDelete24, IconShare24, IconEdit24, IconVisualizationColumn24, IconFilter24, IconClock24, IconLaunch16 } from '@dhis2/ui'
 
 import API from '../../../components/menu/API.md'
 
@@ -105,6 +105,21 @@ A menu gives access to menu items, through a panel that opens from a trigger ele
 -   Use dividers to split items that logically belong together. This makes the menu easier to scan.
 -   Dividers can also show a section header, a text label for that group of menu items.
 -   Use a section header to clarify what the menu items refer to, but don't rely on it. Menus and menu item actions should be clear without needing section headers.
+
+### Suffix
+
+<Demo>
+    <FlyoutMenu className="demo-fullwidth">
+        <MenuItem icon= {<IconFilter24 />} label="Filter data" />
+        <MenuItem icon= {<IconClock24 />} label="Change time period" />
+        <MenuItem icon= {<IconVisualizationColumn24 />} label="Open in Data Visualizer app" suffix= {<IconLaunch16/>}/>
+    </FlyoutMenu>
+</Demo>
+
+-   A menu item can show a suffix.
+-   Use a suffix to show extra information about the context or intent of a menu item.
+-   Common use cases include showing a menu item's keyboard shortcut and showing an indicator that a menu item will open a new tab.
+-   Don't include interactive components, like buttons, in a menu item suffix.
 
 ### Icon
 

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -248,3 +248,6 @@ footer {
     flex-direction: column;
     gap: 8px;
 }
+.demo-fullwidth {
+    width: 100%;
+}


### PR DESCRIPTION
Implements [LIBS-536](https://dhis2.atlassian.net/browse/LIBS-536)

---

### Description

This PR adds the optional `suffix` prop to `<MenuItem>`. A `suffix` is displayed at the end of the component. A `suffix` can be used alongside `chevron: true`.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

![image](https://github.com/dhis2/ui/assets/33054985/c432c678-21d1-4743-83a2-dca0b3d83891)

![image](https://github.com/dhis2/ui/assets/33054985/2770f4a0-8342-4617-8a5a-11c8cc7e4fbe)



[LIBS-536]: https://dhis2.atlassian.net/browse/LIBS-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ