### PR TITLE
fix(prop-type): fix deprecation of buttonVariantPropType

### DIFF
--- a/components/button/src/dropdown-button/dropdown-button.js
+++ b/components/button/src/dropdown-button/dropdown-button.js
@@ -175,8 +175,10 @@ DropdownButton.propTypes = {
     /** Component to show/hide when button is clicked */
     component: PropTypes.element,
     dataTest: PropTypes.string,
-    /** Button variant. Mutually exclusive with `primary` and `secondary` props */
-    destructive: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'destructive' button appearance, implying a dangerous action.
+     */
+    destructive: PropTypes.bool,
     /** Make the button non-interactive */
     disabled: PropTypes.bool,
     icon: PropTypes.element,
@@ -187,10 +189,14 @@ DropdownButton.propTypes = {
     name: PropTypes.string,
     /** Controls popper visibility. When implementing this prop the component becomes a controlled component */
     open: PropTypes.bool,
-    /** Button variant. Mutually exclusive with `destructive` and `secondary` props */
-    primary: sharedPropTypes.buttonVariantPropType,
-    /** Button variant. Mutually exclusive with `primary` and `destructive` props */
-    secondary: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'primary' button appearance, implying the most important action.
+     */
+    primary: PropTypes.bool,
+    /**
+     * Applies 'secondary' button appearance.
+     */
+    secondary: PropTypes.bool,
     /** Button size. Mutually exclusive with `large` prop */
     small: sharedPropTypes.sizePropType,
     tabIndex: PropTypes.string,

--- a/components/button/src/split-button/split-button.js
+++ b/components/button/src/split-button/split-button.js
@@ -147,8 +147,10 @@ SplitButton.propTypes = {
     /** Component to render when the dropdown is opened */
     component: PropTypes.element,
     dataTest: PropTypes.string,
-    /** Applies 'destructive' appearance to indicate purpose. Mutually exclusive with `primary` and `secondary` props */
-    destructive: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'destructive' button appearance, implying a dangerous action.
+     */
+    destructive: PropTypes.bool,
     /** Disables the button and makes it uninteractive */
     disabled: PropTypes.bool,
     /** An icon to add inside the button */
@@ -158,10 +160,14 @@ SplitButton.propTypes = {
     /** Changes button size. Mutually exclusive with `small` prop */
     large: sharedPropTypes.sizePropType,
     name: PropTypes.string,
-    /** Applies 'primary' appearance to indicate purpose. Mutually exclusive with `destructive` and `secondary` props */
-    primary: sharedPropTypes.buttonVariantPropType,
-    /** Applies 'secondary' appearance to indicate purpose. Mutually exclusive with `primary` and `destructive` props */
-    secondary: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'primary' button appearance, implying the most important action.
+     */
+    primary: PropTypes.bool,
+    /**
+     * Applies 'secondary' button appearance.
+     */
+    secondary: PropTypes.bool,
     /** Changes button size. Mutually exclusive with `large` prop */
     small: sharedPropTypes.sizePropType,
     tabIndex: PropTypes.string,

--- a/constants/src/shared-prop-types.js
+++ b/constants/src/shared-prop-types.js
@@ -21,6 +21,29 @@ export const statusArgType = {
 }
 
 /**
+ * @deprecated Not unused, will be removed in a future version.
+ * Button variant propType
+ * @return {PropType} Mutually exclusive variants:
+ * primary/secondary/destructive
+ */
+export const buttonVariantPropType = mutuallyExclusive(
+    ['primary', 'secondary', 'destructive'],
+    PropTypes.bool
+)
+export const buttonVariantArgType = {
+    // No description because it should be set for the component description
+    table: {
+        type: {
+            summary: 'bool',
+            detail: "'primary', 'secondary', and 'destructive' are mutually exclusive props",
+        },
+    },
+    control: {
+        type: 'boolean',
+    },
+}
+
+/**
  * Size variant propType
  * @return {PropType} Mutually exclusive variants:
  * small/large


### PR DESCRIPTION
Fixes an issue with release of `15.0.0`, where `buttonVariantPropType` was removed, but still referenced in internal components. See https://github.com/dhis2/ui/pull/1424 .

This PR reintroduces the propType (but deprecated) because it's actually part of the public API. 
Fixed the references to this propType, and aligned the documentation of those props with `button`.


