### PR TITLE
fix(chip): add tabIndex prop

### DIFF
--- a/components/chip/src/chip.js
+++ b/components/chip/src/chip.js
@@ -22,6 +22,7 @@ const Chip = ({
     marginLeft,
     marginRight,
     marginTop,
+    tabIndex,
 }) => (
     <span
         onClick={(e) => {
@@ -36,6 +37,7 @@ const Chip = ({
             dragging,
         })}
         data-test={dataTest}
+        tabIndex={tabIndex}
     >
         <Icon icon={icon} dataTest={`${dataTest}-icon`} />
         <Content overflow={overflow}>{children}</Content>
@@ -132,6 +134,7 @@ Chip.propTypes = {
     marginTop: PropTypes.number,
     overflow: PropTypes.bool,
     selected: PropTypes.bool,
+    tabIndex: PropTypes.string,
     onClick: PropTypes.func,
     onRemove: PropTypes.func,
 }

--- a/components/chip/types/index.d.ts
+++ b/components/chip/types/index.d.ts
@@ -26,6 +26,7 @@ export interface ChipProps {
     marginTop?: number
     overflow?: boolean
     selected?: boolean
+    tabIndex?: string
     onClick?: (arg0: {}, arg1: React.MouseEvent<HTMLSpanElement>) => void
     onRemove?: (arg0: {}, arg1: React.MouseEvent<HTMLSpanElement>) => void
 }


### PR DESCRIPTION

---

### Description

Adds `tabIndex` to chip component. 

I followed the pattern for other tabIndex, but I wonder why this is a `string` and not `number`? Also in my opinion these tabindex should default to `0` - but they don't? So I decided to keep it aligned with other components. 

---

### Known issues

-   [ ] _issue_

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

