### PR TITLE
fix(constants): remove buttonVariantProptype from constants

### DIFF
--- a/components/button/src/dropdown-button/dropdown-button.js
+++ b/components/button/src/dropdown-button/dropdown-button.js
@@ -175,8 +175,10 @@ DropdownButton.propTypes = {
     /** Component to show/hide when button is clicked */
     component: PropTypes.element,
     dataTest: PropTypes.string,
-    /** Button variant. Mutually exclusive with `primary` and `secondary` props */
-    destructive: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'destructive' button appearance, implying a dangerous action.
+     */
+    destructive: PropTypes.bool,
     /** Make the button non-interactive */
     disabled: PropTypes.bool,
     icon: PropTypes.element,
@@ -187,10 +189,14 @@ DropdownButton.propTypes = {
     name: PropTypes.string,
     /** Controls popper visibility. When implementing this prop the component becomes a controlled component */
     open: PropTypes.bool,
-    /** Button variant. Mutually exclusive with `destructive` and `secondary` props */
-    primary: sharedPropTypes.buttonVariantPropType,
-    /** Button variant. Mutually exclusive with `primary` and `destructive` props */
-    secondary: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'primary' button appearance, implying the most important action.
+     */
+    primary: PropTypes.bool,
+    /**
+     * Applies 'secondary' button appearance.
+     */
+    secondary: PropTypes.bool,
     /** Button size. Mutually exclusive with `large` prop */
     small: sharedPropTypes.sizePropType,
     tabIndex: PropTypes.string,

--- a/components/button/src/split-button/split-button.js
+++ b/components/button/src/split-button/split-button.js
@@ -147,8 +147,10 @@ SplitButton.propTypes = {
     /** Component to render when the dropdown is opened */
     component: PropTypes.element,
     dataTest: PropTypes.string,
-    /** Applies 'destructive' appearance to indicate purpose. Mutually exclusive with `primary` and `secondary` props */
-    destructive: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'destructive' button appearance, implying a dangerous action.
+     */
+    destructive: PropTypes.bool,
     /** Disables the button and makes it uninteractive */
     disabled: PropTypes.bool,
     /** An icon to add inside the button */
@@ -158,10 +160,14 @@ SplitButton.propTypes = {
     /** Changes button size. Mutually exclusive with `small` prop */
     large: sharedPropTypes.sizePropType,
     name: PropTypes.string,
-    /** Applies 'primary' appearance to indicate purpose. Mutually exclusive with `destructive` and `secondary` props */
-    primary: sharedPropTypes.buttonVariantPropType,
-    /** Applies 'secondary' appearance to indicate purpose. Mutually exclusive with `primary` and `destructive` props */
-    secondary: sharedPropTypes.buttonVariantPropType,
+    /**
+     * Applies 'primary' button appearance, implying the most important action.
+     */
+    primary: PropTypes.bool,
+    /**
+     * Applies 'secondary' button appearance.
+     */
+    secondary: PropTypes.bool,
     /** Changes button size. Mutually exclusive with `large` prop */
     small: sharedPropTypes.sizePropType,
     tabIndex: PropTypes.string,

--- a/constants/src/shared-prop-types.js
+++ b/constants/src/shared-prop-types.js
@@ -20,6 +20,13 @@ export const statusArgType = {
     control: { type: 'boolean' },
 }
 
+export const buttonVariantArgType =
+    // No description because it should be set for the component description
+    {
+        table: { type: { summary: 'bool' } },
+        control: { type: 'boolean' },
+    }
+
 /**
  * Size variant propType
  * @return {PropType} Mutually exclusive variants:


### PR DESCRIPTION
Prepares alpha 9 release. Fixes some bad merge resolutions, and brings back `buttonVariantArgType` that is used for storybook. 

BREAKING CHANGE: `buttonVariantPropType` has been removed from constants. This is mostly intended for internal purposes, but was part of the public API.


