### PR TITLE
fix(select): adjust clear button

### DIFF
--- a/components/select/package.json
+++ b/components/select/package.json
@@ -33,7 +33,6 @@
         "styled-jsx": "^4"
     },
     "dependencies": {
-        "@dhis2/prop-types": "^3.1.2",
         "@dhis2-ui/box": "9.4.2",
         "@dhis2-ui/button": "9.4.2",
         "@dhis2-ui/card": "9.4.2",
@@ -45,6 +44,8 @@
         "@dhis2-ui/loader": "9.4.2",
         "@dhis2-ui/popper": "9.4.2",
         "@dhis2-ui/status-icon": "9.4.2",
+        "@dhis2-ui/tooltip": "^9.4.2",
+        "@dhis2/prop-types": "^3.1.2",
         "@dhis2/ui-constants": "9.4.2",
         "@dhis2/ui-icons": "9.4.2",
         "classnames": "^2.3.1",

--- a/components/select/src/multi-select-field/features/has_default_clear_text.feature
+++ b/components/select/src/multi-select-field/features/has_default_clear_text.feature
@@ -2,4 +2,5 @@ Feature: Clear text for the MultiSelectField
 
     Scenario: Rendering a clearable MultiSelectField
         Given a clearable MultiSelectField with selected option is rendered
+        When the clear button is hovered
         Then the clear text is visible

--- a/components/select/src/multi-select-field/features/has_default_clear_text/index.js
+++ b/components/select/src/multi-select-field/features/has_default_clear_text/index.js
@@ -1,7 +1,14 @@
-import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a clearable MultiSelectField with selected option is rendered', () => {
     cy.visitStory('MultiSelectField', 'With clearable and selected option')
+})
+
+When('the clear button is hovered', () => {
+    cy.get('[data-test="dhis2-uicore-multiselect-clear"]').trigger(
+        'mouseover',
+        'top'
+    )
 })
 
 Then('the clear text is visible', () => {

--- a/components/select/src/multi-select/input.js
+++ b/components/select/src/multi-select/input.js
@@ -24,7 +24,7 @@ const Input = ({
     inputMaxHeight,
 }) => {
     const hasSelection = selected.length > 0
-    const onClear = (_, e) => {
+    const onClear = (e) => {
         const data = { selected: [] }
 
         e.stopPropagation()
@@ -80,7 +80,6 @@ const Input = ({
 
                 .root-right {
                     margin-inline-start: auto;
-                    margin-inline-end: 10px;
                 }
             `}</style>
 

--- a/components/select/src/select/input-clear-button.js
+++ b/components/select/src/select/input-clear-button.js
@@ -1,18 +1,55 @@
-import { Button } from '@dhis2-ui/button'
+import { Tooltip } from '@dhis2-ui/tooltip'
+import { colors, theme } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
 const InputClearButton = ({ onClear, clearText, className, dataTest }) => (
-    <Button
-        small
-        secondary
-        dataTest={dataTest}
-        onClick={onClear}
-        type="button"
-        className={className}
-    >
-        {clearText}
-    </Button>
+    <Tooltip openDelay={500} content={clearText}>
+        <button
+            data-test={dataTest}
+            onClick={onClear}
+            type="button"
+            className={className}
+        >
+            <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path
+                    d="M8 16A8 8 0 1 0 8 0a8 8 0 0 0 0 16Zm3.536-5.879a1 1 0 1 1-1.415 1.414l-2.12-2.12-2.122 2.121a1 1 0 1 1-1.415-1.414L6.586 8 4.464 5.878A1 1 0 1 1 5.88 4.464L8 6.586l2.121-2.121a1 1 0 1 1 1.415 1.414L9.415 8l2.12 2.121Z"
+                    fill="none"
+                />
+            </svg>
+            <style jsx>{`
+                button {
+                    background: none;
+                    border: none;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    cursor: pointer;
+                    height: 24px;
+                    width: 24px;
+                    border-radius: 3px;
+                }
+                button svg path {
+                    fill: ${colors.grey500};
+                }
+                button:hover svg path {
+                    fill: ${colors.grey800};
+                }
+                button:hover {
+                    background: ${colors.grey200};
+                }
+                button:focus {
+                    outline: 2px solid ${theme.focus};
+                }
+            `}</style>
+        </button>
+    </Tooltip>
 )
 
 InputClearButton.propTypes = {

--- a/components/select/src/single-select-field/features/has_default_clear_text.feature
+++ b/components/select/src/single-select-field/features/has_default_clear_text.feature
@@ -2,4 +2,5 @@ Feature: Clear text for the SingleSelectField
 
     Scenario: Rendering a clearable SingleSelectField
         Given a clearable SingleSelectField with selected option is rendered
+        When the clear button is hovered
         Then the clear text is visible

--- a/components/select/src/single-select-field/features/has_default_clear_text/index.js
+++ b/components/select/src/single-select-field/features/has_default_clear_text/index.js
@@ -1,7 +1,14 @@
-import { Given, Then } from 'cypress-cucumber-preprocessor/steps'
+import { Given, When, Then } from 'cypress-cucumber-preprocessor/steps'
 
 Given('a clearable SingleSelectField with selected option is rendered', () => {
     cy.visitStory('SingleSelectField', 'With clearable and selected option')
+})
+
+When('the clear button is hovered', () => {
+    cy.get('[data-test="dhis2-uicore-singleselect-clear"]').trigger(
+        'mouseover',
+        'top'
+    )
 })
 
 Then('the clear text is visible', () => {

--- a/components/select/src/single-select/input.js
+++ b/components/select/src/single-select/input.js
@@ -24,7 +24,7 @@ const Input = ({
     inputMaxHeight,
 }) => {
     const hasSelection = selected && typeof selected === 'string'
-    const onClear = (_, e) => {
+    const onClear = (e) => {
         const data = { selected: '' }
 
         e.stopPropagation()
@@ -72,7 +72,6 @@ const Input = ({
 
                 .root-right {
                     margin-inline-start: auto;
-                    margin-inline-end: 10px;
                 }
             `}</style>
 


### PR DESCRIPTION
Implements [UX-154](https://dhis2.atlassian.net/browse/UX-154)

---

### Description

This PR changes the `SingleSelect` and `MultiSelect` clear button to use an icon button rather than a `Button` with text label.

`clearText` prop is used to populate the `Tooltip` that appears on hover.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Before: 
![image](https://github.com/dhis2/ui/assets/33054985/9dd6471f-00e6-4388-b0d3-3f891c620034)
![image](https://github.com/dhis2/ui/assets/33054985/1231f6b2-d51b-45a4-b379-35b3d4662f8a)

After:
![image](https://github.com/dhis2/ui/assets/33054985/b88201e7-50e8-4ac0-afdc-9e9d523fa2af)
![image](https://github.com/dhis2/ui/assets/33054985/07f40c0f-9f71-448b-b0fa-7844300320e7)



[UX-154]: https://dhis2.atlassian.net/browse/UX-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ