### PR TITLE
fix(alertbar): address long texts

### DIFF
--- a/components/alert/src/alert-bar/action.js
+++ b/components/alert/src/alert-bar/action.js
@@ -16,6 +16,7 @@ class Action extends Component {
                     span {
                         margin-right: ${spacers.dp12};
                         text-decoration: underline;
+                        white-space: nowrap;
                     }
                     span:hover {
                         cursor: pointer;

--- a/components/alert/src/alert-bar/alert-bar.stories.js
+++ b/components/alert/src/alert-bar/alert-bar.stories.js
@@ -147,6 +147,21 @@ export const WithActions = () => (
 )
 WithActions.storyName = 'With actions'
 
+export const WithActionsAndInsufficientSpace = () => (
+    <AlertBar
+        permanent
+        actions={[
+            { label: 'Long action 1', onClick: () => {} },
+            { label: 'Long action 2', onClick: () => {} },
+        ]}
+    >
+        Some text, a pretty normal amount, that conflicts with pretty long
+        actions
+    </AlertBar>
+)
+WithActionsAndInsufficientSpace.storyName =
+    'With actions and insufficient space'
+
 export const Icons = () => (
     <React.Fragment>
         <AlertBar permanent>Default icon</AlertBar>


### PR DESCRIPTION
Implements [LIBS-253](https://dhis2.atlassian.net/browse/LIBS-253)

---

### Description

Long texts caused the action bar's description and action labels to break oddly.

---

### Checklist

-   ~~[ ] API docs are generated~~
    - not necessary
-   ~~[ ] Tests were added~~
    - not necessary
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

**before:**
![image](https://github.com/dhis2/ui/assets/10101831/ebd15f4b-9026-479b-b4af-96a912bc55cf)

**after:**
![image](https://github.com/dhis2/ui/assets/10101831/2dba3183-8e74-4da6-9c7c-f3c4d2e27d24)


[LIBS-253]: https://dhis2.atlassian.net/browse/LIBS-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ