### PR TITLE
feat(LIBS-539): forward data-table-row props to allow handling dom events

### DIFF
--- a/components/table/src/data-table/__tests__/data-table-row.test.js
+++ b/components/table/src/data-table/__tests__/data-table-row.test.js
@@ -140,4 +140,23 @@ describe('<DataTableRow>', () => {
         expect(cb).toHaveBeenCalledTimes(1)
         expect(cb).toHaveBeenCalledWith({ expanded: true })
     })
+
+    it('accepts a hover prop', () => {
+        const cb = jest.fn()
+        const wrapper = mount(
+            <DataTableRow
+                expandable
+                expandableContent="test"
+                onExpandToggle={cb}
+                onMouseOver={cb}
+                onClick={cb}
+            />
+        )
+
+        wrapper.find('tr').simulate('mouseover')
+
+        wrapper.find('tr').simulate('click')
+
+        expect(cb).toHaveBeenCalledTimes(2)
+    })
 })

--- a/components/table/src/data-table/data-table-row/data-table-row.js
+++ b/components/table/src/data-table/data-table-row/data-table-row.js
@@ -20,6 +20,7 @@ export const DataTableRow = forwardRef(
             draggable,
             role,
             onExpandToggle,
+            ...rest
         },
         ref
     ) => {
@@ -45,6 +46,7 @@ export const DataTableRow = forwardRef(
                     selected={selected}
                     draggable={draggable}
                     role={role}
+                    {...rest}
                 >
                     {draggable && <DragHandleCell />}
                     {expandableContent && (

--- a/components/table/src/table/table-row.js
+++ b/components/table/src/table/table-row.js
@@ -16,6 +16,7 @@ export const TableRow = ({
     className,
     dataTest,
     suppressZebraStriping,
+    ...rest
 }) => {
     const { suppressZebraStriping: suppressZebraStripingFromContext } =
         useContext(TableContext)
@@ -30,6 +31,7 @@ export const TableRow = ({
             className={cx(className, { zebraStriping })}
             data-test={dataTest}
             role={role}
+            {...rest}
         >
             {children}
 


### PR DESCRIPTION
Implements [LIBS-539](https://dhis2.atlassian.net/browse/LIBS-539)

---

### Description

This forward props down to data-row and table-row components to allow consumers to handle DOM events like click and mouseover. 

---

### Known issues

We have a bigger initiative to allow passing down props for most of our UI components. This was more urgent since it's blocking analytics team, and what we need to pass down made sense. Some components that encapsulate more than one native component might be trickier to implement.

The typings for this should be updated (to inherit from `HTMLTableRowElement`) but I had issues with running types inside the project, which we need to talk about separately.

---

### Checklist

-   [] API docs are generated
-   [x] Tests were added
-   [ ] Storybook demos were added


[LIBS-539]: https://dhis2.atlassian.net/browse/LIBS-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ