### PR TITLE
feat: splitButton accessibility improvements

### DIFF
--- a/components/button/src/split-button/split-button.js
+++ b/components/button/src/split-button/split-button.js
@@ -18,7 +18,24 @@ class SplitButton extends Component {
     state = {
         open: false,
     }
+
     anchorRef = React.createRef()
+
+    componentDidMount() {
+        document.addEventListener('keydown', this.handleKeyDown)
+    }
+
+    componentWillUnmount() {
+        document.removeEventListener('keydown', this.handleKeyDown)
+    }
+
+    handleKeyDown = (event) => {
+        if (event.key === 'Escape' && this.state.open) {
+            this.setState({ open: false })
+
+            this.anchorRef.current && this.anchorRef.current.focus()
+        }
+    }
 
     onClick = (payload, event) => {
         if (this.props.onClick) {
@@ -33,8 +50,9 @@ class SplitButton extends Component {
         }
     }
 
-    onToggle = () => this.setState({ open: !this.state.open })
-
+    onToggle = () => {
+        this.setState((prevState) => ({ open: !prevState.open }))
+    }
     render() {
         const { open } = this.state
         const {
@@ -94,6 +112,8 @@ class SplitButton extends Component {
                     tabIndex={tabIndex}
                     className={cx(className, rightButton.className)}
                     dataTest={`${dataTest}-toggle`}
+                    title="Toggle dropdown"
+                    aria-label="Toggle dropdown"
                 >
                     {arrow}
                 </Button>

--- a/components/button/src/split-button/split-button.test.js
+++ b/components/button/src/split-button/split-button.test.js
@@ -1,0 +1,62 @@
+import { render, fireEvent } from '@testing-library/react'
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { SplitButton } from './split-button.js'
+
+describe('SplitButton', () => {
+    it('renders button with children', () => {
+        const { getByText } = render(<SplitButton>Click me</SplitButton>)
+        expect(getByText('Click me')).toBeInTheDocument()
+    })
+
+    it('toggles dropdown when right button is clicked', () => {
+        const { getByTestId, queryByTestId } = render(<SplitButton />)
+        const toggleButton = getByTestId('dhis2-uicore-splitbutton-toggle')
+
+        fireEvent.click(toggleButton)
+        expect(
+            queryByTestId('dhis2-uicore-splitbutton-menu')
+        ).toBeInTheDocument()
+
+        fireEvent.click(toggleButton)
+        expect(
+            queryByTestId('dhis2-uicore-splitbutton-menu')
+        ).not.toBeInTheDocument()
+    })
+
+    it('renders dropdown content when open is true', () => {
+        const { getByTestId } = render(
+            <SplitButton component={<div>Dropdown Content</div>} />
+        )
+
+        const toggleButton = getByTestId('dhis2-uicore-splitbutton-toggle')
+        fireEvent.click(toggleButton)
+
+        expect(getByTestId('dhis2-uicore-splitbutton-menu')).toBeInTheDocument()
+    })
+
+    it('closes dropdown when escape key is pressed', () => {
+        const { getByTestId, queryByTestId } = render(
+            <SplitButton
+                component={
+                    <div data-testid="dropdown-content">Dropdown Content</div>
+                }
+            />
+        )
+
+        const toggleButton = getByTestId('dhis2-uicore-splitbutton-toggle')
+        fireEvent.click(toggleButton)
+
+        fireEvent.keyDown(document, { key: 'Escape' })
+
+        expect(queryByTestId('dropdown-content')).not.toBeInTheDocument()
+    })
+
+    it('adds title and aria-label attributes to the right button', () => {
+        const { getByTestId } = render(<SplitButton />)
+        const toggleButton = getByTestId('dhis2-uicore-splitbutton-toggle')
+
+        expect(toggleButton).toHaveAttribute('title', 'Toggle dropdown')
+        expect(toggleButton).toHaveAttribute('aria-label', 'Toggle dropdown')
+    })
+})


### PR DESCRIPTION
update accessibility in SplitButton component

---

### Description

Implemented (https://dhis2.atlassian.net/browse/LIBS-566) by updating the SplitButton component to improve accessibility. This includes adding `title` and `aria-label` attributes to the toggle button to provide better context for screen readers. Additionally, made the splitButton close when the escape button is closed.

---

### Known issues

-   [ ] None

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [ ] Storybook demos were added

---

### Screenshots
- None

---

### Additional Notes 
- Updated the `SplitButton` component to include `title` and `aria-label` attributes for improved accessibility.
- Allowed use of "escape" button on the keyboard to close the split button.
- Tests were added to ensure proper functionality and accessibility.
- Reviewed and updated relevant documentation.

_supporting text_

