### PR TITLE
feat(tooltip): accessibility improvements for tooltip

### DIFF
--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -130,6 +130,7 @@ const Tooltip = ({
                         modifiers={[offsetModifier, flipModifier, hideModifier]}
                     >
                         <div
+                            className={className}
                             id="tooltipContenDhis2Ui"
                             onMouseOver={onMouseOver}
                             onMouseOut={onMouseOut}

--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -9,8 +9,6 @@ const TOOLTIP_OFFSET = 4
 
 const popperStyle = resolve`
     z-index: ${layers.applicationTop};
-    pointer-events: none;
-
     // Hide popper when reference component is obscured (https://popper.js.org/docs/v2/modifiers/hide/)
     div[data-popper-reference-hidden="true"] {
         visibility: hidden;
@@ -66,13 +64,39 @@ const Tooltip = ({
         }, closeDelay)
     }
 
-    useEffect(
-        () => () => {
+    const onFocus = () => {
+        clearTimeout(closeTimerRef.current)
+
+        openTimerRef.current = setTimeout(() => {
+            setOpen(true)
+        }, openDelay)
+    }
+
+    const onBlur = () => {
+        clearTimeout(openTimerRef.current)
+
+        closeTimerRef.current = setTimeout(() => {
+            setOpen(false)
+        }, closeDelay)
+    }
+
+    const handleKeyDown = (event) => {
+        if (event.key === 'Escape') {
+            closeTimerRef.current = setTimeout(() => {
+                setOpen(false)
+            }, closeDelay)
+        }
+    }
+
+    useEffect(() => {
+        document.addEventListener('keydown', handleKeyDown)
+
+        return () => {
             clearTimeout(openTimerRef.current)
             clearTimeout(closeTimerRef.current)
-        },
-        []
-    )
+            document.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [])
 
     return (
         <>
@@ -80,19 +104,23 @@ const Tooltip = ({
                 children({
                     onMouseOver: onMouseOver,
                     onMouseOut: onMouseOut,
+                    onFocus: { onFocus },
+                    onBlur: { onBlur },
                     ref: popperReference,
                 })
             ) : (
                 <span
                     onMouseOver={onMouseOver}
                     onMouseOut={onMouseOut}
+                    onFocus={onFocus}
+                    onBlur={onBlur}
                     ref={popperReference}
+                    aria-describedby={open ? 'tooltipContenDhis2Ui' : ''}
                     data-test={`${dataTest}-reference`}
                 >
                     {children}
                 </span>
             )}
-
             {open && (
                 <Portal>
                     <Popper
@@ -102,8 +130,11 @@ const Tooltip = ({
                         modifiers={[offsetModifier, flipModifier, hideModifier]}
                     >
                         <div
-                            className={className}
+                            id="tooltipContenDhis2Ui"
+                            onMouseOver={onMouseOver}
+                            onMouseOut={onMouseOut}
                             data-test={`${dataTest}-content`}
+                            role="tooltip"
                         >
                             {content}
                         </div>

--- a/components/tooltip/src/tooltip.test.js
+++ b/components/tooltip/src/tooltip.test.js
@@ -152,3 +152,45 @@ describe('it handles custom open and close delays', () => {
         expect(document.querySelector(tooltipContentSelector)).toBe(null)
     })
 })
+
+describe('Keyboard interaction', () => {
+    it('opens on keyboard focus and closes on blur', () => {
+        wrapper = mount(<Tooltip content={tooltipContent}>Hi hi!</Tooltip>)
+        wrapper.simulate('focus')
+
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+
+        // wait for 'open delay' to elapse to open tooltip
+        act(() => {
+            jest.advanceTimersByTime(200)
+        })
+
+        // expect tooltip to be open after delay
+        const res = document.querySelector(tooltipContentSelector)
+        expect(res).not.toBe(null)
+        expect(res.textContent).toBe(tooltipContent)
+
+        wrapper.simulate('blur')
+        act(() => {
+            jest.advanceTimersByTime(200) // Assuming default closeDelay is 200ms
+        })
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+        // this last part clears a warning about "code should be wrapped in `act(...)`"
+        // and clears the tooltip
+        act(() => {
+            jest.runAllTimers()
+        })
+    })
+
+    it('closes when escape key is pressed', () => {
+        wrapper = mount(<Tooltip content={tooltipContent}>Hi hi!</Tooltip>)
+
+        // open tooltip
+        wrapper.simulate('mouseover')
+        act(() => {
+            jest.advanceTimersByTime(200) // open the tooltip
+        })
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+        expect(document.querySelector(tooltipContentSelector)).toBe(null)
+    })
+})

--- a/components/tooltip/src/tooltip.test.js
+++ b/components/tooltip/src/tooltip.test.js
@@ -160,23 +160,20 @@ describe('Keyboard interaction', () => {
 
         expect(document.querySelector(tooltipContentSelector)).toBe(null)
 
-        // wait for 'open delay' to elapse to open tooltip
         act(() => {
             jest.advanceTimersByTime(200)
         })
 
-        // expect tooltip to be open after delay
         const res = document.querySelector(tooltipContentSelector)
         expect(res).not.toBe(null)
         expect(res.textContent).toBe(tooltipContent)
 
         wrapper.simulate('blur')
         act(() => {
-            jest.advanceTimersByTime(200) // Assuming default closeDelay is 200ms
+            jest.advanceTimersByTime(200)
         })
         expect(document.querySelector(tooltipContentSelector)).toBe(null)
-        // this last part clears a warning about "code should be wrapped in `act(...)`"
-        // and clears the tooltip
+
         act(() => {
             jest.runAllTimers()
         })
@@ -187,10 +184,27 @@ describe('Keyboard interaction', () => {
 
         // open tooltip
         wrapper.simulate('mouseover')
+
         act(() => {
-            jest.advanceTimersByTime(200) // open the tooltip
+            jest.advanceTimersByTime(200)
         })
-        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+
+        // verify tooltip is open
+        expect(document.querySelector(tooltipContentSelector)).not.toBe(null)
+
+        //Press the Escape key
+        act(() => {
+            document.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape' })
+            )
+        })
+
+        // wait for close delay
+        act(() => {
+            jest.advanceTimersByTime(200)
+        })
+
+        // expect tooltip to be closed
         expect(document.querySelector(tooltipContentSelector)).toBe(null)
     })
 })


### PR DESCRIPTION
Implements [LIBS-558](https://dhis2.atlassian.net/browse/LIBS-558)

---

### Description

- [x] Tooltip has role="tooltip"

- [x] Tooltip is shown when trigger element receives keyboard focus.

- [x] Tooltip itself can be hovered. Tooltip closes when either the trigger element or the Tooltip are no longer hovered, or the trigger element is no longer focused.

- [x] Tooltip can be closed by pressing the `esc` key.

- [x] Trigger element reference tooltip with `aria-describedby`.

---

### Known issues

-   Tooltip can't be hovered when `closeDelay` is set to `zero`.

---

### Checklist

-   [ ] API docs are generated
-   [x] Tests were added
-   [ ] Storybook demos were added


[LIBS-558]: https://dhis2.atlassian.net/browse/LIBS-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ