### PR TITLE
feat(menu): accessibility improvements to menu and menu item components

### DIFF
--- a/components/menu/src/flyout-menu/flyout-menu.js
+++ b/components/menu/src/flyout-menu/flyout-menu.js
@@ -1,12 +1,6 @@
 import { colors, elevations, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
-import React, {
-    Children,
-    cloneElement,
-    isValidElement,
-    useState,
-    // useEffect,
-} from 'react'
+import React, { Children, cloneElement, isValidElement, useState } from 'react'
 import { Menu } from '../index.js'
 
 const FlyoutMenu = ({
@@ -17,24 +11,11 @@ const FlyoutMenu = ({
     maxHeight,
     maxWidth,
 }) => {
-    const [openedSubMenu, setOpenedSubMenu] = useState(0)
+    const [openedSubMenu, setOpenedSubMenu] = useState(null)
     const toggleSubMenu = (index) => {
         const toggleValue = index === openedSubMenu ? null : index
         setOpenedSubMenu(toggleValue)
     }
-
-    // useEffect(() => {
-    //     if (openedSubMenu) {
-    //         menuItemRef.current.childNodes[0].focus()
-    //     }
-    // }, [openedSubMenu])
-
-    // console.log(document.activeElement, "flyout menu active element")
-    // // const handleKeydown = () => {
-
-    // // }
-
-    console.log(openedSubMenu, 'opened submenu')
 
     return (
         <div className={className} data-test={dataTest}>

--- a/components/menu/src/flyout-menu/flyout-menu.js
+++ b/components/menu/src/flyout-menu/flyout-menu.js
@@ -1,6 +1,13 @@
 import { colors, elevations, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
-import React, { Children, cloneElement, isValidElement, useState } from 'react'
+import React, {
+    Children,
+    cloneElement,
+    isValidElement,
+    useEffect,
+    useRef,
+    useState,
+} from 'react'
 import { Menu } from '../index.js'
 
 const FlyoutMenu = ({
@@ -16,9 +23,16 @@ const FlyoutMenu = ({
         const toggleValue = index === openedSubMenu ? null : index
         setOpenedSubMenu(toggleValue)
     }
+    const ref = useRef(null)
+
+    useEffect(() => {
+        if (ref.current && ref.current?.children[0]) {
+            ref.current.children[0].focus()
+        }
+    }, [])
 
     return (
-        <div className={className} data-test={dataTest}>
+        <div className={className} data-test={dataTest} ref={ref}>
             <Menu dense={dense}>
                 {Children.map(children, (child, index) =>
                     isValidElement(child)

--- a/components/menu/src/flyout-menu/flyout-menu.js
+++ b/components/menu/src/flyout-menu/flyout-menu.js
@@ -1,6 +1,12 @@
 import { colors, elevations, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
-import React, { Children, cloneElement, isValidElement, useState } from 'react'
+import React, {
+    Children,
+    cloneElement,
+    isValidElement,
+    useState,
+    // useEffect,
+} from 'react'
 import { Menu } from '../index.js'
 
 const FlyoutMenu = ({
@@ -11,11 +17,24 @@ const FlyoutMenu = ({
     maxHeight,
     maxWidth,
 }) => {
-    const [openedSubMenu, setOpenedSubMenu] = useState(null)
+    const [openedSubMenu, setOpenedSubMenu] = useState(0)
     const toggleSubMenu = (index) => {
         const toggleValue = index === openedSubMenu ? null : index
         setOpenedSubMenu(toggleValue)
     }
+
+    // useEffect(() => {
+    //     if (openedSubMenu) {
+    //         menuItemRef.current.childNodes[0].focus()
+    //     }
+    // }, [openedSubMenu])
+
+    // console.log(document.activeElement, "flyout menu active element")
+    // // const handleKeydown = () => {
+
+    // // }
+
+    console.log(openedSubMenu, 'opened submenu')
 
     return (
         <div className={className} data-test={dataTest}>

--- a/components/menu/src/menu-divider/menu-divider.js
+++ b/components/menu/src/menu-divider/menu-divider.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 const MenuDivider = ({ className, dataTest, dense }) => (
-    <li className={className} data-test={dataTest}>
+    <li className={className} data-test={dataTest} role="separator">
         <Divider dense={dense} />
 
         <style jsx>{`

--- a/components/menu/src/menu-item/__tests__/menu-item.test.js
+++ b/components/menu/src/menu-item/__tests__/menu-item.test.js
@@ -3,19 +3,18 @@ import React from 'react'
 import { MenuItem } from '../menu-item.js'
 
 describe('Menu Component', () => {
-    it('Default menu item has aria role', () => {
+    it('Default menu item has role', () => {
         const menuItemDataTest = 'data-test-menu-item'
         const wrapper = mount(
             <MenuItem dataTest={menuItemDataTest} label="Menu item" />
         )
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
-        expect(menuItem.prop('role')).toBe('menuitem')
-        //     expect(menuItem.prop('aria-disabled')).toBe(false)
-        //     expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
-        //
+        expect(menuItem.childAt(0).prop('role')).toBe('menuitem')
+        expect(menuItem.childAt(0).prop('aria-disabled')).toBe(undefined)
+        expect(menuItem.childAt(0).prop('aria-label')).toBe('Menu item')
     })
 
-    it('Disabled menu item has aria disabled attribute', () => {
+    it('Disabled menu item has aria-disabled attribute', () => {
         const menuItemDataTest = 'data-test-menu-item'
         const wrapper = mount(
             <MenuItem
@@ -25,9 +24,12 @@ describe('Menu Component', () => {
             />
         )
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
-        expect(menuItem.prop('role')).toBe('menuitem')
-        // expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
-        // expect(menuItem.prop('aria-disabled')).toBe(true)
+
+        expect(menuItem.childAt(0).prop('role')).toBe('menuitem')
+        expect(menuItem.childAt(0).prop('aria-disabled')).toBe(true)
+        expect(menuItem.childAt(0).prop('aria-label')).toBe(
+            'Disabled menu item'
+        )
     })
 
     it('Toggle-able menu item has menuitemcheckbox role', () => {
@@ -37,10 +39,16 @@ describe('Menu Component', () => {
                 dataTest={menuItemDataTest}
                 label="Toggle-able menu item"
                 checkbox={true}
+                checked={false}
             />
         )
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
-        expect(menuItem.prop('role')).toBe('menuitemcheckbox')
-        // expect(menuItem.prop('aria-disabled')).toBe(false)
+
+        expect(menuItem.childAt(0).prop('role')).not.toBe('menuitem')
+        expect(menuItem.childAt(0).prop('role')).toBe('menuitemcheckbox')
+        expect(menuItem.childAt(0).prop('aria-checked')).toBe(false)
+        expect(menuItem.childAt(0).prop('aria-label')).toBe(
+            'Toggle-able menu item'
+        )
     })
 })

--- a/components/menu/src/menu-item/__tests__/menu-item.test.js
+++ b/components/menu/src/menu-item/__tests__/menu-item.test.js
@@ -10,8 +10,9 @@ describe('Menu Component', () => {
         )
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
         expect(menuItem.prop('role')).toBe('menuitem')
-        expect(menuItem.prop('aria-disabled')).toBe(false)
-        expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
+        //     expect(menuItem.prop('aria-disabled')).toBe(false)
+        //     expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
+        //
     })
 
     it('Disabled menu item has aria disabled attribute', () => {
@@ -25,8 +26,8 @@ describe('Menu Component', () => {
         )
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
         expect(menuItem.prop('role')).toBe('menuitem')
-        expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
-        expect(menuItem.prop('aria-disabled')).toBe(true)
+        // expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
+        // expect(menuItem.prop('aria-disabled')).toBe(true)
     })
 
     it('Toggle-able menu item has menuitemcheckbox role', () => {
@@ -40,6 +41,6 @@ describe('Menu Component', () => {
         )
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
         expect(menuItem.prop('role')).toBe('menuitemcheckbox')
-        expect(menuItem.prop('aria-disabled')).toBe(false)
+        // expect(menuItem.prop('aria-disabled')).toBe(false)
     })
 })

--- a/components/menu/src/menu-item/__tests__/menu-item.test.js
+++ b/components/menu/src/menu-item/__tests__/menu-item.test.js
@@ -1,0 +1,45 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import { MenuItem } from '../menu-item.js'
+
+describe('Menu Component', () => {
+    it('Default menu item has aria role', () => {
+        const menuItemDataTest = 'data-test-menu-item'
+        const wrapper = mount(
+            <MenuItem dataTest={menuItemDataTest} label="Menu item" />
+        )
+        const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
+        expect(menuItem.prop('role')).toBe('menuitem')
+        expect(menuItem.prop('aria-disabled')).toBe(false)
+        expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
+    })
+
+    it('Disabled menu item has aria disabled attribute', () => {
+        const menuItemDataTest = 'data-test-menu-item'
+        const wrapper = mount(
+            <MenuItem
+                dataTest={menuItemDataTest}
+                label="Disabled menu item"
+                disabled={true}
+            />
+        )
+        const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
+        expect(menuItem.prop('role')).toBe('menuitem')
+        expect(menuItem.prop('role')).not.toBe('menuitemcheckbox')
+        expect(menuItem.prop('aria-disabled')).toBe(true)
+    })
+
+    it('Toggle-able menu item has menuitemcheckbox role', () => {
+        const menuItemDataTest = 'data-test-menu-item'
+        const wrapper = mount(
+            <MenuItem
+                dataTest={menuItemDataTest}
+                label="Toggle-able menu item"
+                checkbox={true}
+            />
+        )
+        const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
+        expect(menuItem.prop('role')).toBe('menuitemcheckbox')
+        expect(menuItem.prop('aria-disabled')).toBe(false)
+    })
+})

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -3,7 +3,7 @@ import { Portal } from '@dhis2-ui/portal'
 import { IconChevronRight24 } from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useRef } from 'react'
+import React, { useRef, useEffect } from 'react'
 import { FlyoutMenu } from '../index.js'
 import styles from './menu-item.styles.js'
 
@@ -40,10 +40,18 @@ const MenuItem = ({
     showSubMenu,
     toggleSubMenu,
     suffix,
+    tabIndex,
     checkbox,
-    selected,
+    radio,
+    checked,
 }) => {
     const menuItemRef = useRef()
+
+    useEffect(() => {
+        if (active && tabIndex === 0) {
+            menuItemRef.current.childNodes[0].focus()
+        }
+    }, [active, tabIndex])
 
     return (
         <>
@@ -52,13 +60,11 @@ const MenuItem = ({
                     destructive,
                     disabled,
                     dense,
-                    active: active || showSubMenu || selected,
+                    active: active || showSubMenu,
                     'with-chevron': children || chevron,
                 })}
+                ref={menuItemRef}
                 data-test={dataTest}
-                role={checkbox ? 'menuitemcheckbox' : 'menuitem'}
-                aria-disabled={disabled ? disabled : false}
-                tabIndex={-1}
             >
                 <a
                     target={target}
@@ -73,6 +79,18 @@ const MenuItem = ({
                               })
                             : undefined
                     }
+                    role={
+                        checkbox
+                            ? 'menuitemcheckbox'
+                            : radio
+                            ? 'menuitemradio'
+                            : 'menuitem'
+                    }
+                    aria-haspopup={children && 'menu'}
+                    aria-expanded={showSubMenu}
+                    aria-checked={checkbox && checked}
+                    aria-disabled={disabled}
+                    tabIndex={tabIndex}
                 >
                     {icon && <span className="icon">{icon}</span>}
 
@@ -106,7 +124,10 @@ MenuItem.defaultProps = {
 
 MenuItem.propTypes = {
     active: PropTypes.bool,
+    /* For using menuitem as checkbox */
     checkbox: PropTypes.bool,
+    /* Value of checkbox */
+    checked: PropTypes.bool,
     chevron: PropTypes.bool,
     /**
      * Nested menu items can become submenus.
@@ -124,11 +145,13 @@ MenuItem.propTypes = {
     icon: PropTypes.node,
     /** Text in the menu item */
     label: PropTypes.node,
-    selected: PropTypes.bool,
+    /* For using menuitem as radio */
+    radio: PropTypes.bool,
     /** When true, nested menu items are shown in a Popper */
     showSubMenu: PropTypes.bool,
     /** A supporting element shown at the end of the menu item */
     suffix: PropTypes.node,
+    tabIndex: PropTypes.number,
     /** For using menu item as a link */
     target: PropTypes.string,
     /** On click, this function is called (without args) */

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -3,7 +3,7 @@ import { Portal } from '@dhis2-ui/portal'
 import { IconChevronRight24 } from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { forwardRef, useRef } from 'react'
+import React, { forwardRef, useCallback, useRef, useState } from 'react'
 import { FlyoutMenu } from '../index.js'
 import styles from './menu-item.styles.js'
 
@@ -49,6 +49,32 @@ const MenuItem = forwardRef(function MenuItem(
     ref
 ) {
     const menuItemRef = useRef()
+    const [openSubMenu, setOpenSubmenu] = useState(false)
+    const [subMenu, setSubMenu] = useState([])
+
+    const handleKeyDown = useCallback(
+        (event) => {
+            setSubMenu(document.querySelectorAll('[data-submenu-open=true]'))
+            switch (event.key) {
+                case 'ArrowRight':
+                    event.preventDefault()
+                    if (event.target.getAttribute('aria-haspopup')) {
+                        setOpenSubmenu(true)
+                    }
+                    break
+                case 'ArrowLeft':
+                    event.preventDefault()
+                    if (subMenu.length) {
+                        subMenu[subMenu.length - 1].focus()
+                    }
+                    setOpenSubmenu(false)
+                    break
+                default:
+                    return
+            }
+        },
+        [subMenu]
+    )
 
     return (
         <>
@@ -86,7 +112,7 @@ const MenuItem = forwardRef(function MenuItem(
                             : 'menuitem'
                     }
                     aria-haspopup={children && 'menu'}
-                    aria-expanded={showSubMenu}
+                    aria-expanded={showSubMenu || openSubMenu}
                     aria-disabled={disabled}
                     aria-checked={checkbox && checked}
                     aria-label={label}
@@ -94,6 +120,8 @@ const MenuItem = forwardRef(function MenuItem(
                         children &&
                         `popper-${label.split(' ').join('-').toLowerCase()}`
                     }
+                    data-submenu-open={children ? openSubMenu : null}
+                    onKeyDown={handleKeyDown}
                 >
                     {icon && <span className="icon">{icon}</span>}
 
@@ -110,7 +138,7 @@ const MenuItem = forwardRef(function MenuItem(
 
                 <style jsx>{styles}</style>
             </li>
-            {children && showSubMenu && (
+            {children && (showSubMenu || openSubMenu) && (
                 <Portal>
                     <Popper
                         placement="right-start"

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -40,6 +40,7 @@ const MenuItem = ({
     showSubMenu,
     toggleSubMenu,
     suffix,
+    checkbox,
 }) => {
     const menuItemRef = useRef()
 
@@ -55,6 +56,8 @@ const MenuItem = ({
                 })}
                 ref={menuItemRef}
                 data-test={dataTest}
+                role={checkbox ? 'menuitemcheckbox' : 'menuitem'}
+                aria-disabled={disabled ? disabled : false}
             >
                 <a
                     target={target}
@@ -102,6 +105,7 @@ MenuItem.defaultProps = {
 
 MenuItem.propTypes = {
     active: PropTypes.bool,
+    checkbox: PropTypes.bool,
     chevron: PropTypes.bool,
     /**
      * Nested menu items can become submenus.

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -41,6 +41,7 @@ const MenuItem = ({
     toggleSubMenu,
     suffix,
     checkbox,
+    selected,
 }) => {
     const menuItemRef = useRef()
 
@@ -51,13 +52,13 @@ const MenuItem = ({
                     destructive,
                     disabled,
                     dense,
-                    active: active || showSubMenu,
+                    active: active || showSubMenu || selected,
                     'with-chevron': children || chevron,
                 })}
-                ref={menuItemRef}
                 data-test={dataTest}
                 role={checkbox ? 'menuitemcheckbox' : 'menuitem'}
                 aria-disabled={disabled ? disabled : false}
+                tabIndex={-1}
             >
                 <a
                     target={target}
@@ -123,6 +124,7 @@ MenuItem.propTypes = {
     icon: PropTypes.node,
     /** Text in the menu item */
     label: PropTypes.node,
+    selected: PropTypes.bool,
     /** When true, nested menu items are shown in a Popper */
     showSubMenu: PropTypes.bool,
     /** A supporting element shown at the end of the menu item */

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -3,7 +3,7 @@ import { Portal } from '@dhis2-ui/portal'
 import { IconChevronRight24 } from '@dhis2/ui-icons'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useRef, useEffect } from 'react'
+import React, { forwardRef, useRef } from 'react'
 import { FlyoutMenu } from '../index.js'
 import styles from './menu-item.styles.js'
 
@@ -22,36 +22,33 @@ const createOnClickHandler =
         onClick && onClick({ value }, evt)
         toggleSubMenu && toggleSubMenu()
     }
-const MenuItem = ({
-    href,
-    onClick,
-    children,
-    target,
-    icon,
-    className,
-    destructive,
-    disabled,
-    dense,
-    active,
-    dataTest,
-    chevron,
-    value,
-    label,
-    showSubMenu,
-    toggleSubMenu,
-    suffix,
-    tabIndex,
-    checkbox,
-    radio,
-    checked,
-}) => {
+const MenuItem = forwardRef(function MenuItem(
+    {
+        href,
+        onClick,
+        children,
+        target,
+        icon,
+        className,
+        destructive,
+        disabled,
+        dense,
+        active,
+        dataTest,
+        chevron,
+        value,
+        label,
+        showSubMenu,
+        toggleSubMenu,
+        suffix,
+        tabIndex,
+        checkbox,
+        radio,
+        checked,
+    },
+    ref
+) {
     const menuItemRef = useRef()
-
-    useEffect(() => {
-        if (active && tabIndex === 0) {
-            menuItemRef.current.childNodes[0].focus()
-        }
-    }, [active, tabIndex])
 
     return (
         <>
@@ -79,6 +76,8 @@ const MenuItem = ({
                               })
                             : undefined
                     }
+                    tabIndex={tabIndex}
+                    ref={ref}
                     role={
                         checkbox
                             ? 'menuitemcheckbox'
@@ -88,9 +87,9 @@ const MenuItem = ({
                     }
                     aria-haspopup={children && 'menu'}
                     aria-expanded={showSubMenu}
-                    aria-checked={checkbox && checked}
                     aria-disabled={disabled}
-                    tabIndex={tabIndex}
+                    aria-checked={checkbox && checked}
+                    aria-label={label}
                 >
                     {icon && <span className="icon">{icon}</span>}
 
@@ -116,7 +115,7 @@ const MenuItem = ({
             )}
         </>
     )
-}
+})
 
 MenuItem.defaultProps = {
     dataTest: 'dhis2-uicore-menuitem',

--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -90,6 +90,10 @@ const MenuItem = forwardRef(function MenuItem(
                     aria-disabled={disabled}
                     aria-checked={checkbox && checked}
                     aria-label={label}
+                    aria-owns={
+                        children &&
+                        `popper-${label.split(' ').join('-').toLowerCase()}`
+                    }
                 >
                     {icon && <span className="icon">{icon}</span>}
 
@@ -108,7 +112,14 @@ const MenuItem = forwardRef(function MenuItem(
             </li>
             {children && showSubMenu && (
                 <Portal>
-                    <Popper placement="right-start" reference={menuItemRef}>
+                    <Popper
+                        placement="right-start"
+                        reference={menuItemRef}
+                        id={`popper-${label
+                            .split(' ')
+                            .join('-')
+                            .toLowerCase()}`}
+                    >
                         <FlyoutMenu dense={dense}>{children}</FlyoutMenu>
                     </Popper>
                 </Portal>

--- a/components/menu/src/menu-item/menu-item.stories.js
+++ b/components/menu/src/menu-item/menu-item.stories.js
@@ -133,6 +133,7 @@ export const ToggleMenuItem = (args) => {
                 onClick={toggleOn}
                 icon={icon}
                 label="A toggle menu item"
+                checkbox={true}
             />
         </Menu>
     )

--- a/components/menu/src/menu-item/menu-item.stories.js
+++ b/components/menu/src/menu-item/menu-item.stories.js
@@ -134,6 +134,7 @@ export const ToggleMenuItem = (args) => {
                 icon={icon}
                 label="A toggle menu item"
                 checkbox={true}
+                checked={on}
             />
         </Menu>
     )

--- a/components/menu/src/menu/__tests__/menu.test.js
+++ b/components/menu/src/menu/__tests__/menu.test.js
@@ -1,0 +1,34 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import { MenuDivider } from '../../menu-divider/menu-divider.js'
+import { MenuItem } from '../../menu-item/menu-item.js'
+import { MenuSectionHeader } from '../../menu-section-header/menu-section-header.js'
+import { Menu } from '../menu.js'
+
+describe('Menu Component', () => {
+    it('Menu has aria attributes', () => {
+        const menuDataTest = 'data-test-menu'
+        const menuItemDataTest = 'data-test-menu-item'
+        const dividerDataTest = 'data-test-menu-divider'
+        const wrapper = mount(
+            <Menu dataTest={menuDataTest} dense={false}>
+                <MenuSectionHeader label="First - no divider above" />
+                <MenuDivider dataTest={'data-test-menu-divider'} />
+                <MenuItem dataTest={menuItemDataTest} label="Menu item" />
+            </Menu>
+        )
+        const menuElement = wrapper.find({ 'data-test': menuDataTest })
+        const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
+        const menuDivider = wrapper.find({ 'data-test': dividerDataTest })
+        expect(menuItem.prop('role')).toBe('menuitem')
+        expect(menuDivider.prop('role')).toBe('separator')
+        expect(menuElement.prop('role')).toBe('menu')
+    })
+
+    it('Empty menu has aria attributes', () => {
+        const menuDataTest = 'data-test-menu'
+        const wrapper = mount(<Menu dataTest={menuDataTest} dense={false} />)
+        const menuElement = wrapper.find({ 'data-test': menuDataTest })
+        expect(menuElement.prop('role')).toBe('menu')
+    })
+})

--- a/components/menu/src/menu/__tests__/menu.test.js
+++ b/components/menu/src/menu/__tests__/menu.test.js
@@ -6,29 +6,58 @@ import { MenuSectionHeader } from '../../menu-section-header/menu-section-header
 import { Menu } from '../menu.js'
 
 describe('Menu Component', () => {
-    it('Menu has aria attributes', () => {
+    it('Menu and menu items have aria attributes', () => {
         const menuDataTest = 'data-test-menu'
         const menuItemDataTest = 'data-test-menu-item'
         const dividerDataTest = 'data-test-menu-divider'
         const wrapper = mount(
             <Menu dataTest={menuDataTest} dense={false}>
-                <MenuSectionHeader label="First - no divider above" />
-                <MenuDivider dataTest={'data-test-menu-divider'} />
+                <MenuSectionHeader label="Header" />
+                <MenuDivider dataTest={dividerDataTest} />
                 <MenuItem dataTest={menuItemDataTest} label="Menu item" />
             </Menu>
         )
         const menuElement = wrapper.find({ 'data-test': menuDataTest })
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
         const menuDivider = wrapper.find({ 'data-test': dividerDataTest })
-        expect(menuItem.firstChild.prop('role')).toBe('menuitem')
-        expect(menuDivider.prop('role')).toBe('separator')
+
         expect(menuElement.prop('role')).toBe('menu')
+
+        expect(menuItem.childAt(0).props().role).toBe('menuitem')
+        expect(menuItem.childAt(0).prop('aria-label')).toBe('Menu item')
+        expect(menuDivider.prop('role')).toBe('separator')
     })
 
-    it('Empty menu has aria attributes', () => {
+    it('Empty menu has role menu', () => {
         const menuDataTest = 'data-test-menu'
         const wrapper = mount(<Menu dataTest={menuDataTest} dense={false} />)
         const menuElement = wrapper.find({ 'data-test': menuDataTest })
         expect(menuElement.prop('role')).toBe('menu')
+    })
+
+    it('Submenu has relevant aria attributes', () => {
+        const showSubMenu = false
+        const wrapper = mount(
+            <Menu>
+                <MenuItem
+                    showSubMenu={showSubMenu}
+                    toggleSubMenu={() => jest.fn()}
+                    label="Parent of submenus"
+                >
+                    <MenuItem label="Test submenu child" />
+                </MenuItem>
+            </Menu>
+        )
+
+        const menuItem = wrapper.find({ role: 'menuitem' })
+
+        expect(menuItem.prop('aria-haspopup')).toBe('menu')
+        expect(menuItem.prop('aria-expanded')).toBe(false)
+        expect(menuItem.prop('aria-expanded')).toBe(false)
+        expect(menuItem.prop('aria-label')).toBe('Parent of submenus')
+        expect(wrapper.find({ label: 'Test submenu child' }).exists()).toBe(
+            false
+        )
+        // todo: simulate click to show submenu
     })
 })

--- a/components/menu/src/menu/__tests__/menu.test.js
+++ b/components/menu/src/menu/__tests__/menu.test.js
@@ -20,7 +20,7 @@ describe('Menu Component', () => {
         const menuElement = wrapper.find({ 'data-test': menuDataTest })
         const menuItem = wrapper.find({ 'data-test': menuItemDataTest })
         const menuDivider = wrapper.find({ 'data-test': dividerDataTest })
-        expect(menuItem.prop('role')).toBe('menuitem')
+        expect(menuItem.firstChild.prop('role')).toBe('menuitem')
         expect(menuDivider.prop('role')).toBe('separator')
         expect(menuElement.prop('role')).toBe('menu')
     })

--- a/components/menu/src/menu/menu.js
+++ b/components/menu/src/menu/menu.js
@@ -33,14 +33,13 @@ const Menu = ({ children, className, dataTest, dense }) => {
         return obj
     }
 
-    const focusFirstFocusableItem = useCallback(
+    const handleFocus = useCallback(
         (e) => {
             const focusableItems = findFocusableItems()
 
             if (e.target === menuRef.current) {
                 if (focusedIndex === -1) {
                     setFocusedIndex(~~Object.keys(focusableItems)[0])
-                    // Object.values(focusableItems)[0].focus()
                 }
             }
         },
@@ -96,33 +95,12 @@ const Menu = ({ children, className, dataTest, dense }) => {
                         })
                     )
                     break
-                case 'ArrowRight':
-                    event.preventDefault()
-                    if (event.target.hasAttribute('aria-haspopup')) {
-                        event.target.click()
-                    }
-                    break
-                case 'ArrowLeft':
-                    event.preventDefault()
-                    document
-                        .querySelector(
-                            `[aria-owns='${event.target.parentNode.parentNode.parentNode.parentNode.getAttribute(
-                                'id'
-                            )}']`
-                        )
-                        .focus()
-                    document
-                        .querySelector(
-                            `[aria-owns='${event.target.parentNode.parentNode.parentNode.parentNode.getAttribute(
-                                'id'
-                            )}']`
-                        )
-                        .click()
-                    break
                 case ' ':
                 case 'Enter':
                     event.preventDefault()
-                    event.target.click()
+                    if (event.target.getAttribute('aria-disabled') === null) {
+                        event.target.click()
+                    }
                     break
                 default:
                     return
@@ -144,14 +122,14 @@ const Menu = ({ children, className, dataTest, dense }) => {
         }
         const menu = menuRef.current
 
-        menu.addEventListener('focus', focusFirstFocusableItem)
+        menu.addEventListener('focus', handleFocus)
         menu.addEventListener('keydown', handleKeyDown)
 
         return () => {
             menu.removeEventListener('keydown', handleKeyDown)
-            menu.removeEventListener('focus', focusFirstFocusableItem)
+            menu.removeEventListener('focus', handleFocus)
         }
-    }, [focusFirstFocusableItem, handleKeyDown])
+    }, [handleFocus, handleKeyDown])
 
     return (
         <ul
@@ -178,20 +156,24 @@ const Menu = ({ children, className, dataTest, dense }) => {
                           showSubMenu: child.props.children
                               ? child.props.showSubMenu
                               : null,
-                          ref: (node) => {
-                              const role = node?.getAttribute('role')
-                              if (
-                                  [
-                                      'menuitem',
-                                      'menuitemradio',
-                                      'menuitemcheckbox',
-                                  ].includes(role)
-                              ) {
-                                  return (itemsRefs.current[index] = node)
-                              } else {
-                                  return null
-                              }
-                          },
+                          ...(child.props.dataTest &&
+                          child.props.dataTest.includes('menuitem')
+                              ? {
+                                    ref: (node) => {
+                                        const role = node?.getAttribute('role')
+                                        if (
+                                            [
+                                                'menuitem',
+                                                'menuitemradio',
+                                                'menuitemcheckbox',
+                                            ].includes(role)
+                                        ) {
+                                            return (itemsRefs.current[index] =
+                                                node)
+                                        }
+                                    },
+                                }
+                              : {}),
                       })
                     : child
             })}

--- a/components/menu/src/menu/menu.js
+++ b/components/menu/src/menu/menu.js
@@ -33,14 +33,19 @@ const Menu = ({ children, className, dataTest, dense }) => {
         return obj
     }
 
-    const focusFirstFocusableItem = useCallback((e) => {
-        const focusableItems = findFocusableItems()
+    const focusFirstFocusableItem = useCallback(
+        (e) => {
+            const focusableItems = findFocusableItems()
 
-        if (e.target === menuRef.current) {
-            setFocusedIndex(~~Object.keys(focusableItems)[0])
-            Object.values(focusableItems)[0].focus()
-        }
-    }, [])
+            if (e.target === menuRef.current) {
+                if (focusedIndex === -1) {
+                    setFocusedIndex(~~Object.keys(focusableItems)[0])
+                    // Object.values(focusableItems)[0].focus()
+                }
+            }
+        },
+        [focusedIndex]
+    )
 
     const setNextFocusableIndex = useCallback(({ elemIndex, action }) => {
         const focusableItems = findFocusableItems()
@@ -99,6 +104,20 @@ const Menu = ({ children, className, dataTest, dense }) => {
                     break
                 case 'ArrowLeft':
                     event.preventDefault()
+                    document
+                        .querySelector(
+                            `[aria-owns='${event.target.parentNode.parentNode.parentNode.parentNode.getAttribute(
+                                'id'
+                            )}']`
+                        )
+                        .focus()
+                    document
+                        .querySelector(
+                            `[aria-owns='${event.target.parentNode.parentNode.parentNode.parentNode.getAttribute(
+                                'id'
+                            )}']`
+                        )
+                        .click()
                     break
                 case ' ':
                 case 'Enter':
@@ -156,6 +175,9 @@ const Menu = ({ children, className, dataTest, dense }) => {
                                   : child.props.hideDivider,
                           tabIndex: focusedIndex === index ? 0 : -1,
                           active: focusedIndex === index,
+                          showSubMenu: child.props.children
+                              ? child.props.showSubMenu
+                              : null,
                           ref: (node) => {
                               const role = node?.getAttribute('role')
                               if (

--- a/components/menu/src/menu/menu.js
+++ b/components/menu/src/menu/menu.js
@@ -1,37 +1,138 @@
 import PropTypes from 'prop-types'
-import React, { Children, cloneElement, isValidElement } from 'react'
+import React, {
+    Children,
+    cloneElement,
+    isValidElement,
+    useEffect,
+    useState,
+    useRef,
+} from 'react'
 
-const Menu = ({ children, className, dataTest, dense }) => (
-    <ul className={className} data-test={dataTest} role="menu">
-        {Children.map(children, (child, index) =>
-            isValidElement(child)
-                ? cloneElement(child, {
-                      dense:
-                          typeof child.props.dense === 'boolean'
-                              ? child.props.dense
-                              : dense,
-                      hideDivider:
-                          typeof child.props.hideDivider !== 'boolean' &&
-                          index === 0
-                              ? true
-                              : child.props.hideDivider,
-                  })
-                : child
-        )}
+const Menu = ({ children, className, dataTest, dense }) => {
+    const [selectedIndex, setSelectedIndex] = useState(-1)
+    const menuRef = useRef(null)
 
-        <style jsx>{`
-            ul {
-                display: block;
-                position: relative;
-                width: 100%;
-                margin: 0;
+    useEffect(() => {
+        if (!menuRef.current) {
+            return
+        }
+        const menu = menuRef.current
+        const childrenArray = Children.toArray(children)
 
-                padding: 0;
-                user-select: none;
+        const handleIndex = (index, action) => {
+            let current_position = index
+            if (current_position === -1) {
+                return current_position
             }
-        `}</style>
-    </ul>
-)
+            const current_element = childrenArray[current_position]
+            if (
+                ['MenuSectionHeader', 'MenuDivider'].includes(
+                    current_element.type?.name
+                ) ||
+                current_element.props.disabled
+            ) {
+                current_position = action === 'up' ? index - 1 : index + 1
+            }
+
+            if (current_position > childrenArray.length - 1) {
+                current_position = 0
+            } else if (current_position < 0) {
+                current_position = childrenArray.length - 1
+            }
+
+            return current_position
+        }
+
+        const handleDirection = (event) => {
+            let active = selectedIndex
+            const { key } = event
+
+            if (key === 'ArrowUp') {
+                if (active > 0) {
+                    active = active - 1
+                    active = handleIndex(active, 'up')
+                    setSelectedIndex(active)
+                }
+            }
+            if (key === 'ArrowDown') {
+                if (active < childrenArray.length - 1) {
+                    active = active + 1
+                    active = handleIndex(active, 'down')
+                    setSelectedIndex(active)
+                }
+            }
+        }
+
+        const handleActionKeys = (event) => {
+            if (selectedIndex > -1) {
+                const { target } = event
+                const child = target.children[selectedIndex]
+                if (child.onclick) {
+                    child.click()
+                } else if (child.childNodes[0].onclick) {
+                    child.childNodes[0].click()
+                }
+            }
+        }
+
+        const handleKeyDown = (event) => {
+            event.preventDefault()
+
+            if (event.key === ' ' || event.key === 'Enter') {
+                handleActionKeys(event)
+            }
+            if (event.key.startsWith('Arrow')) {
+                handleDirection(event)
+            }
+        }
+
+        menu.addEventListener('keydown', handleKeyDown)
+
+        return () => {
+            menu.removeEventListener('keydown', handleKeyDown)
+        }
+    }, [children, selectedIndex])
+
+    return (
+        <ul
+            className={className}
+            data-test={dataTest}
+            role="menu"
+            tabIndex={0}
+            ref={menuRef}
+        >
+            {Children.map(children, (child, index) => {
+                return isValidElement(child)
+                    ? cloneElement(child, {
+                          dense:
+                              typeof child.props.dense === 'boolean'
+                                  ? child.props.dense
+                                  : dense,
+                          hideDivider:
+                              typeof child.props.hideDivider !== 'boolean' &&
+                              index === 0
+                                  ? true
+                                  : child.props.hideDivider,
+                          selected:
+                              index === selectedIndex && !child.props.disabled,
+                      })
+                    : child
+            })}
+
+            <style jsx>{`
+                ul {
+                    display: block;
+                    position: relative;
+                    width: 100%;
+                    margin: 0;
+
+                    padding: 0;
+                    user-select: none;
+                }
+            `}</style>
+        </ul>
+    )
+}
 
 Menu.defaultProps = {
     dataTest: 'dhis2-uicore-menulist',

--- a/components/menu/src/menu/menu.js
+++ b/components/menu/src/menu/menu.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { Children, cloneElement, isValidElement } from 'react'
 
 const Menu = ({ children, className, dataTest, dense }) => (
-    <ul className={className} data-test={dataTest}>
+    <ul className={className} data-test={dataTest} role="menu">
         {Children.map(children, (child, index) =>
             isValidElement(child)
                 ? cloneElement(child, {

--- a/components/popper/src/popper.js
+++ b/components/popper/src/popper.js
@@ -16,6 +16,7 @@ const flipPlacement = (placement) => {
 }
 
 const Popper = ({
+    id,
     children,
     className,
     dataTest,
@@ -51,6 +52,7 @@ const Popper = ({
 
     return (
         <div
+            id={id}
             className={className}
             data-test={dataTest}
             ref={setPopperElement}
@@ -74,6 +76,7 @@ Popper.propTypes = {
     children: PropTypes.node.isRequired,
     className: PropTypes.string,
     dataTest: PropTypes.string,
+    id: PropTypes.string,
     /** A property of the `createPopper` options. See [popper docs](https://popper.js.org/docs/v2/constructors/) */
     modifiers: PropTypes.arrayOf(
         PropTypes.shape({

--- a/components/popper/types/index.d.ts
+++ b/components/popper/types/index.d.ts
@@ -6,6 +6,7 @@ type PopperReference = VirtualElement | Element
 type ReferenceElement = PopperReference | React.RefObject<PopperReference>
 
 export interface PopperProps {
+    id?: string
     /**
      * Content inside the Popper
      */


### PR DESCRIPTION
Implements [LIBS-556](https://dhis2.atlassian.net/browse/LIBS-556)

---

### Description
This feature improves the accessibility of the menu and menu components, i.e. MenuDivider, MenuItem, MenuSectionHeader. 

- It adds aria-roles to the different parts of the menu and its components
- A user can use the `Up` and `Down` arrow keys to navigate through the list of menu items and focus them (except the menu section header and menu divider)
- A user can use the `Enter` and `Space` keys to trigger actions attached to menu items (except the disabled ones). For example: opening a link, toggling a checkbox, opening a submenu, etc. 
- A user can use the `Right` arrow key to open a submenu and `Left` arrow key to close it. 

---

### Checklist

-   [ ] API docs are generated
-   [x] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

_supporting text_


[LIBS-556]: https://dhis2.atlassian.net/browse/LIBS-556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ