### PR TITLE
fix(deps): upgrade @dhis2/multi-calendar-dates for relaxed peer deps fix [LIBS-587]

### DIFF
--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -27,8 +27,8 @@
         "test": "d2-app-scripts test --jestConfig ../../jest.config.shared.js"
     },
     "peerDependencies": {
-        "react": "^16.8",
         "@dhis2/d2-i18n": "^1",
+        "react": "^16.8",
         "react-dom": "^16.8",
         "styled-jsx": "^4"
     },
@@ -38,7 +38,7 @@
         "@dhis2-ui/input": "9.4.3",
         "@dhis2-ui/layer": "9.4.3",
         "@dhis2-ui/popper": "9.4.3",
-        "@dhis2/multi-calendar-dates": "1.0.2",
+        "@dhis2/multi-calendar-dates": "^1.1.1",
         "@dhis2/prop-types": "^3.1.2",
         "@dhis2/ui-constants": "9.4.3",
         "@dhis2/ui-icons": "9.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,10 +2586,10 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/multi-calendar-dates@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.2.tgz#e54dc85e512aba93fceef3004e67e199077f3ba8"
-  integrity sha512-oQZ7PFMwHFpt4ygDN9DmAeYO3g07L7AHJW6diZ37mzpkEF/DyMafhsZHnJWNlTH5HDp8nYuO3EjBiM7fZN6C0g==
+"@dhis2/multi-calendar-dates@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.1.1.tgz#fb76a77114ce0b757db7dd9f588d1a47809732da"
+  integrity sha512-kaisVuRGfdqY/Up6sWqgc81K67ymPVoRYgYRcT29z61ol2WhiTXTSTuRX/gDO1VKjmskeB5/badRrdLMf4BBUA==
   dependencies:
     "@js-temporal/polyfill" "^0.4.2"
     classnames "^2.3.2"


### PR DESCRIPTION
Part of [LIBS-587](https://dhis2.atlassian.net/browse/LIBS-587)

A peer dependency on exactly `react@16.8` was part of a dependency conflict with other packages that need `react@^16.14` -- the change in `@dhis2/multi-calendar-dates` now need to be propagated to `@dhis2/ui`, `@dhis2/cli-app-scripts`, and `@dhis2/cli`