### PR TITLE
fix(button): fix prop types for button

### DIFF
--- a/components/button/types/index.d.ts
+++ b/components/button/types/index.d.ts
@@ -16,7 +16,6 @@ type ButtonOpenEventHandler<
     Event extends React.SyntheticEvent = React.MouseEvent<HTMLButtonElement>
 > = (arg0: ButtonEventPayload & { open: boolean }, event: Event) => void
 
-
 export interface BaseButtonProps {
     /**
      * Component to render inside the button
@@ -103,7 +102,8 @@ export interface BaseButtonProps {
     onKeyDown?: ButtonEventHandler<React.KeyboardEvent<HTMLButtonElement>>
 }
 
-export type ButtonProps = BaseButtonProps & Omit<React.ComponentPropsWithoutRef<'button'>, keyof BaseButtonProps>
+export type ButtonProps = BaseButtonProps &
+    Omit<React.ComponentPropsWithoutRef<'button'>, keyof BaseButtonProps>
 
 export const Button: React.FC<ButtonProps>
 

--- a/components/button/types/index.d.ts
+++ b/components/button/types/index.d.ts
@@ -16,7 +16,7 @@ type ButtonOpenEventHandler<
     Event extends React.SyntheticEvent = React.MouseEvent<HTMLButtonElement>
 > = (arg0: ButtonEventPayload & { open: boolean }, event: Event) => void
 
-export interface ButtonProps extends HTMLButtonElement {
+export interface ButtonProps {
     /**
      * Component to render inside the button
      */
@@ -102,7 +102,9 @@ export interface ButtonProps extends HTMLButtonElement {
     onKeyDown?: ButtonEventHandler<React.KeyboardEvent<HTMLButtonElement>>
 }
 
-export const Button: React.FC<ButtonProps>
+export const Button: React.FC<
+    ButtonProps & Omit<React.HTMLProps<HTMLButtonElement>, keyof ButtonProps>
+>
 
 export interface ButtonStripProps {
     children?: React.ReactNode

--- a/components/button/types/index.d.ts
+++ b/components/button/types/index.d.ts
@@ -16,7 +16,8 @@ type ButtonOpenEventHandler<
     Event extends React.SyntheticEvent = React.MouseEvent<HTMLButtonElement>
 > = (arg0: ButtonEventPayload & { open: boolean }, event: Event) => void
 
-export interface ButtonProps {
+
+export interface BaseButtonProps {
     /**
      * Component to render inside the button
      */
@@ -102,9 +103,9 @@ export interface ButtonProps {
     onKeyDown?: ButtonEventHandler<React.KeyboardEvent<HTMLButtonElement>>
 }
 
-export const Button: React.FC<
-    ButtonProps & Omit<React.HTMLProps<HTMLButtonElement>, keyof ButtonProps>
->
+export type ButtonProps = BaseButtonProps & Omit<React.ComponentPropsWithoutRef<'button'>, keyof BaseButtonProps>
+
+export const Button: React.FC<ButtonProps>
 
 export interface ButtonStripProps {
     children?: React.ReactNode


### PR DESCRIPTION
### Description

I don't think we should extend `HTML`-elements directly. In some cases like `tabIndex` we're actually using a conflicting type, which causes type-errors in our types. 
`tabIndex` should really be a `number` (that's what the html type is), but that would be breaking due to our prop-types etc.

So instead of ButtonProps extending the `HTMLButtonElement`, I'm using type intersection with the `ComponentPropsWithoutRef<'button'>` without the keys for `ButtonProps`, to avoid conflicts. 
I also split this in two types types because eg. `export interface ButtonProps extends Omit<React.ComponentPropsWithoutRef<'button'>, keyof ButtonProps>`) wouldn't work because of circular references. 

See https://github.com/typescript-cheatsheets/react/blob/main/docs/advanced/patterns_by_usecase.md#wrappingmirroring, and expand "Why not ComponentProps or IntrinsicElements or [Element]HTMLAttributes or HTMLProps or HTMLAttributes?"  for why we're using `ComponentPropsWithoutRef`, as opposed to the other prop-types. 

