### PR TITLE
fix(split-button): stop swallowing key down events

### DIFF
--- a/components/button/src/split-button/split-button.js
+++ b/components/button/src/split-button/split-button.js
@@ -30,8 +30,8 @@ class SplitButton extends Component {
         document.removeEventListener('keydown', this.handleKeyDown)
     }
     handleKeyDown = (event) => {
-        event.preventDefault()
         if (event.key === 'Escape' && this.state.open) {
+            event.preventDefault()
             event.stopPropagation()
             this.setState({ open: false })
             this.anchorRef.current && this.anchorRef.current.focus()


### PR DESCRIPTION
Fixes an issue where the split button swallows the key down event regardless of wheteher it's ESC being hit or not

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._
