### PR TITLE
fix: do not hijack input when inside a menu

### DIFF
--- a/components/menu/src/menu/__tests__/menu.test.js
+++ b/components/menu/src/menu/__tests__/menu.test.js
@@ -1,3 +1,4 @@
+import { Input } from '@dhis2-ui/input'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { mount } from 'enzyme'
@@ -179,5 +180,25 @@ describe('Menu Component', () => {
         expect(nonListMenuItem.parentElement).toHaveFocus()
         // non menu items do not receive focus
         expect(plainListItem.parentElement).not.toHaveFocus()
+    })
+
+    it('does not hijack input change value if space entered [bug]', () => {
+        const onChange = jest.fn()
+        const { getByPlaceholderText } = render(
+            <Menu dataTest={menuDataTest} dense={false}>
+                <MenuItem value="myValue" label="Click menu item" />
+                <Input onChange={onChange} placeholder="test"></Input>
+            </Menu>
+        )
+
+        const inputField = getByPlaceholderText('test')
+        inputField.focus()
+        userEvent.keyboard('t')
+        userEvent.keyboard('e')
+        userEvent.keyboard(' ')
+        userEvent.keyboard('st')
+
+        expect(inputField.value).toBe('te st')
+        expect(onChange).toHaveBeenCalled()
     })
 })

--- a/components/menu/src/menu/use-menu.js
+++ b/components/menu/src/menu/use-menu.js
@@ -52,9 +52,9 @@ export const useMenuNavigation = (children) => {
                         break
                     case 'Enter':
                     case ' ':
-                        event.preventDefault()
                         if (event.target.nodeName === 'LI') {
-                            event.target.children[0].click()
+                            event.preventDefault()
+                            event.target.children?.[0]?.click()
                         }
                         break
                     default:


### PR DESCRIPTION
When an input is inside a menu item, the logic to handle a `space` (for accessibility) was hijacking any spaces entered in the input. Now we're restricting the handling of spaces for toggling a menu item to the menu item itself. (Bug Reported by Tracker)

I added a test to recreate the bug, and validate the fix.