### PR TITLE
fix(ts and prop types): correct some types and propTypes

### DIFF
--- a/components/menu/types/index.d.ts
+++ b/components/menu/types/index.d.ts
@@ -80,7 +80,7 @@ export interface MenuItemProps {
     /**
      * A supporting element shown at the end of the menu item
      */
-    suffix: React.ReactNode
+    suffix?: React.ReactNode
     tabIndex?: number
     /**
      * For using menu item as a link

--- a/components/modal/src/modal-title/modal-title.js
+++ b/components/modal/src/modal-title/modal-title.js
@@ -26,6 +26,6 @@ ModalTitle.defaultProps = {
 }
 
 ModalTitle.propTypes = {
-    children: PropTypes.string,
+    children: PropTypes.node,
     dataTest: PropTypes.string,
 }

--- a/components/modal/types/index.d.ts
+++ b/components/modal/types/index.d.ts
@@ -36,7 +36,7 @@ export interface ModalContentProps {
 export const ModalContent: React.FC<ModalContentProps>
 
 export interface ModalTitleProps {
-    children?: string
+    children?: React.ReactNode
     dataTest?: string
 }
 

--- a/components/tag/src/tag.js
+++ b/components/tag/src/tag.js
@@ -102,7 +102,7 @@ Tag.defaultProps = {
 Tag.propTypes = {
     /** Use bold tags where it is important that the tag is seen by the user in an information dense interface. Bold tags should be reserved for edge cases and not overused. */
     bold: PropTypes.bool,
-    children: PropTypes.string,
+    children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
     /** Tags can contain icons. Use icons where they will help users easily identify the content of the tag. Tags must have a text label and cannot display only an icon. */

--- a/components/tag/types/index.d.ts
+++ b/components/tag/types/index.d.ts
@@ -5,7 +5,7 @@ export interface TagProps {
      * Use bold tags where it is important that the tag is seen by the user in an information dense interface. Bold tags should be reserved for edge cases and not overused.
      */
     bold?: boolean
-    children?: string
+    children?: React.ReactNode
     className?: string
     dataTest?: string
     /**

--- a/icons/types/index.d.ts
+++ b/icons/types/index.d.ts
@@ -184,6 +184,8 @@ export const IconSubscribe16: React.FC<IconProps>
 export const IconSubscribe24: React.FC<IconProps>
 export const IconSubscribeOff16: React.FC<IconProps>
 export const IconSubscribeOff24: React.FC<IconProps>
+export const IconSubtract16: React.FC<IconProps>
+export const IconSubtract24: React.FC<IconProps>
 export const IconSubtractCircle16: React.FC<IconProps>
 export const IconSubtractCircle24: React.FC<IconProps>
 export const IconSync16: React.FC<IconProps>


### PR DESCRIPTION
While moving the instance manager FE from CRA to Vite, I encountered some type issues in this repository, see commit messages:

* fix(icon types): export IconSubtract16 & IconSubtract24
* fix(menu item types): make suffix prop optional
* fix(modal types): accept ReactNodes as children
* fix(tag types): accept ReactNodes as children