### PR TITLE
refactor: improve performance of calendar component

### DIFF
--- a/components/calendar/src/calendar-input/calendar-input.js
+++ b/components/calendar/src/calendar-input/calendar-input.js
@@ -93,6 +93,7 @@ export const CalendarInput = ({
             maxDate,
             validation, // todo: clarify "validation" type in the hook
             format,
+            isValid: pickerResults.isValid,
             calendarWeekDays: pickerResults.calendarWeekDays,
             weekDayLabels: pickerResults.weekDayLabels,
             currMonth: pickerResults.currMonth,

--- a/components/calendar/src/calendar-input/calendar-input.js
+++ b/components/calendar/src/calendar-input/calendar-input.js
@@ -7,13 +7,10 @@ import {
     useDatePicker,
     useResolvedDirection,
 } from '@dhis2/multi-calendar-dates'
-import { colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
-// import { debounce } from 'lodash'
 import React, { useRef, useState, useMemo, useCallback } from 'react'
-import { CalendarTable } from '../calendar/calendar-table.js'
+import { CalendarContainer } from '../calendar/calendar-container.js'
 import { CalendarProps } from '../calendar/calendar.js'
-import { NavigationContainer } from '../calendar/navigation-container.js'
 import i18n from '../locales/index.js'
 
 const offsetModifier = {
@@ -56,16 +53,11 @@ export const CalendarInput = ({
         [calendar, locale, numberingSystem, timeZone, weekDayFormat]
     )
 
-    const onDateSelect = useCallback(
-        (result, keepPopperOpen = false) => {
-            setOpen(keepPopperOpen)
+    const pickerResults = useDatePicker({
+        onDateSelect: (result) => {
+            setOpen(false)
             parentOnDateSelect?.(result)
         },
-        [parentOnDateSelect]
-    )
-
-    const pickerResults = useDatePicker({
-        onDateSelect,
         date,
         minDate: minDate,
         maxDate: maxDate,
@@ -75,24 +67,20 @@ export const CalendarInput = ({
     })
 
     const handleChange = (e) => {
-        onDateSelect?.({ calendarDateString: e.value })
+        parentOnDateSelect?.({ calendarDateString: e.value })
     }
 
     const onFocus = () => {
         setOpen(true)
     }
 
+    const languageDirection = useResolvedDirection(dir, locale)
+
     const calendarProps = useMemo(() => {
         return {
             date,
-            dir,
-            locale,
             width,
             cellSize,
-            minDate,
-            maxDate,
-            validation, // todo: clarify "validation" type in the hook
-            format,
             isValid: pickerResults.isValid,
             calendarWeekDays: pickerResults.calendarWeekDays,
             weekDayLabels: pickerResults.weekDayLabels,
@@ -102,21 +90,9 @@ export const CalendarInput = ({
             nextYear: pickerResults.nextYear,
             prevMonth: pickerResults.prevMonth,
             prevYear: pickerResults.prevYear,
+            languageDirection,
         }
-    }, [
-        cellSize,
-        date,
-        dir,
-        format,
-        locale,
-        maxDate,
-        minDate,
-        pickerResults,
-        validation,
-        width,
-    ])
-
-    const languageDirection = useResolvedDirection(dir, locale)
+    }, [cellSize, date, pickerResults, width, languageDirection])
 
     return (
         <>
@@ -151,7 +127,7 @@ export const CalendarInput = ({
                             secondary
                             small
                             onClick={() => {
-                                onDateSelect?.(null)
+                                parentOnDateSelect?.(null)
                             }}
                             type="button"
                         >
@@ -172,27 +148,7 @@ export const CalendarInput = ({
                         modifiers={[offsetModifier]}
                     >
                         <Card>
-                            <div
-                                className="calendar-wrapper"
-                                dir={languageDirection}
-                                data-test="calendar"
-                            >
-                                <NavigationContainer
-                                    pickerOptions={calendarProps}
-                                    languageDirection={languageDirection}
-                                />
-                                <CalendarTable
-                                    selectedDate={
-                                        calendarProps.isValid ? date : null
-                                    }
-                                    calendarWeekDays={
-                                        calendarProps.calendarWeekDays
-                                    }
-                                    weekDayLabels={calendarProps.weekDayLabels}
-                                    cellSize={cellSize}
-                                    width={width}
-                                />
-                            </div>
+                            <CalendarContainer {...calendarProps} />
                         </Card>
                     </Popper>
                 </Layer>
@@ -213,20 +169,6 @@ export const CalendarInput = ({
                     }
                     .calendar-clear-button.with-dense-wrapper {
                         inset-block-start: 23px;
-                    }
-                    .calendar-wrapper {
-                        font-family: Roboto, sans-serif;
-                        font-weight: 400;
-                        font-size: 14px;
-                        background-color: none;
-                        display: flex;
-                        flex-direction: column;
-                        border: 1px solid ${colors.grey300};
-                        border-radius: 3px;
-                        min-width: ${width};
-                        width: max-content;
-                        box-shadow: 0px 4px 6px -2px #2129340d;
-                        box-shadow: 0px 10px 15px -3px #2129341a;
                     }
                 `}
             </style>

--- a/components/calendar/src/calendar/calendar-container.js
+++ b/components/calendar/src/calendar/calendar-container.js
@@ -1,0 +1,92 @@
+import { colors } from '@dhis2/ui-constants'
+import PropTypes from 'prop-types'
+import React, { useMemo } from 'react'
+import { CalendarTable, CalendarTableProps } from './calendar-table.js'
+import {
+    NavigationContainer,
+    NavigationContainerProps,
+} from './navigation-container.js'
+
+const wrapperBorderColor = colors.grey300
+const backgroundColor = 'none'
+
+export const CalendarContainer = ({
+    date,
+    width,
+    cellSize,
+    calendarWeekDays,
+    weekDayLabels,
+    currMonth,
+    currYear,
+    nextMonth,
+    nextYear,
+    prevMonth,
+    prevYear,
+    languageDirection,
+}) => {
+    const navigationProps = useMemo(() => {
+        return {
+            currMonth,
+            currYear,
+            nextMonth,
+            nextYear,
+            prevMonth,
+            prevYear,
+            languageDirection,
+        }
+    }, [
+        currMonth,
+        currYear,
+        languageDirection,
+        nextMonth,
+        nextYear,
+        prevMonth,
+        prevYear,
+    ])
+    return (
+        <div>
+            <div
+                className="calendar-wrapper"
+                dir={languageDirection}
+                data-test="calendar"
+            >
+                <NavigationContainer {...navigationProps} />
+                <CalendarTable
+                    selectedDate={date}
+                    calendarWeekDays={calendarWeekDays}
+                    weekDayLabels={weekDayLabels}
+                    cellSize={cellSize}
+                    width={width}
+                />
+            </div>
+            <style jsx>{`
+                .calendar-wrapper {
+                    font-family: Roboto, sans-serif;
+                    font-weight: 400;
+                    font-size: 14px;
+                    background-color: ${backgroundColor};
+                    display: flex;
+                    flex-direction: column;
+                    border: 1px solid ${wrapperBorderColor};
+                    border-radius: 3px;
+                    min-width: ${width};
+                    width: max-content;
+                    box-shadow: 0px 4px 6px -2px #2129340d;
+                    box-shadow: 0px 10px 15px -3px #2129341a;
+                }
+            `}</style>
+        </div>
+    )
+}
+
+CalendarContainer.defaultProps = {
+    cellSize: '32px',
+    width: '240px',
+}
+
+CalendarContainer.propTypes = {
+    /** the currently selected date using an iso-like format YYYY-MM-DD, in the calendar system provided (not iso8601) */
+    date: PropTypes.string,
+    ...CalendarTableProps,
+    ...NavigationContainerProps,
+}

--- a/components/calendar/src/calendar/calendar-table.js
+++ b/components/calendar/src/calendar/calendar-table.js
@@ -48,7 +48,7 @@ export const CalendarTable = ({
     </div>
 )
 
-CalendarTable.propTypes = {
+export const CalendarTableProps = {
     calendarWeekDays: PropTypes.arrayOf(
         PropTypes.arrayOf(
             PropTypes.shape({
@@ -70,3 +70,5 @@ CalendarTable.propTypes = {
     weekDayLabels: PropTypes.arrayOf(PropTypes.string),
     width: PropTypes.string,
 }
+
+CalendarTable.propTypes = CalendarTableProps

--- a/components/calendar/src/calendar/calendar.js
+++ b/components/calendar/src/calendar/calendar.js
@@ -2,11 +2,9 @@ import {
     useDatePicker,
     useResolvedDirection,
 } from '@dhis2/multi-calendar-dates'
-import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
-import React, { useState } from 'react'
-import { CalendarTable } from './calendar-table.js'
-import { NavigationContainer } from './navigation-container.js'
+import React, { useMemo, useState } from 'react'
+import { CalendarContainer } from './calendar-container.js'
 
 export const Calendar = ({
     onDateSelect,
@@ -20,9 +18,6 @@ export const Calendar = ({
     width,
     cellSize,
 }) => {
-    const wrapperBorderColor = colors.grey300
-    const backgroundColor = 'none'
-
     const [selectedDateString, setSelectedDateString] = useState(date)
     const languageDirection = useResolvedDirection(dir, locale)
 
@@ -34,7 +29,7 @@ export const Calendar = ({
         weekDayFormat,
     }
 
-    const pickerOptions = useDatePicker({
+    const pickerResults = useDatePicker({
         onDateSelect: (result) => {
             const { calendarDateString } = result
             setSelectedDateString(calendarDateString)
@@ -44,43 +39,33 @@ export const Calendar = ({
         options,
     })
 
-    const { calendarWeekDays, weekDayLabels } = pickerOptions
+    const calendarProps = useMemo(() => {
+        return {
+            date,
+            dir,
+            locale,
+            width,
+            cellSize,
+            // minDate,
+            // maxDate,
+            // validation, // todo: clarify how we use validation props (and format) in Calendar (not CalendarInput)
+            // format,
+            isValid: pickerResults.isValid,
+            calendarWeekDays: pickerResults.calendarWeekDays,
+            weekDayLabels: pickerResults.weekDayLabels,
+            currMonth: pickerResults.currMonth,
+            currYear: pickerResults.currYear,
+            nextMonth: pickerResults.nextMonth,
+            nextYear: pickerResults.nextYear,
+            prevMonth: pickerResults.prevMonth,
+            prevYear: pickerResults.prevYear,
+            languageDirection,
+        }
+    }, [cellSize, date, dir, locale, pickerResults, width, languageDirection])
 
     return (
         <div>
-            <div
-                className="calendar-wrapper"
-                dir={languageDirection}
-                data-test="calendar"
-            >
-                <NavigationContainer
-                    pickerOptions={pickerOptions}
-                    languageDirection={languageDirection}
-                />
-                <CalendarTable
-                    selectedDate={selectedDateString}
-                    calendarWeekDays={calendarWeekDays}
-                    weekDayLabels={weekDayLabels}
-                    cellSize={cellSize}
-                    width={width}
-                />
-            </div>
-            <style jsx>{`
-                .calendar-wrapper {
-                    font-family: Roboto, sans-serif;
-                    font-weight: 400;
-                    font-size: 14px;
-                    background-color: ${backgroundColor};
-                    display: flex;
-                    flex-direction: column;
-                    border: 1px solid ${wrapperBorderColor};
-                    border-radius: 3px;
-                    min-width: ${width};
-                    width: max-content;
-                    box-shadow: 0px 4px 6px -2px #2129340d;
-                    box-shadow: 0px 10px 15px -3px #2129341a;
-                }
-            `}</style>
+            <CalendarContainer {...calendarProps} />
         </div>
     )
 }

--- a/components/calendar/src/calendar/calendar.js
+++ b/components/calendar/src/calendar/calendar.js
@@ -1,50 +1,50 @@
 import {
-    useResolvedDirection,
     useDatePicker,
+    useResolvedDirection,
 } from '@dhis2/multi-calendar-dates'
 import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useState } from 'react'
 import { CalendarTable } from './calendar-table.js'
 import { NavigationContainer } from './navigation-container.js'
 
-export const Calendar = (calendarProps) => {
-    const {
-        date,
-        dir,
-        locale,
-        width,
-        cellSize,
-        isValid,
-        onDateSelect,
-        minDate,
-        maxDate,
-        validation,
-        format,
-    } = calendarProps
-    let { calendarWeekDays, weekDayLabels } = calendarProps
-    const pickerOptions = useDatePicker({
-        onDateSelect: (result) => {
-            onDateSelect(result)
-        },
-        date: date,
-        minDate: minDate,
-        maxDate: maxDate,
-        validation: validation,
-        format: format,
-        options: calendarProps,
-    })
-
-    if (!calendarWeekDays) {
-        calendarWeekDays = pickerOptions.calendarWeekDays
-    }
-    if (!weekDayLabels) {
-        weekDayLabels = pickerOptions.weekDayLabels
-    }
+export const Calendar = ({
+    onDateSelect,
+    calendar,
+    date,
+    dir,
+    locale,
+    numberingSystem,
+    weekDayFormat,
+    timeZone,
+    width,
+    cellSize,
+}) => {
     const wrapperBorderColor = colors.grey300
     const backgroundColor = 'none'
 
+    const [selectedDateString, setSelectedDateString] = useState(date)
     const languageDirection = useResolvedDirection(dir, locale)
+
+    const options = {
+        locale,
+        calendar,
+        timeZone,
+        numberingSystem,
+        weekDayFormat,
+    }
+
+    const pickerOptions = useDatePicker({
+        onDateSelect: (result) => {
+            const { calendarDateString } = result
+            setSelectedDateString(calendarDateString)
+            onDateSelect(result)
+        },
+        date: selectedDateString,
+        options,
+    })
+
+    const { calendarWeekDays, weekDayLabels } = pickerOptions
 
     return (
         <div>
@@ -54,15 +54,11 @@ export const Calendar = (calendarProps) => {
                 data-test="calendar"
             >
                 <NavigationContainer
-                    pickerOptions={
-                        calendarProps.calendarWeekDays
-                            ? calendarProps
-                            : pickerOptions
-                    }
+                    pickerOptions={pickerOptions}
                     languageDirection={languageDirection}
                 />
                 <CalendarTable
-                    selectedDate={isValid ? date : null}
+                    selectedDate={selectedDateString}
                     calendarWeekDays={calendarWeekDays}
                     weekDayLabels={weekDayLabels}
                     cellSize={cellSize}
@@ -96,6 +92,10 @@ Calendar.defaultProps = {
 }
 
 export const CalendarProps = {
+    /** the calendar to use such gregory, ethiopic, nepali - full supported list here: https://github.com/dhis2/multi-calendar-dates/blob/main/src/constants/calendars.ts  */
+    calendar: PropTypes.any.isRequired,
+    /** Called with signature `(null)` \|\| `({ dateCalendarString: string, dateCalendar: Temporal.ZonedDateTime })` with `dateCalendarString` being the stringified date in the specified calendar in the format `yyyy-MM-dd` */
+    onDateSelect: PropTypes.func.isRequired,
     /** the size of a single cell in the table forming the calendar */
     cellSize: PropTypes.string,
     /** the currently selected date using an iso-like format YYYY-MM-DD, in the calendar system provided (not iso8601) */
@@ -104,18 +104,14 @@ export const CalendarProps = {
     dir: PropTypes.oneOf(['ltr', 'rtl']),
     /** any valid locale -  if none provided, the internal library will fallback to the user locale (more info here: https://github.com/dhis2/multi-calendar-dates/blob/main/src/hooks/internal/useResolvedLocaleOptions.ts#L15) */
     locale: PropTypes.string,
+    /** numbering system to use - full list here https://github.com/dhis2/multi-calendar-dates/blob/main/src/constants/numberingSystems.ts */
+    numberingSystem: PropTypes.string,
+    /** the timeZone to use */
+    timeZone: PropTypes.string,
     /** the format to display for the week day, i.e. Monday (long), Mon (short), M (narrow) */
     weekDayFormat: PropTypes.oneOf(['narrow', 'short', 'long']),
     /** the width of the calendar component */
     width: PropTypes.string,
-    /** is date valid and within range */
-    isValid: PropTypes.bool,
-    calendarWeekDays: PropTypes.array,
-    weekDayLabels: PropTypes.arrayOf(PropTypes.string),
-    minDate: PropTypes.string,
-    maxDate: PropTypes.string,
-    validation: PropTypes.string,
-    format: PropTypes.string,
 }
 
-Calendar.propTypes = { ...CalendarProps }
+Calendar.propTypes = CalendarProps

--- a/components/calendar/src/calendar/navigation-container.js
+++ b/components/calendar/src/calendar/navigation-container.js
@@ -7,14 +7,19 @@ import i18n from '../locales/index.js'
 const wrapperBorderColor = colors.grey300
 const headerBackground = colors.grey050
 
-export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
+export const NavigationContainer = ({
+    languageDirection,
+    currMonth,
+    currYear,
+    nextMonth,
+    nextYear,
+    prevMonth,
+    prevYear,
+}) => {
     const PreviousIcon =
         languageDirection === 'ltr' ? IconChevronLeft16 : IconChevronRight16
     const NextIcon =
         languageDirection === 'ltr' ? IconChevronRight16 : IconChevronLeft16
-
-    const { currMonth, currYear, nextMonth, nextYear, prevMonth, prevYear } =
-        pickerOptions
 
     // Ethiopic years - when localised to English - add the era (i.e. 2015 ERA1), which is redundant in practice (like writing AD for gregorian years)
     // there is an ongoing discussion in JS-Temporal polyfill whether the era should be included or not, but for our case, it's safer to remove it
@@ -155,30 +160,30 @@ export const NavigationContainer = ({ languageDirection, pickerOptions }) => {
     )
 }
 
-NavigationContainer.propTypes = {
+export const NavigationContainerProps = {
+    currMonth: PropTypes.shape({
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    }),
+    currYear: PropTypes.shape({
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    }),
     languageDirection: PropTypes.oneOf(['ltr', 'rtl']),
-    pickerOptions: PropTypes.shape({
-        currMonth: PropTypes.shape({
-            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        }),
-        currYear: PropTypes.shape({
-            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        }),
-        nextMonth: PropTypes.shape({
-            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            navigateTo: PropTypes.func,
-        }),
-        nextYear: PropTypes.shape({
-            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            navigateTo: PropTypes.func,
-        }),
-        prevMonth: PropTypes.shape({
-            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            navigateTo: PropTypes.func,
-        }),
-        prevYear: PropTypes.shape({
-            label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-            navigateTo: PropTypes.func,
-        }),
+    nextMonth: PropTypes.shape({
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        navigateTo: PropTypes.func,
+    }),
+    nextYear: PropTypes.shape({
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        navigateTo: PropTypes.func,
+    }),
+    prevMonth: PropTypes.shape({
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        navigateTo: PropTypes.func,
+    }),
+    prevYear: PropTypes.shape({
+        label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        navigateTo: PropTypes.func,
     }),
 }
+
+NavigationContainer.propTypes = NavigationContainerProps


### PR DESCRIPTION
Implements [LIBS-440](https://dhis2.atlassian.net/browse/LIBS-440)

Some minor performance improvements for multi-calendar component:

- use calendar inner components directly to avoid double calls to multi-calendar library.
  -  revert `Calendar` component to its old state, since it doesn't need to handle two states (when used independently, and when used as part of `CalendarInput`)
- use validation, error, and warning directly from the hook rather than wrapping them in an effect

Additionally, I've tried to change the component to being semi-controlled, so it doesn't call the hook multiple times unnecessary, and only when leaving the input. This worked in improving the performance (screenshots attached), but overcomplicated the interaction with the inner `calendar`. After several attempts, I decided to let go of that route in favour of improving the hook in multi-calendar itself - Ticket [here](https://dhis2.atlassian.net/browse/LIBS-648). 

| controlled | semi-controlled |
| --- | --- |
|  ![Screenshot from 2024-06-10 18-56-04](https://github.com/user-attachments/assets/351b292f-323c-4cd6-9fce-c76bf04a372f) | ![Screenshot from 2024-06-10 18-56-15](https://github.com/user-attachments/assets/dd355d13-d9c8-4ac3-b1c7-c77f94ad6a45) |


[LIBS-440]: https://dhis2.atlassian.net/browse/LIBS-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ