### PR TITLE
fix: pin react version in resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     },
     "dependencies": {
         "@dhis2/d2-i18n": "^1.1.0",
-        "react": "^16.13",
-        "react-dom": "^16.13",
+        "react": "16.13",
+        "react-dom": "16.13",
         "react-scripts": "^5.0.1",
         "styled-jsx": "^4.0.1"
     },
@@ -82,6 +82,6 @@
         "wait-on": "^6.0.0"
     },
     "resolutions": {
-        "react": "^16.13"
+        "react": "16.13.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19863,7 +19863,15 @@ react-dom@16.13:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^16.13, react-dom@^16.8.6:
+"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
+  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
+  dependencies:
+    loose-envify "^1.1.0"
+    scheduler "^0.23.2"
+
+react-dom@^16.8.6:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -19872,14 +19880,6 @@ react-dom@^16.13, react-dom@^16.8.6:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
-
-"react-dom@^16.8.0 || ^17.0.0 || ^18.0.0":
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
-  integrity sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==
-  dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.23.2"
 
 react-element-to-jsx-string@^14.3.1:
   version "14.3.4"
@@ -20202,10 +20202,10 @@ react-tooltip@^3.10.0:
   dependencies:
     prop-types "^15.6.0"
 
-react@16.13, react@^16.13, "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@^16.8.6:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@16.13, react@16.13.1, "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@^16.8.6:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
+  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
attempts to fix the release step in master - The error we get now is [EINVALIDTAGNAME](https://github.com/dhis2/ui/actions/runs/10249760523/job/28355082754#step:7:1136) which seems like it would be fixed by using `--legacy-peer-deps` flag again (according to [this](https://stackoverflow.com/a/67301099) and other places), but trying to solve it without doing that.

The error happens in the [prepare step ](https://github.com/dhis2/action-semantic-release/blob/f72ea64f5c6215abf3aca5e9c908fd7b62cc6c3a/dist/index.js#L22927-L22928) of our semantic-release version when it runs [npm version](https://github.com/semantic-release/npm/blob/master/lib/prepare.js#L15). It is likely due to the action using node 12 (npm < 7) which has a different [behaviour](https://stackoverflow.com/a/66620869) when it comes to peer dependencies.

This fix basically reverts thing to this version that J.G [had](https://github.com/dhis2/ui/pull/1560/commits/79053ec548022de8ba0a6ae907e5d097ed5abf67) before my code review comment.