### PR TITLE
chore: update css variables info

### DIFF
--- a/docs/docs/utilities/constants.md
+++ b/docs/docs/utilities/constants.md
@@ -6,7 +6,7 @@ There are are a number of constants that can be imported from the UI library tha
 import { colors, theme, spacers, layers, elevation } from '@dhis2/ui'
 ```
 
-If you need access to these variables in CSS (not recommended), see the `<CssVariables>` component documentation for making these variables accessible in CSS.
+If you need access to these variables in CSS, see the `<CssVariables>` component documentation for making these variables accessible in CSS.
 
 ## Colors
 


### PR DESCRIPTION
This removes the `(not recommended)` parenthetical about using <CssVariables> component for making DHIS2 UI constants accessible in CSS.

Summary of points from slack conversation where we discussed why we originally had this language:
- ...the original rationale behind that was that these constants are used in the design system and that apps are made using the design system so they should not be needed. (Hendrik)
- Maybe there was a time when we were using css-in-js styles that could consume the constants from the UI library? (Kai)

In summary, we now recognize that it is common to need these values (e.g. colors) for styling and that as we mostly use css modules for styling, it makes sense to not officially discourage use of <CSSVariables> component.