### PR TITLE
fix(field-group): fix typo in className

### DIFF
--- a/components/field/src/field-group/field-group.js
+++ b/components/field/src/field-group/field-group.js
@@ -16,7 +16,7 @@ const FieldGroup = ({
     error,
     warning,
 }) => (
-    <FieldSet classname={className} dataTest={dataTest}>
+    <FieldSet className={className} dataTest={dataTest}>
         <Field
             label={label}
             disabled={disabled}


### PR DESCRIPTION

---

### Description

Fixes a minor typo in `className`. Note the lower case `n`. This caused className to not be functional at all. 

---

