### PR TITLE
fix: circular dependency in input-field

### DIFF
--- a/components/input/src/input-field/input-field.js
+++ b/components/input/src/input-field/input-field.js
@@ -1,9 +1,9 @@
-import { sharedPropTypes } from '@dhis2/ui-constants'
 import { Box } from '@dhis2-ui/box'
 import { Field } from '@dhis2-ui/field'
-import { Input } from '@dhis2-ui/input'
+import { sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { Input } from '../input/index.js'
 
 class InputField extends React.Component {
     render() {

--- a/components/input/src/input-field/input-field.js
+++ b/components/input/src/input-field/input-field.js
@@ -1,6 +1,6 @@
+import { sharedPropTypes } from '@dhis2/ui-constants'
 import { Box } from '@dhis2-ui/box'
 import { Field } from '@dhis2-ui/field'
-import { sharedPropTypes } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Input } from '../input/index.js'


### PR DESCRIPTION
Building with Vite/Rollup reveals a warning about a circular dependency:

```sh
Export "InputField" of module "node_modules/@dhis2-ui/input/build/es/input-field/input-field.js" was reexported through module "node_modules/@dhis2-ui/input/build/es/index.js" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
```

In my tests in apps, other components like `MenuItem` and `SingleSelectField` also created warnings, but those ones have [already](https://github.com/dhis2/ui/commit/83b611a721881f5913642b7e103181f923ebc697) been [fixed](https://github.com/dhis2/ui/commit/77b3a33acea94dcba3f0edb532f8e307781a000d) in recent UI versions 👏 🥳  using the latest version in a test app fixes the warnings other than `InputField`