### PR TITLE
fix: bump multi-calendar library

### DIFF
--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -38,7 +38,7 @@
         "@dhis2-ui/input": "9.12.0-alpha.4",
         "@dhis2-ui/layer": "9.12.0-alpha.4",
         "@dhis2-ui/popper": "9.12.0-alpha.4",
-        "@dhis2/multi-calendar-dates": "1.3.0",
+        "@dhis2/multi-calendar-dates": "2.0.0-alpha.1",
         "@dhis2/prop-types": "^3.1.2",
         "@dhis2/ui-constants": "9.12.0-alpha.4",
         "@dhis2/ui-icons": "9.12.0-alpha.4",

--- a/components/calendar/src/calendar-input/calendar-input.js
+++ b/components/calendar/src/calendar-input/calendar-input.js
@@ -232,7 +232,7 @@ CalendarInput.defaultProps = {
 CalendarInput.propTypes = {
     /** the calendar to use such gregory, ethiopic, nepali - full supported list here: https://github.com/dhis2/multi-calendar-dates/blob/main/src/constants/calendars.ts  */
     calendar: PropTypes.any.isRequired,
-    /** Called with signature `(null)` \|\| `({ dateCalendarString: string, dateCalendar: Temporal.ZonedDateTime })` with `dateCalendarString` being the stringified date in the specified calendar in the format `yyyy-MM-dd` */
+    /** Called with signature `(null)` \|\| `({ dateCalendarString: string })` with `dateCalendarString` being the stringified date in the specified calendar in the format `yyyy-MM-dd` */
     onDateSelect: PropTypes.func.isRequired,
     /** the size of a single cell in the table forming the calendar */
     cellSize: PropTypes.string,

--- a/components/calendar/src/calendar/calendar-table-cell.js
+++ b/components/calendar/src/calendar/calendar-table-cell.js
@@ -13,11 +13,11 @@ export const CalendarTableCell = ({
     const selectedDayBackgroundColor = colors.teal700
 
     return (
-        <td data-test={day?.calendarDate} onClick={day.onClick}>
+        <td data-test={day?.dateValue} onClick={day.onClick}>
             <button
                 name="day"
                 className={cx('day', {
-                    isSelected: selectedDate === day?.calendarDate,
+                    isSelected: selectedDate === day?.dateValue,
                     isToday: day.isToday,
                     otherMonth: !day.isInCurrentMonth,
                 })}
@@ -92,7 +92,7 @@ export const CalendarTableCell = ({
 CalendarTableCell.propTypes = {
     cellSize: PropTypes.string,
     day: PropTypes.shape({
-        calendarDate: PropTypes.string,
+        dateValue: PropTypes.string,
         isInCurrentMonth: PropTypes.bool,
         isSelected: PropTypes.bool,
         isToday: PropTypes.bool,

--- a/components/calendar/src/calendar/calendar-table.js
+++ b/components/calendar/src/calendar/calendar-table.js
@@ -22,7 +22,7 @@ export const CalendarTable = ({
                             <CalendarTableCell
                                 selectedDate={selectedDate}
                                 day={day}
-                                key={day?.calendarDate}
+                                key={day?.dateValue}
                                 cellSize={cellSize}
                                 width={width}
                                 unfocusable={unfocusable}

--- a/components/calendar/src/calendar/calendar.js
+++ b/components/calendar/src/calendar/calendar.js
@@ -79,7 +79,7 @@ Calendar.defaultProps = {
 export const CalendarProps = {
     /** the calendar to use such gregory, ethiopic, nepali - full supported list here: https://github.com/dhis2/multi-calendar-dates/blob/main/src/constants/calendars.ts  */
     calendar: PropTypes.any.isRequired,
-    /** Called with signature `(null)` \|\| `({ dateCalendarString: string, dateCalendar: Temporal.ZonedDateTime })` with `dateCalendarString` being the stringified date in the specified calendar in the format `yyyy-MM-dd` */
+    /** Called with signature `(null)` \|\| `({ dateCalendarString: string })` with `dateCalendarString` being the stringified date in the specified calendar in the format `yyyy-MM-dd` */
     onDateSelect: PropTypes.func.isRequired,
     /** the size of a single cell in the table forming the calendar */
     cellSize: PropTypes.string,

--- a/components/calendar/types/index.d.ts
+++ b/components/calendar/types/index.d.ts
@@ -13,7 +13,7 @@ export interface CalendarProps {
      */
     calendar: CalendarPickerOptions['calendar']
     /**
-     * Called with signature `(null)` \|\| `({ dateCalendarString: string, dateCalendar: Temporal.ZonedDateTime })` with `dateCalendarString` being the stringified date in the specified calendar in the format `yyyy-MM-dd`
+     * Called with signature `(null)` \|\| `({ dateCalendarString: string })` with `dateCalendarString` being the stringified date in the specified calendar in the format `yyyy-MM-dd`
      */
     onDateSelect: CalendarPickerParam['onDateSelect']
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2707,7 +2707,16 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/multi-calendar-dates@1.3.0", "@dhis2/multi-calendar-dates@^1.2.3":
+"@dhis2/multi-calendar-dates@2.0.0-alpha.1":
+  version "2.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-2.0.0-alpha.1.tgz#5ae801160c044b1488704dcc13f6a4cc8cccb3e4"
+  integrity sha512-fPZ8E5ioAXPxfVQstkDOyyzBhbS5XxIUS/iUwaZxCU6Opw4CXVMBeABwQX7Y+ySTpPqGkTUYmnjhOwMlVapSng==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.1.3"
+    "@js-temporal/polyfill" "0.4.3"
+    classnames "^2.3.2"
+
+"@dhis2/multi-calendar-dates@^1.2.3":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.3.0.tgz#8e8943369662167b768cdaaba0a8f147875be50d"
   integrity sha512-7NlKPX+UQ+HSta0Q2SJt6RfrKLxRTX9OIMcvtUouNXfVXuS+6xVxQc4Qil+1zcIT272y7NbUmC4Z7UE/cLI9tw==


### PR DESCRIPTION
BREAKING CHANGE: multi-calendar hook no longer returns Temporal date - although it's unlikely to affect anyone, it's a breaking change in theory and should be reflected as such.

more context here: https://github.com/dhis2/multi-calendar-dates/pull/75

Implements [DHIS2-18131](https://dhis2.atlassian.net/browse/DHIS2-18131)


[DHIS2-18131]: https://dhis2.atlassian.net/browse/DHIS2-18131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ