### PR TITLE
fix(sharing-dialog): add 'route' to SharingType type

### DIFF
--- a/components/sharing-dialog/types/index.d.ts
+++ b/components/sharing-dialog/types/index.d.ts
@@ -54,6 +54,7 @@ type SharingType =
     | 'programStageWorkingList'
     | 'relationshipType'
     | 'report'
+    | 'route'
     | 'sqlView'
     | 'trackedEntityAttribute'
     | 'trackedEntityFilter'


### PR DESCRIPTION
`route` also is supported by sharing API, and currently gives a type error.