### PR TITLE
fix: remove redundant wrapper object from onfocus and onblur callbacks

### DIFF
--- a/components/tooltip/src/tooltip.js
+++ b/components/tooltip/src/tooltip.js
@@ -104,8 +104,8 @@ const Tooltip = ({
                 children({
                     onMouseOver: onMouseOver,
                     onMouseOut: onMouseOut,
-                    onFocus: { onFocus },
-                    onBlur: { onBlur },
+                    onFocus: onFocus,
+                    onBlur: onBlur,
                     ref: popperReference,
                 })
             ) : (


### PR DESCRIPTION
Just a small fix
