### PR TITLE
fix(menu-item): tweak active and focused styles

### DIFF
--- a/components/menu/src/menu-item/menu-item.js
+++ b/components/menu/src/menu-item/menu-item.js
@@ -104,7 +104,7 @@ const MenuItem = ({
                     destructive,
                     disabled,
                     dense,
-                    active: active || showSubMenu || tabIndex === 0,
+                    active: active || showSubMenu,
                     'with-chevron': children || chevron,
                 })}
                 ref={menuItemRef}

--- a/components/menu/src/menu-item/menu-item.prod.stories.js
+++ b/components/menu/src/menu-item/menu-item.prod.stories.js
@@ -91,6 +91,22 @@ Icon.parameters = {
     },
 }
 
+export const InContainer = (args) => {
+    return (
+        <div
+            style={{
+                height: 40,
+                width: 300,
+                overflow: 'hidden',
+            }}
+        >
+            <Menu {...args}>
+                <MenuItem label="Menu item" />
+            </Menu>
+        </div>
+    )
+}
+
 export const Suffix = Template.bind({})
 Suffix.args = {
     label: 'Open in Data Visualizer',

--- a/components/menu/src/menu-item/menu-item.styles.js
+++ b/components/menu/src/menu-item/menu-item.styles.js
@@ -49,6 +49,15 @@ export default css`
         background-color: ${colors.white};
     }
 
+    /*focus-visible backwards compatibility for safari: https://css-tricks.com/platform-news-using-focus-visible-bbcs-new-typeface-declarative-shadow-doms-a11y-and-placeholders/*/
+    li:focus {
+        outline: 3px solid ${theme.focus};
+        outline-offset: -3px;
+    }
+    li:focus:not(:focus-visible) {
+        outline: none;
+    }
+
     a {
         display: inline-flex;
         flex-grow: 1;
@@ -57,14 +66,6 @@ export default css`
         min-height: 40px;
         text-decoration: none;
         color: inherit;
-    }
-    /*focus-visible backwards compatibility for safari: https://css-tricks.com/platform-news-using-focus-visible-bbcs-new-typeface-declarative-shadow-doms-a11y-and-placeholders/*/
-    a:focus {
-        outline: 3px solid ${theme.focus};
-        outline-offset: -3px;
-    }
-    a:focus:not(:focus-visible) {
-        outline: none;
     }
 
     li.with-chevron a {


### PR DESCRIPTION
This PR contains two loosely related changes:

### Remove active style from menu item with tabIndex 0
Setting the active class on items with tab index 0 works nicely when using keyboard navigation but causes odd behaviour when using mouse-based interaction: a `Menu` with `MenuItems` can end up having multiple "active items":
<img width="394" alt="Screenshot 2024-11-25 at 15 39 41" src="https://github.com/user-attachments/assets/b8411491-d735-4b73-96f4-5d2e9779ff1d">
By removing this code the keyboard navigation is still visually supported by the focus outline, which is enough IMO.

### Fix focussed outline styles
The problem was as follows:
* The menu-item styles included focus styles for the `<a>` tag
* This makes sense because these are "naturally focusable elements", similar to a button.
* However now that we have keyboard navigation, the parent `<li>` gets a `tab-index` and the `<li>` becomes the element that receives focus

So I've moved the focus styles from the `<a>` to the `<li>` and everything looks better.

<img width="320" alt="Screenshot 2024-11-26 at 09 45 57" src="https://github.com/user-attachments/assets/d0d0a700-32ff-4df5-b480-9ca5e9a868cd">

For reference, here's a screenshot of how the focussed menu-item looked before, with the broken outline styles and the grey background:
<img width="218" alt="Screenshot 2024-11-25 at 17 40 28" src="https://github.com/user-attachments/assets/0e757e47-068d-47a9-a2ad-ac9e2b824e60">
