### PR TITLE
fix(select): prevent prop-types error by making `tabIndex` an optional prop

### DIFF
--- a/components/select/src/select/input-wrapper.js
+++ b/components/select/src/select/input-wrapper.js
@@ -100,13 +100,13 @@ const InputWrapper = ({
 InputWrapper.propTypes = {
     dataTest: PropTypes.string.isRequired,
     inputRef: PropTypes.object.isRequired,
-    tabIndex: PropTypes.string.isRequired,
     onToggle: PropTypes.func.isRequired,
     children: PropTypes.element,
     className: PropTypes.string,
     dense: PropTypes.bool,
     disabled: PropTypes.bool,
     error: sharedPropTypes.statusPropType,
+    tabIndex: PropTypes.string,
     valid: sharedPropTypes.statusPropType,
     warning: sharedPropTypes.statusPropType,
 }


### PR DESCRIPTION
This PR prevents a prop-types error by making `tabIndex` an optional prop, which is not a problem since `tabIndex` also [has a default value](https://github.com/dhis2/ui/blob/9459c0678931a13d8b3450bd2fcc97005eb3cca5/components/select/src/select/input-wrapper.js#L11) in the component.

I originally encountered this bug in the sharing dialog-after upgrading `@dhis2/ui` in the Dashboards App and was able to reproduce it bug in the "For dashboard with cascading sharing partial success" demo story. I have also been able to verify that this PR addresses the issue this way.