### PR TITLE
fix(button): use flexbox instead of font-size to ensure the icon is centered

### DIFF
--- a/components/button/src/button/button.styles.js
+++ b/components/button/src/button/button.styles.js
@@ -224,8 +224,9 @@ export default css`
         margin-inline-end: 6px;
         color: inherit;
         fill: inherit;
-        font-size: 26px;
-        vertical-align: middle;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
         pointer-events: none;
     }
 


### PR DESCRIPTION
I think the styles that we had to center the icon were a relic of a very old implementation. I think using flexbox makes a lot more sense.