### PR TITLE
fix(types): fix missing width type for input

### DIFF
--- a/components/input/types/index.d.ts
+++ b/components/input/types/index.d.ts
@@ -116,6 +116,10 @@ export interface InputProps {
      */
     warning?: boolean
     /**
+     * Defines the width of the input. Can be any valid CSS measurement
+     */
+    width?: string
+    /**
      * Called with signature `({ name: string, value: string }, event)`
      */
     onBlur?: InputFocusHandler


### PR DESCRIPTION


---

### Description

This PR: LIBS-699/clearable-input-and-prefix-icon added `width` as a prop, but forgot to add it to the types. 

