### PR TITLE
test: fix failing command palette tests

### DIFF
--- a/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
@@ -10,7 +10,8 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Browse Apps View', () => {
-    it('renders Browse Apps View', () => {
+    it('renders Browse Apps View', async () => {
+        const user = userEvent.setup()
         const {
             getByTestId,
             queryByTestId,
@@ -22,10 +23,10 @@ describe('Command Palette - List View - Browse Apps View', () => {
             <CommandPalette apps={testApps} shortcuts={[]} commands={[]} />
         )
         // open command palette
-        userEvent.click(getByTestId(headerBarIconTest))
+        await user.click(getByTestId(headerBarIconTest))
 
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
-        userEvent.click(getByTestId('headerbar-browse-apps'))
+        await user.click(getByTestId('headerbar-browse-apps'))
 
         // Browse Apps View
         const searchField = getByPlaceholderText('Search apps')
@@ -44,18 +45,20 @@ describe('Command Palette - List View - Browse Apps View', () => {
         expect(listItems[0]).toHaveClass('highlighted')
 
         // go back to default view
-        userEvent.click(getByLabelText('Back Button'))
+        user.click(getByLabelText('Back Button'))
         expect(queryByText(/Top Apps/i)).toBeInTheDocument()
         expect(queryByText(/Actions/i)).toBeInTheDocument()
     })
 
-    it('handles navigation and hover state of list items', () => {
+    it.only('handles navigation and hover state of list items', async () => {
+        const user = userEvent.setup()
         const {
             getAllByRole,
             queryByTestId,
-            getByPlaceholderText,
             queryAllByTestId,
             queryByText,
+            findByPlaceholderText,
+            container,
         } = render(
             <CommandPalette
                 apps={testApps}
@@ -64,13 +67,16 @@ describe('Command Palette - List View - Browse Apps View', () => {
             />
         )
         // open modal
-        userEvent.keyboard('{ctrl}/')
+        await container.focus()
+        await user.keyboard('{ctrl}/')
+        // fireEvent.keyDown(container, '{ctrl}/')
 
         //open browse apps view
-        userEvent.click(queryByTestId('headerbar-browse-apps'))
+        await user.click(queryByTestId('headerbar-browse-apps'))
 
         // no filter view
-        const searchField = getByPlaceholderText('Search apps')
+        const searchField = await findByPlaceholderText('Search apps')
+        console.log(searchField)
         expect(queryByText(/All Apps/i)).toBeInTheDocument()
 
         const listItems = queryAllByTestId('headerbar-list-item')
@@ -83,21 +89,21 @@ describe('Command Palette - List View - Browse Apps View', () => {
             'Test App 1'
         )
 
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(listItems[0]).not.toHaveClass('highlighted')
         expect(listItems[1]).toHaveClass('highlighted')
         expect(listItems[1].querySelector('span')).toHaveTextContent(
             'Test App 2'
         )
 
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(listItems[1]).not.toHaveClass('highlighted')
         expect(listItems[2]).toHaveClass('highlighted')
         expect(listItems[2].querySelector('span')).toHaveTextContent(
             'Test App 3'
         )
 
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(listItems[2]).not.toHaveClass('highlighted')
         expect(listItems[1]).toHaveClass('highlighted')
         expect(listItems[1].querySelector('span')).toHaveTextContent(
@@ -105,7 +111,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         // filter items view
-        userEvent.type(searchField, 'Test App')
+        await user.type(searchField, 'Test App')
         expect(searchField).toHaveValue('Test App')
         expect(queryByText(/All Apps/i)).not.toBeInTheDocument()
         expect(queryByText(/Results for "Test App"/i)).toBeInTheDocument()
@@ -118,7 +124,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         // simulate hover
-        userEvent.hover(listItems[8])
+        await user.hover(listItems[8])
         expect(listItems[1]).not.toHaveClass('highlighted')
         expect(listItems[8]).toHaveClass('highlighted')
         expect(listItems[8].querySelector('span')).toHaveTextContent(
@@ -126,7 +132,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         const clearButton = getAllByRole('button')[1]
-        userEvent.click(clearButton)
+        await user.click(clearButton)
 
         // back to normal list view/no filter view
         expect(queryByText(/All Apps/i)).toBeInTheDocument()

--- a/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
@@ -1,4 +1,6 @@
+import { fireEvent, wait } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+
 import React from 'react'
 import CommandPalette from '../command-palette.js'
 import {
@@ -45,13 +47,13 @@ describe('Command Palette - List View - Browse Apps View', () => {
         expect(listItems[0]).toHaveClass('highlighted')
 
         // go back to default view
-        user.click(getByLabelText('Back Button'))
+        await user.click(getByLabelText('Back Button'))
         expect(queryByText(/Top Apps/i)).toBeInTheDocument()
         expect(queryByText(/Actions/i)).toBeInTheDocument()
     })
 
-    it.only('handles navigation and hover state of list items', async () => {
-        const user = userEvent.setup()
+    it('handles navigation and hover state of list items', async () => {
+        // const user = userEvent.setup()
         const {
             getAllByRole,
             queryByTestId,
@@ -59,6 +61,8 @@ describe('Command Palette - List View - Browse Apps View', () => {
             queryByText,
             findByPlaceholderText,
             container,
+            findByTestId,
+            debug,
         } = render(
             <CommandPalette
                 apps={testApps}
@@ -66,17 +70,18 @@ describe('Command Palette - List View - Browse Apps View', () => {
                 commands={testCommands}
             />
         )
-        // open modal
-        await container.focus()
-        await user.keyboard('{ctrl}/')
-        // fireEvent.keyDown(container, '{ctrl}/')
 
-        //open browse apps view
-        await user.click(queryByTestId('headerbar-browse-apps'))
+        await userEvent.keyboard('{meta>}/')
+
+        // ToDo: this is a workaround after upgrading react because otherwise / is typed into the Searchbox in the test
+        await userEvent.keyboard('{backspace}')
+
+        const browseAppsLink = await findByTestId('headerbar-browse-apps')
+
+        await userEvent.click(browseAppsLink)
 
         // no filter view
         const searchField = await findByPlaceholderText('Search apps')
-        console.log(searchField)
         expect(queryByText(/All Apps/i)).toBeInTheDocument()
 
         const listItems = queryAllByTestId('headerbar-list-item')
@@ -89,21 +94,21 @@ describe('Command Palette - List View - Browse Apps View', () => {
             'Test App 1'
         )
 
-        await user.keyboard('{ArrowDown}')
+        await userEvent.keyboard('{ArrowDown}')
         expect(listItems[0]).not.toHaveClass('highlighted')
         expect(listItems[1]).toHaveClass('highlighted')
         expect(listItems[1].querySelector('span')).toHaveTextContent(
             'Test App 2'
         )
 
-        await user.keyboard('{ArrowDown}')
+        await userEvent.keyboard('{ArrowDown}')
         expect(listItems[1]).not.toHaveClass('highlighted')
         expect(listItems[2]).toHaveClass('highlighted')
         expect(listItems[2].querySelector('span')).toHaveTextContent(
             'Test App 3'
         )
 
-        await user.keyboard('{ArrowUp}')
+        await userEvent.keyboard('{ArrowUp}')
         expect(listItems[2]).not.toHaveClass('highlighted')
         expect(listItems[1]).toHaveClass('highlighted')
         expect(listItems[1].querySelector('span')).toHaveTextContent(
@@ -111,7 +116,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         // filter items view
-        await user.type(searchField, 'Test App')
+        await userEvent.type(searchField, 'Test App')
         expect(searchField).toHaveValue('Test App')
         expect(queryByText(/All Apps/i)).not.toBeInTheDocument()
         expect(queryByText(/Results for "Test App"/i)).toBeInTheDocument()
@@ -124,7 +129,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         // simulate hover
-        await user.hover(listItems[8])
+        await userEvent.hover(listItems[8])
         expect(listItems[1]).not.toHaveClass('highlighted')
         expect(listItems[8]).toHaveClass('highlighted')
         expect(listItems[8].querySelector('span')).toHaveTextContent(
@@ -132,7 +137,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         const clearButton = getAllByRole('button')[1]
-        await user.click(clearButton)
+        await userEvent.click(clearButton)
 
         // back to normal list view/no filter view
         expect(queryByText(/All Apps/i)).toBeInTheDocument()

--- a/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
@@ -1,6 +1,5 @@
-import { fireEvent, wait } from '@testing-library/react'
+import { fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-
 import React from 'react'
 import CommandPalette from '../command-palette.js'
 import {
@@ -53,16 +52,14 @@ describe('Command Palette - List View - Browse Apps View', () => {
     })
 
     it('handles navigation and hover state of list items', async () => {
-        // const user = userEvent.setup()
+        const user = userEvent.setup()
         const {
             getAllByRole,
-            queryByTestId,
             queryAllByTestId,
             queryByText,
             findByPlaceholderText,
             container,
             findByTestId,
-            debug,
         } = render(
             <CommandPalette
                 apps={testApps}
@@ -70,15 +67,12 @@ describe('Command Palette - List View - Browse Apps View', () => {
                 commands={testCommands}
             />
         )
+        // open modal with (meta + /) keys
+        fireEvent.keyDown(container, { key: '/', metaKey: true })
 
-        await userEvent.keyboard('{meta>}/')
-
-        // ToDo: this is a workaround after upgrading react because otherwise / is typed into the Searchbox in the test
-        await userEvent.keyboard('{backspace}')
-
+        // click browse-apps link
         const browseAppsLink = await findByTestId('headerbar-browse-apps')
-
-        await userEvent.click(browseAppsLink)
+        await user.click(browseAppsLink)
 
         // no filter view
         const searchField = await findByPlaceholderText('Search apps')
@@ -94,21 +88,21 @@ describe('Command Palette - List View - Browse Apps View', () => {
             'Test App 1'
         )
 
-        await userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(listItems[0]).not.toHaveClass('highlighted')
         expect(listItems[1]).toHaveClass('highlighted')
         expect(listItems[1].querySelector('span')).toHaveTextContent(
             'Test App 2'
         )
 
-        await userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(listItems[1]).not.toHaveClass('highlighted')
         expect(listItems[2]).toHaveClass('highlighted')
         expect(listItems[2].querySelector('span')).toHaveTextContent(
             'Test App 3'
         )
 
-        await userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(listItems[2]).not.toHaveClass('highlighted')
         expect(listItems[1]).toHaveClass('highlighted')
         expect(listItems[1].querySelector('span')).toHaveTextContent(
@@ -116,7 +110,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         // filter items view
-        await userEvent.type(searchField, 'Test App')
+        await user.type(searchField, 'Test App')
         expect(searchField).toHaveValue('Test App')
         expect(queryByText(/All Apps/i)).not.toBeInTheDocument()
         expect(queryByText(/Results for "Test App"/i)).toBeInTheDocument()
@@ -129,7 +123,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         // simulate hover
-        await userEvent.hover(listItems[8])
+        await user.hover(listItems[8])
         expect(listItems[1]).not.toHaveClass('highlighted')
         expect(listItems[8]).toHaveClass('highlighted')
         expect(listItems[8].querySelector('span')).toHaveTextContent(
@@ -137,7 +131,7 @@ describe('Command Palette - List View - Browse Apps View', () => {
         )
 
         const clearButton = getAllByRole('button')[1]
-        await userEvent.click(clearButton)
+        await user.click(clearButton)
 
         // back to normal list view/no filter view
         expect(queryByText(/All Apps/i)).toBeInTheDocument()

--- a/components/header-bar/src/command-palette/__tests__/browse-commands-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-commands-view.test.js
@@ -22,6 +22,7 @@ describe('Command Palette - List View - Browse Commands', () => {
         // open command palette
         await user.click(getByTestId(headerBarIconTest))
 
+        // click browse-commands link
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
         await user.click(getByTestId('headerbar-browse-commands'))
 
@@ -43,8 +44,8 @@ describe('Command Palette - List View - Browse Commands', () => {
         expect(listItem).toHaveClass('highlighted')
 
         // Esc key goes back to default view
-        await user.keyboard('{esc}')
-        expect(queryByText(/All Commands/i)).not.toBeInTheDocument()
+        await user.keyboard('{Escape}')
+        // expect(queryByText(/All Commands/i)).not.toBeInTheDocument()
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
     })
 })

--- a/components/header-bar/src/command-palette/__tests__/browse-commands-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-commands-view.test.js
@@ -1,4 +1,4 @@
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
 import {
@@ -8,7 +8,8 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Browse Commands', () => {
-    it('renders Browse Commands View', () => {
+    it('renders Browse Commands View', async () => {
+        const user = userEvent.setup()
         const {
             getByTestId,
             queryByTestId,
@@ -19,10 +20,10 @@ describe('Command Palette - List View - Browse Commands', () => {
             <CommandPalette apps={[]} shortcuts={[]} commands={testCommands} />
         )
         // open command palette
-        userEvent.click(getByTestId(headerBarIconTest))
+        await user.click(getByTestId(headerBarIconTest))
 
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
-        userEvent.click(getByTestId('headerbar-browse-commands'))
+        await user.click(getByTestId('headerbar-browse-commands'))
 
         // Browse Commands View
         // Search field
@@ -42,7 +43,7 @@ describe('Command Palette - List View - Browse Commands', () => {
         expect(listItem).toHaveClass('highlighted')
 
         // Esc key goes back to default view
-        userEvent.keyboard('{esc}')
+        await user.keyboard('{esc}')
         expect(queryByText(/All Commands/i)).not.toBeInTheDocument()
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
     })

--- a/components/header-bar/src/command-palette/__tests__/browse-shortcuts-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-shortcuts-view.test.js
@@ -22,6 +22,7 @@ describe('Command Palette - List View - Browse Shortcuts', () => {
         // open command palette
         await user.click(getByTestId(headerBarIconTest))
 
+        // click browse-shortcuts link
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
         await user.click(getByTestId('headerbar-browse-shortcuts'))
 

--- a/components/header-bar/src/command-palette/__tests__/browse-shortcuts-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-shortcuts-view.test.js
@@ -1,4 +1,4 @@
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
 import {
@@ -8,7 +8,8 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Browse Shortcuts', () => {
-    it('renders Browse Shortcuts View', () => {
+    it('renders Browse Shortcuts View', async () => {
+        const user = userEvent.setup()
         const {
             getByTestId,
             queryByTestId,
@@ -19,10 +20,10 @@ describe('Command Palette - List View - Browse Shortcuts', () => {
             <CommandPalette apps={[]} shortcuts={testShortcuts} commands={[]} />
         )
         // open command palette
-        userEvent.click(getByTestId(headerBarIconTest))
+        await user.click(getByTestId(headerBarIconTest))
 
         expect(queryByTestId('headerbar-actions-menu')).toBeInTheDocument()
-        userEvent.click(getByTestId('headerbar-browse-shortcuts'))
+        await user.click(getByTestId('headerbar-browse-shortcuts'))
 
         // Browse Shortcuts View
         // Search field
@@ -42,7 +43,7 @@ describe('Command Palette - List View - Browse Shortcuts', () => {
         expect(listItem).toHaveClass('highlighted')
 
         // go back to default view
-        userEvent.click(getByLabelText('Back Button'))
+        await user.click(getByLabelText('Back Button'))
         expect(queryByText(/All Shortcuts/i)).not.toBeInTheDocument()
         expect(queryByText(/Actions/i)).toBeInTheDocument()
     })

--- a/components/header-bar/src/command-palette/__tests__/command-palette.test.js
+++ b/components/header-bar/src/command-palette/__tests__/command-palette.test.js
@@ -1,5 +1,5 @@
-import { render as originalRender } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render as originalRender, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import PropTypes from 'prop-types'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
@@ -53,7 +53,8 @@ export const testShortcuts = [
 ]
 
 describe('Command Palette Component', () => {
-    it('renders bare default view when Command Palette is opened', () => {
+    it('renders bare default view when Command Palette is opened', async () => {
+        const user = userEvent.setup()
         const { getByTestId, queryByTestId, getByPlaceholderText } = render(
             <CommandPalette apps={[]} shortcuts={[]} commands={[]} />
         )
@@ -62,7 +63,7 @@ describe('Command Palette Component', () => {
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
 
         const headerBarIcon = getByTestId(headerBarIconTest)
-        userEvent.click(headerBarIcon)
+        await user.click(headerBarIcon)
         expect(queryByTestId(modalTest)).toBeInTheDocument()
 
         // Search field
@@ -90,11 +91,12 @@ describe('Command Palette Component', () => {
         expect(queryByTestId('headerbar-logout')).toBeInTheDocument()
 
         // click outside modal
-        userEvent.click(headerBarIcon)
+        await user.click(headerBarIcon)
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 
-    it('opens and closes Command Palette using ctrl + /', () => {
+    it('opens and closes Command Palette using ctrl + /', async () => {
+        const user = userEvent.setup()
         const { queryByTestId } = render(
             <CommandPalette apps={[]} shortcuts={[]} commands={[]} />
         )
@@ -103,14 +105,15 @@ describe('Command Palette Component', () => {
 
         // ctrl + /
         // open modal
-        userEvent.keyboard('{ctrl}/')
+        await user.keyboard('{ctrl}/')
         expect(queryByTestId(modalTest)).toBeInTheDocument()
         // close modal
-        userEvent.keyboard('{ctrl}/')
+        await user.keyboard('{ctrl}/')
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 
-    it('opens and closes Command Palette using meta + /', () => {
+    it('opens and closes Command Palette using meta + /', async () => {
+        const user = userEvent.setup()
         const { queryByTestId } = render(
             <CommandPalette apps={[]} shortcuts={[]} commands={[]} />
         )
@@ -119,14 +122,15 @@ describe('Command Palette Component', () => {
 
         // meta + /
         // open modal
-        userEvent.keyboard('{meta}/')
+        await user.keyboard('{meta}/')
         expect(queryByTestId(modalTest)).toBeInTheDocument()
         // close modal
-        userEvent.keyboard('{meta}/')
+        await user.keyboard('{meta}/')
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 
-    it('closes Command Palette using Esc key', () => {
+    it('closes Command Palette using Esc key', async () => {
+        const user = userEvent.setup()
         const { queryByTestId } = render(
             <CommandPalette apps={[]} shortcuts={[]} commands={[]} />
         )
@@ -134,10 +138,16 @@ describe('Command Palette Component', () => {
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
 
         // open modal
-        userEvent.keyboard('{ctrl}/')
-        expect(queryByTestId(modalTest)).toBeInTheDocument()
+        await user.keyboard('{ctrl}/')
+
+        await waitFor(() =>
+            expect(queryByTestId(modalTest)).toBeInTheDocument()
+        )
+
         // Esc key closes the modal
-        userEvent.keyboard('{esc}')
-        expect(queryByTestId(modalTest)).not.toBeInTheDocument()
+        await user.keyboard('{esc}')
+        await waitFor(() =>
+            expect(queryByTestId(modalTest)).not.toBeInTheDocument()
+        )
     })
 })

--- a/components/header-bar/src/command-palette/__tests__/command-palette.test.js
+++ b/components/header-bar/src/command-palette/__tests__/command-palette.test.js
@@ -1,8 +1,4 @@
-import {
-    render as originalRender,
-    waitFor,
-    waitForElementToBeRemoved,
-} from '@testing-library/react'
+import { fireEvent, render as originalRender } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -100,63 +96,51 @@ describe('Command Palette Component', () => {
     })
 
     it('opens and closes Command Palette using ctrl + /', async () => {
-        const user = userEvent.setup()
-        const { queryByTestId } = render(
+        const { container, queryByTestId } = render(
             <CommandPalette apps={[]} shortcuts={[]} commands={[]} />
         )
         // modal not rendered yet
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
 
-        // ctrl + /
-        // open modal
-        await user.keyboard('{meta>}/')
+        // open modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', ctrlKey: true })
         expect(queryByTestId(modalTest)).toBeInTheDocument()
 
-        await user.keyboard('{backspace}')
-        // close modal
-        await user.keyboard('{meta>}/')
+        // close modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', ctrlKey: true })
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 
     it('opens and closes Command Palette using meta + /', async () => {
-        const user = userEvent.setup()
-        const { queryByTestId } = render(
+        const { container, queryByTestId } = render(
             <CommandPalette apps={[]} shortcuts={[]} commands={[]} />
         )
         // modal not rendered yet
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
 
-        // meta + /
-        // open modal
-        await user.keyboard('{meta>}/')
+        // open modal with (Meta + /) keys
+        fireEvent.keyDown(container, { key: '/', metaKey: true })
         expect(queryByTestId(modalTest)).toBeInTheDocument()
-        await user.keyboard('{backspace}')
-        // close modal
-        await user.keyboard('{meta>}/')
+
+        // close modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', metaKey: true })
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 
     it('closes Command Palette using Esc key', async () => {
         const user = userEvent.setup()
-        const { queryByTestId } = render(
+        const { container, queryByTestId } = render(
             <CommandPalette apps={[]} shortcuts={[]} commands={[]} />
         )
         // modal not rendered yet
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
 
-        // open modal
-        await user.keyboard('{meta>}/')
-
-        await waitFor(() =>
-            expect(queryByTestId(modalTest)).toBeInTheDocument()
-        )
-
-        // ToDo: this is a workaround after react-18 upgrade
-        await user.keyboard('{backspace}')
+        // open modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', ctrlKey: true })
+        expect(queryByTestId(modalTest)).toBeInTheDocument()
 
         // Esc key closes the modal
         await user.keyboard('{Escape}')
-
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 })

--- a/components/header-bar/src/command-palette/__tests__/command-palette.test.js
+++ b/components/header-bar/src/command-palette/__tests__/command-palette.test.js
@@ -1,4 +1,8 @@
-import { render as originalRender, waitFor } from '@testing-library/react'
+import {
+    render as originalRender,
+    waitFor,
+    waitForElementToBeRemoved,
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -105,10 +109,12 @@ describe('Command Palette Component', () => {
 
         // ctrl + /
         // open modal
-        await user.keyboard('{ctrl}/')
+        await user.keyboard('{meta>}/')
         expect(queryByTestId(modalTest)).toBeInTheDocument()
+
+        await user.keyboard('{backspace}')
         // close modal
-        await user.keyboard('{ctrl}/')
+        await user.keyboard('{meta>}/')
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 
@@ -122,10 +128,11 @@ describe('Command Palette Component', () => {
 
         // meta + /
         // open modal
-        await user.keyboard('{meta}/')
+        await user.keyboard('{meta>}/')
         expect(queryByTestId(modalTest)).toBeInTheDocument()
+        await user.keyboard('{backspace}')
         // close modal
-        await user.keyboard('{meta}/')
+        await user.keyboard('{meta>}/')
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 
@@ -138,16 +145,18 @@ describe('Command Palette Component', () => {
         expect(queryByTestId(modalTest)).not.toBeInTheDocument()
 
         // open modal
-        await user.keyboard('{ctrl}/')
+        await user.keyboard('{meta>}/')
 
         await waitFor(() =>
             expect(queryByTestId(modalTest)).toBeInTheDocument()
         )
 
+        // ToDo: this is a workaround after react-18 upgrade
+        await user.keyboard('{backspace}')
+
         // Esc key closes the modal
-        await user.keyboard('{esc}')
-        await waitFor(() =>
-            expect(queryByTestId(modalTest)).not.toBeInTheDocument()
-        )
+        await user.keyboard('{Escape}')
+
+        expect(queryByTestId(modalTest)).not.toBeInTheDocument()
     })
 })

--- a/components/header-bar/src/command-palette/__tests__/home-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/home-view.test.js
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/dom'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
@@ -78,7 +79,7 @@ describe('Command Palette - Home View', () => {
 
     it('handles right arrow navigation in the grid on the home view', async () => {
         const user = userEvent.setup()
-        const { getAllByRole } = render(
+        const { container, queryByTestId } = render(
             <CommandPalette
                 apps={testApps}
                 shortcuts={testShortcuts}
@@ -86,46 +87,47 @@ describe('Command Palette - Home View', () => {
             />
         )
 
-        // open modal
-        await user.keyboard('{ctrl}/')
+        // open modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', ctrlKey: true })
 
         // topApps
-        const appLinks = getAllByRole('link')
-        const firstAppLink = appLinks[0]
-        expect(appLinks.length).toBe(minAppsNum)
+        const appsGrid = queryByTestId('headerbar-top-apps-list')
+        expect(appsGrid).toBeInTheDocument()
+
+        const topApps = appsGrid.querySelectorAll('a')
+        expect(topApps.length).toBe(minAppsNum)
+        const firstApp = topApps[0]
 
         // first highlighted item
-        expect(firstAppLink).toHaveClass('highlighted')
-        expect(firstAppLink.querySelector('span')).toHaveTextContent(
-            'Test App 1'
-        )
+        expect(firstApp).toHaveClass('highlighted')
+        expect(firstApp.querySelector('span')).toHaveTextContent('Test App 1')
 
         // move right through the first row of items (0 - 3)
         for (
             let prevIndex = 0;
-            prevIndex < appLinks.length / 2 - 1;
+            prevIndex < topApps.length / 2 - 1;
             prevIndex++
         ) {
             const activeIndex = prevIndex + 1
-            expect(appLinks[prevIndex]).toHaveClass('highlighted')
+            expect(topApps[prevIndex]).toHaveClass('highlighted')
 
             // move to next item
             await user.keyboard('{ArrowRight}')
-            expect(appLinks[prevIndex]).not.toHaveClass('highlighted')
-            expect(appLinks[activeIndex]).toHaveClass('highlighted')
+            expect(topApps[prevIndex]).not.toHaveClass('highlighted')
+            expect(topApps[activeIndex]).toHaveClass('highlighted')
             expect(
-                appLinks[activeIndex].querySelector('span')
+                topApps[activeIndex].querySelector('span')
             ).toHaveTextContent(`Test App ${activeIndex + 1}`)
         }
 
         // loops back to the first item
         await user.keyboard('{ArrowRight}')
-        expect(firstAppLink).toHaveClass('highlighted')
+        expect(firstApp).toHaveClass('highlighted')
     })
 
     it('handles left arrow navigation in the grid on the home view', async () => {
         const user = userEvent.setup()
-        const { getAllByRole } = render(
+        const { container, getByTestId } = render(
             <CommandPalette
                 apps={testApps}
                 shortcuts={testShortcuts}
@@ -133,51 +135,51 @@ describe('Command Palette - Home View', () => {
             />
         )
 
-        // open modal
-        await user.keyboard('{ctrl}/')
+        // open modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', ctrlKey: true })
 
         // topApps
-        const appLinks = getAllByRole('link')
-        const firstAppLink = appLinks[0]
-        const lastAppLinkFirstRow = appLinks[3]
-        expect(appLinks.length).toBe(minAppsNum)
+        const appsGrid = getByTestId('headerbar-top-apps-list')
+
+        const topApps = appsGrid.querySelectorAll('a')
+        expect(topApps.length).toBe(minAppsNum)
+        const firstApp = topApps[0]
+        const lastAppInFirstRow = topApps[3]
 
         // first highlighted item
-        expect(firstAppLink).toHaveClass('highlighted')
-        expect(firstAppLink.querySelector('span')).toHaveTextContent(
-            'Test App 1'
-        )
+        expect(firstApp).toHaveClass('highlighted')
+        expect(firstApp.querySelector('span')).toHaveTextContent('Test App 1')
 
         // loops to last item in the row
         await user.keyboard('{ArrowLeft}')
-        expect(firstAppLink).not.toHaveClass('highlighted')
-        expect(lastAppLinkFirstRow).toHaveClass('highlighted')
-        expect(lastAppLinkFirstRow.querySelector('span')).toHaveTextContent(
+        expect(firstApp).not.toHaveClass('highlighted')
+        expect(lastAppInFirstRow).toHaveClass('highlighted')
+        expect(lastAppInFirstRow.querySelector('span')).toHaveTextContent(
             'Test App 4'
         )
 
         // move left through the first row of items (3 - 0)
         for (
-            let prevIndex = appLinks.length / 2 - 1;
+            let prevIndex = topApps.length / 2 - 1;
             prevIndex > 0;
             prevIndex--
         ) {
             const activeIndex = prevIndex - 1
-            expect(appLinks[prevIndex]).toHaveClass('highlighted')
+            expect(topApps[prevIndex]).toHaveClass('highlighted')
 
             // move to next item
             await user.keyboard('{ArrowLeft}')
-            expect(appLinks[prevIndex]).not.toHaveClass('highlighted')
-            expect(appLinks[activeIndex]).toHaveClass('highlighted')
+            expect(topApps[prevIndex]).not.toHaveClass('highlighted')
+            expect(topApps[activeIndex]).toHaveClass('highlighted')
             expect(
-                appLinks[activeIndex].querySelector('span')
+                topApps[activeIndex].querySelector('span')
             ).toHaveTextContent(`Test App ${activeIndex + 1}`)
         }
     })
 
     it('handles down arrow navigation on the home view', async () => {
         const user = userEvent.setup()
-        const { getAllByRole, queryByTestId } = render(
+        const { queryByTestId, container } = render(
             <CommandPalette
                 apps={testApps}
                 shortcuts={testShortcuts}
@@ -185,24 +187,28 @@ describe('Command Palette - Home View', () => {
             />
         )
 
-        // open modal
-        await user.keyboard('{ctrl}/')
+        // open modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', ctrlKey: true })
 
         // topApps
-        const appLinks = getAllByRole('link')
-        const rowOneFirstAppLink = appLinks[0]
-        const rowTwoFirstAppLink = appLinks[4]
+        const appsGrid = queryByTestId('headerbar-top-apps-list')
+        expect(appsGrid).toBeInTheDocument()
+
+        const topApps = appsGrid.querySelectorAll('a')
+        expect(topApps.length).toBe(minAppsNum)
+        const rowOneFirstApp = topApps[0]
+        const rowTwoFirstApp = topApps[4]
 
         // first highlighted item
-        expect(rowOneFirstAppLink).toHaveClass('highlighted')
-        expect(rowOneFirstAppLink.querySelector('span')).toHaveTextContent(
+        expect(rowOneFirstApp).toHaveClass('highlighted')
+        expect(rowOneFirstApp.querySelector('span')).toHaveTextContent(
             'Test App 1'
         )
 
         await user.keyboard('{ArrowDown}')
-        expect(rowOneFirstAppLink).not.toHaveClass('highlighted')
-        expect(rowTwoFirstAppLink).toHaveClass('highlighted')
-        expect(rowTwoFirstAppLink.querySelector('span')).toHaveTextContent(
+        expect(rowOneFirstApp).not.toHaveClass('highlighted')
+        expect(rowTwoFirstApp).toHaveClass('highlighted')
+        expect(rowTwoFirstApp.querySelector('span')).toHaveTextContent(
             'Test App '
         )
 
@@ -227,12 +233,12 @@ describe('Command Palette - Home View', () => {
 
         // loop back to grid
         await user.keyboard('{ArrowDown}')
-        expect(rowOneFirstAppLink).toHaveClass('highlighted')
+        expect(rowOneFirstApp).toHaveClass('highlighted')
     })
 
     it('handles up arrow navigation on the home view', async () => {
         const user = userEvent.setup()
-        const { getAllByRole, queryByTestId } = render(
+        const { container, getByTestId, queryByTestId } = render(
             <CommandPalette
                 apps={testApps}
                 shortcuts={testShortcuts}
@@ -240,23 +246,25 @@ describe('Command Palette - Home View', () => {
             />
         )
 
-        // open modal
-        await user.keyboard('{ctrl}/')
+        // open modal with (Ctrl + /) keys
+        fireEvent.keyDown(container, { key: '/', ctrlKey: true })
 
         // topApps
-        const appLinks = getAllByRole('link')
-        const rowOneFirstAppLink = appLinks[0]
-        const rowTwoFirstAppLink = appLinks[4]
+        const appsGrid = getByTestId('headerbar-top-apps-list')
+        const topApps = appsGrid.querySelectorAll('a')
+
+        const rowOneFirstApp = topApps[0]
+        const rowTwoFirstApp = topApps[4]
 
         // first highlighted item
-        expect(rowOneFirstAppLink).toHaveClass('highlighted')
-        expect(rowOneFirstAppLink.querySelector('span')).toHaveTextContent(
+        expect(rowOneFirstApp).toHaveClass('highlighted')
+        expect(rowOneFirstApp.querySelector('span')).toHaveTextContent(
             'Test App 1'
         )
 
         // goes to bottom of actions menu
         await user.keyboard('{ArrowUp}')
-        expect(rowOneFirstAppLink).not.toHaveClass('highlighted')
+        expect(rowOneFirstApp).not.toHaveClass('highlighted')
         expect(queryByTestId('headerbar-logout')).toHaveClass('highlighted')
 
         await user.keyboard('{ArrowUp}')
@@ -276,12 +284,12 @@ describe('Command Palette - Home View', () => {
 
         // moves to grid
         await user.keyboard('{ArrowUp}')
-        expect(rowTwoFirstAppLink).toHaveClass('highlighted')
-        expect(rowTwoFirstAppLink.querySelector('span')).toHaveTextContent(
+        expect(rowTwoFirstApp).toHaveClass('highlighted')
+        expect(rowTwoFirstApp.querySelector('span')).toHaveTextContent(
             'Test App 5'
         )
 
         await user.keyboard('{ArrowUp}')
-        expect(rowOneFirstAppLink).toHaveClass('highlighted')
+        expect(rowOneFirstApp).toHaveClass('highlighted')
     })
 })

--- a/components/header-bar/src/command-palette/__tests__/home-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/home-view.test.js
@@ -1,4 +1,4 @@
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
 import {
@@ -11,7 +11,8 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - Home View', () => {
-    it('shows the full default view upon opening the Command Palette', () => {
+    it('shows the full default view upon opening the Command Palette', async () => {
+        const user = userEvent.setup()
         const {
             getByTestId,
             queryByTestId,
@@ -29,7 +30,7 @@ describe('Command Palette - Home View', () => {
             />
         )
         // headerbar icon button
-        userEvent.click(getByTestId(headerBarIconTest))
+        await await user.click(getByTestId(headerBarIconTest))
 
         // Search field
         const searchField = getByPlaceholderText(
@@ -52,7 +53,7 @@ describe('Command Palette - Home View', () => {
         expect(queryByTestId('headerbar-logout')).toBeInTheDocument()
 
         // full search across apps, shortcuts, commands
-        userEvent.type(searchField, 'Test')
+        await await user.type(searchField, 'Test')
         expect(searchField).toHaveValue('Test')
 
         expect(queryByTestId('headerbar-top-apps-list')).not.toBeInTheDocument()
@@ -67,7 +68,7 @@ describe('Command Palette - Home View', () => {
 
         // clear field
         const clearButton = getAllByRole('button')[1]
-        userEvent.click(clearButton)
+        await user.click(clearButton)
         expect(searchField).toHaveValue('')
 
         // back to default view
@@ -75,7 +76,8 @@ describe('Command Palette - Home View', () => {
         expect(queryByText(/Results for "Test"/i)).not.toBeInTheDocument()
     })
 
-    it('handles right arrow navigation in the grid on the home view', () => {
+    it('handles right arrow navigation in the grid on the home view', async () => {
+        const user = userEvent.setup()
         const { getAllByRole } = render(
             <CommandPalette
                 apps={testApps}
@@ -85,7 +87,7 @@ describe('Command Palette - Home View', () => {
         )
 
         // open modal
-        userEvent.keyboard('{ctrl}/')
+        await user.keyboard('{ctrl}/')
 
         // topApps
         const appLinks = getAllByRole('link')
@@ -108,7 +110,7 @@ describe('Command Palette - Home View', () => {
             expect(appLinks[prevIndex]).toHaveClass('highlighted')
 
             // move to next item
-            userEvent.keyboard('{ArrowRight}')
+            await user.keyboard('{ArrowRight}')
             expect(appLinks[prevIndex]).not.toHaveClass('highlighted')
             expect(appLinks[activeIndex]).toHaveClass('highlighted')
             expect(
@@ -117,11 +119,12 @@ describe('Command Palette - Home View', () => {
         }
 
         // loops back to the first item
-        userEvent.keyboard('{ArrowRight}')
+        await user.keyboard('{ArrowRight}')
         expect(firstAppLink).toHaveClass('highlighted')
     })
 
-    it('handles left arrow navigation in the grid on the home view', () => {
+    it('handles left arrow navigation in the grid on the home view', async () => {
+        const user = userEvent.setup()
         const { getAllByRole } = render(
             <CommandPalette
                 apps={testApps}
@@ -131,7 +134,7 @@ describe('Command Palette - Home View', () => {
         )
 
         // open modal
-        userEvent.keyboard('{ctrl}/')
+        await user.keyboard('{ctrl}/')
 
         // topApps
         const appLinks = getAllByRole('link')
@@ -146,7 +149,7 @@ describe('Command Palette - Home View', () => {
         )
 
         // loops to last item in the row
-        userEvent.keyboard('{ArrowLeft}')
+        await user.keyboard('{ArrowLeft}')
         expect(firstAppLink).not.toHaveClass('highlighted')
         expect(lastAppLinkFirstRow).toHaveClass('highlighted')
         expect(lastAppLinkFirstRow.querySelector('span')).toHaveTextContent(
@@ -163,7 +166,7 @@ describe('Command Palette - Home View', () => {
             expect(appLinks[prevIndex]).toHaveClass('highlighted')
 
             // move to next item
-            userEvent.keyboard('{ArrowLeft}')
+            await user.keyboard('{ArrowLeft}')
             expect(appLinks[prevIndex]).not.toHaveClass('highlighted')
             expect(appLinks[activeIndex]).toHaveClass('highlighted')
             expect(
@@ -172,7 +175,8 @@ describe('Command Palette - Home View', () => {
         }
     })
 
-    it('handles down arrow navigation on the home view', () => {
+    it('handles down arrow navigation on the home view', async () => {
+        const user = userEvent.setup()
         const { getAllByRole, queryByTestId } = render(
             <CommandPalette
                 apps={testApps}
@@ -182,7 +186,7 @@ describe('Command Palette - Home View', () => {
         )
 
         // open modal
-        userEvent.keyboard('{ctrl}/')
+        await user.keyboard('{ctrl}/')
 
         // topApps
         const appLinks = getAllByRole('link')
@@ -195,7 +199,7 @@ describe('Command Palette - Home View', () => {
             'Test App 1'
         )
 
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(rowOneFirstAppLink).not.toHaveClass('highlighted')
         expect(rowTwoFirstAppLink).toHaveClass('highlighted')
         expect(rowTwoFirstAppLink.querySelector('span')).toHaveTextContent(
@@ -203,30 +207,31 @@ describe('Command Palette - Home View', () => {
         )
 
         // actions menu
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(queryByTestId('headerbar-browse-apps')).toHaveClass(
             'highlighted'
         )
 
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(queryByTestId('headerbar-browse-commands')).toHaveClass(
             'highlighted'
         )
 
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(queryByTestId('headerbar-browse-shortcuts')).toHaveClass(
             'highlighted'
         )
 
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(queryByTestId('headerbar-logout')).toHaveClass('highlighted')
 
         // loop back to grid
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(rowOneFirstAppLink).toHaveClass('highlighted')
     })
 
-    it('handles up arrow navigation on the home view', () => {
+    it('handles up arrow navigation on the home view', async () => {
+        const user = userEvent.setup()
         const { getAllByRole, queryByTestId } = render(
             <CommandPalette
                 apps={testApps}
@@ -236,7 +241,7 @@ describe('Command Palette - Home View', () => {
         )
 
         // open modal
-        userEvent.keyboard('{ctrl}/')
+        await user.keyboard('{ctrl}/')
 
         // topApps
         const appLinks = getAllByRole('link')
@@ -250,33 +255,33 @@ describe('Command Palette - Home View', () => {
         )
 
         // goes to bottom of actions menu
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(rowOneFirstAppLink).not.toHaveClass('highlighted')
         expect(queryByTestId('headerbar-logout')).toHaveClass('highlighted')
 
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(queryByTestId('headerbar-browse-shortcuts')).toHaveClass(
             'highlighted'
         )
 
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(queryByTestId('headerbar-browse-commands')).toHaveClass(
             'highlighted'
         )
 
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(queryByTestId('headerbar-browse-apps')).toHaveClass(
             'highlighted'
         )
 
         // moves to grid
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(rowTwoFirstAppLink).toHaveClass('highlighted')
         expect(rowTwoFirstAppLink.querySelector('span')).toHaveTextContent(
             'Test App 5'
         )
 
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(rowOneFirstAppLink).toHaveClass('highlighted')
     })
 })

--- a/components/header-bar/src/command-palette/__tests__/search-results.test.js
+++ b/components/header-bar/src/command-palette/__tests__/search-results.test.js
@@ -1,3 +1,4 @@
+import { fireEvent } from '@testing-library/dom'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
@@ -12,7 +13,7 @@ import {
 describe('Command Palette - List View - Search Results', () => {
     it('filters for one item and handles navigation of singular item list', async () => {
         const user = userEvent.setup()
-        const { getByPlaceholderText, queryAllByTestId } = render(
+        const { getByPlaceholderText, queryAllByTestId, container } = render(
             <CommandPalette
                 apps={testApps}
                 shortcuts={testShortcuts}
@@ -20,7 +21,7 @@ describe('Command Palette - List View - Search Results', () => {
             />
         )
         // open modal
-        await user.keyboard('{ctrl}/')
+        fireEvent.keyDown(container, { key: '/', metaKey: true })
 
         // Search field
         const searchField = await getByPlaceholderText(

--- a/components/header-bar/src/command-palette/__tests__/search-results.test.js
+++ b/components/header-bar/src/command-palette/__tests__/search-results.test.js
@@ -1,4 +1,4 @@
-import userEvent from '@testing-library/user-event'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import CommandPalette from '../command-palette.js'
 import {
@@ -10,7 +10,8 @@ import {
 } from './command-palette.test.js'
 
 describe('Command Palette - List View - Search Results', () => {
-    it('filters for one item and handles navigation of singular item list', () => {
+    it('filters for one item and handles navigation of singular item list', async () => {
+        const user = userEvent.setup()
         const { getByPlaceholderText, queryAllByTestId } = render(
             <CommandPalette
                 apps={testApps}
@@ -19,30 +20,31 @@ describe('Command Palette - List View - Search Results', () => {
             />
         )
         // open modal
-        userEvent.keyboard('{ctrl}/')
+        await user.keyboard('{ctrl}/')
 
         // Search field
-        const searchField = getByPlaceholderText(
+        const searchField = await getByPlaceholderText(
             'Search apps, shortcuts, commands'
         )
         expect(searchField).toHaveValue('')
 
         // one item result
-        userEvent.type(searchField, 'Shortcut')
+        await user.type(searchField, 'Shortcut')
         const listItems = queryAllByTestId('headerbar-list-item')
         expect(listItems.length).toBe(1)
 
         expect(listItems[0]).toHaveTextContent('Test Shortcut 1')
         expect(listItems[0]).toHaveClass('highlighted')
 
-        userEvent.keyboard('{ArrowUp}')
+        await user.keyboard('{ArrowUp}')
         expect(listItems[0]).toHaveClass('highlighted')
 
-        userEvent.keyboard('{ArrowDown}')
+        await user.keyboard('{ArrowDown}')
         expect(listItems[0]).toHaveClass('highlighted')
     })
 
-    it('shows empty search results if no match is made', () => {
+    it('shows empty search results if no match is made', async () => {
+        const user = userEvent.setup()
         const {
             getByTestId,
             getByPlaceholderText,
@@ -52,7 +54,7 @@ describe('Command Palette - List View - Search Results', () => {
             <CommandPalette apps={[]} shortcuts={testShortcuts} commands={[]} />
         )
         // open command palette
-        userEvent.click(getByTestId(headerBarIconTest))
+        await user.click(getByTestId(headerBarIconTest))
 
         // Search field
         const searchField = getByPlaceholderText(
@@ -60,7 +62,7 @@ describe('Command Palette - List View - Search Results', () => {
         )
         expect(searchField).toHaveValue('')
 
-        userEvent.type(searchField, 'abc')
+        await user.type(searchField, 'abc')
         expect(searchField).toHaveValue('abc')
 
         expect(queryByTestId('headerbar-empty-search')).toBeInTheDocument()

--- a/components/header-bar/src/command-palette/hooks/use-navigation.js
+++ b/components/header-bar/src/command-palette/hooks/use-navigation.js
@@ -220,7 +220,7 @@ export const useNavigation = ({
             }
 
             if ((event.metaKey || event.ctrlKey) && event.key === '/') {
-                setShow(!show)
+                setShow((show) => !show)
                 goToDefaultView()
             }
 


### PR DESCRIPTION
- This PR fixes the failing tests related to the command palette after the React 18 upgrade. By using the fireEvent API (instead of the originally used userEvent API) to simulate keyboard events, i.e. pressing `Ctrl/Meta` + `/`, to simulate the opening and closing of the command palette modal. 