### PR TITLE
fix(deps): remove testing-library from selector bar prod deps

### DIFF
--- a/components/selector-bar/package.json
+++ b/components/selector-bar/package.json
@@ -39,7 +39,6 @@
         "@dhis2-ui/layer": "10.1.6",
         "@dhis2/ui-constants": "10.1.6",
         "@dhis2/ui-icons": "10.1.6",
-        "@testing-library/react": "^16.0.1",
         "classnames": "^2.3.1",
         "prop-types": "^15.7.2"
     },


### PR DESCRIPTION
Noticed this when examining testing-library deps in the app platform alpha:

![sharing-dialog-testing-library-upgraded](https://github.com/user-attachments/assets/4580c876-89da-4e87-92b2-d2d53da6e3cd)

It shouldn't be necessary here; there's a dev dependency at the package root
