### PR TITLE
fix(transfer): adjust filter inputs and container spacing [LIBS-728] 

### DIFF
--- a/components/transfer/src/filter.js
+++ b/components/transfer/src/filter.js
@@ -8,6 +8,7 @@ export const Filter = ({ dataTest, filter, onChange, label, placeholder }) => (
     <div data-test={dataTest}>
         <Field label={label} name={dataTest} dataTest={`${dataTest}-field`}>
             <Input
+                dense
                 dataTest={`${dataTest}-input`}
                 type="search"
                 placeholder={placeholder}

--- a/components/transfer/src/options-container.js
+++ b/components/transfer/src/options-container.js
@@ -1,4 +1,3 @@
-import { spacers } from '@dhis2/ui-constants'
 import { CircularLoader } from '@dhis2-ui/loader'
 import PropTypes from 'prop-types'
 import React, { Fragment, useRef } from 'react'
@@ -69,7 +68,6 @@ export const OptionsContainer = ({
             <style jsx>{`
                 .optionsContainer {
                     flex-grow: 1;
-                    padding: ${spacers.dp4} 0;
                     position: relative;
                     overflow: hidden;
                 }

--- a/components/transfer/src/transfer-option.js
+++ b/components/transfer/src/transfer-option.js
@@ -1,4 +1,4 @@
-import { colors } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
@@ -65,6 +65,14 @@ export const TransferOption = ({
                 div.disabled {
                     color: ${colors.grey600};
                     cursor: not-allowed;
+                }
+
+                div:first-child {
+                    margin-block-start: ${spacers.dp4};
+                }
+
+                div:last-child {
+                    margin-block-end: ${spacers.dp4};
                 }
             `}</style>
         </div>


### PR DESCRIPTION
Implements [LIBS-728](https://dhis2.atlassian.net/browse/LIBS-728)

---

### Description

This PR makes two minor style changes to `Transfer`:
- Use `dense` inputs for the default filter inputs
- Apply margin to first and last options, rather than the options container, which removes the spacing above/below the scrollbar.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Before 1: 

![image](https://github.com/user-attachments/assets/132e7a16-55b8-483d-ae83-fc47c6ed3399)


After 1:

![image](https://github.com/user-attachments/assets/536e062f-0772-4e33-9a3a-09b669f2775e)


Before 2:

![image](https://github.com/user-attachments/assets/7c6df46b-9998-436a-8a06-da77b41254bd)


After 2:

![image](https://github.com/user-attachments/assets/a000a09f-5bbc-4e8c-8546-907a9252877b)


[LIBS-728]: https://dhis2.atlassian.net/browse/LIBS-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ