### PR TITLE
fix: correct component imports, open apps in same window

### DIFF
--- a/components/button/src/dropdown-button/__tests__/dropdown-button.test.js
+++ b/components/button/src/dropdown-button/__tests__/dropdown-button.test.js
@@ -1,10 +1,10 @@
 import { Layer } from '@dhis2-ui/layer'
+import { Modal } from '@dhis2-ui/modal'
 import { Popper } from '@dhis2-ui/popper'
 import { render, fireEvent, waitFor } from '@testing-library/react'
 import { mount } from 'enzyme'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
-import { Modal } from '../../../../modal/src/modal/modal.js'
 import { Button } from '../../index.js'
 import { DropdownButton } from '../dropdown-button.js'
 

--- a/components/header-bar/i18n/en.pot
+++ b/components/header-bar/i18n/en.pot
@@ -5,11 +5,44 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-06-12T03:40:49.012Z\n"
-"PO-Revision-Date: 2024-06-12T03:40:49.013Z\n"
+"POT-Creation-Date: 2024-12-17T01:42:03.299Z\n"
+"PO-Revision-Date: 2024-12-17T01:42:03.300Z\n"
 
 msgid "Search apps"
 msgstr "Search apps"
+
+msgid "Search commands"
+msgstr "Search commands"
+
+msgid "Search shortcuts"
+msgstr "Search shortcuts"
+
+msgid "Search apps, shortcuts, commands"
+msgstr "Search apps, shortcuts, commands"
+
+msgid "Browse apps"
+msgstr "Browse apps"
+
+msgid "Browse commands"
+msgstr "Browse commands"
+
+msgid "Browse shortcuts"
+msgstr "Browse shortcuts"
+
+msgid "Logout"
+msgstr "Logout"
+
+msgid "Top apps"
+msgstr "Top apps"
+
+msgid "All Apps"
+msgstr "All Apps"
+
+msgid "All Commands"
+msgstr "All Commands"
+
+msgid "All Shortcuts"
+msgstr "All Shortcuts"
 
 msgid "DHIS2 {{dhis2Version}}"
 msgstr "DHIS2 {{dhis2Version}}"
@@ -61,9 +94,6 @@ msgstr "Help"
 
 msgid "About DHIS2"
 msgstr "About DHIS2"
-
-msgid "Logout"
-msgstr "Logout"
 
 msgid "New {{appName}} version available"
 msgstr "New {{appName}} version available"

--- a/components/header-bar/src/command-palette/hooks/use-navigation.js
+++ b/components/header-bar/src/command-palette/hooks/use-navigation.js
@@ -231,7 +231,7 @@ export const useNavigation = ({
                         ?.childNodes?.[highlightedIndex]?.click()
                 } else {
                     // open apps, shortcuts link
-                    window.open(itemsArray[highlightedIndex]?.['defaultAction'])
+                    window.location.href = itemsArray[highlightedIndex]?.['defaultAction']
                     // TODO: execute commands
                 }
             }

--- a/components/header-bar/src/command-palette/sections/app-item.js
+++ b/components/header-bar/src/command-palette/sections/app-item.js
@@ -7,6 +7,7 @@ function AppItem({ name, path, img, highlighted, handleMouseEnter }) {
     return (
         <a
             href={path}
+            target="_self"
             className={cx('item', { highlighted })}
             onMouseEnter={handleMouseEnter}
             tabIndex={-1}

--- a/components/header-bar/src/command-palette/sections/list-item.js
+++ b/components/header-bar/src/command-palette/sections/list-item.js
@@ -19,6 +19,7 @@ function ListItem({
     return (
         <a
             href={path ? path : undefined}
+            target="_self"
             onClick={onClickHandler}
             className={cx('item', { highlighted })}
             data-test={dataTest}

--- a/components/header-bar/src/command-palette/sections/search-field.js
+++ b/components/header-bar/src/command-palette/sections/search-field.js
@@ -1,8 +1,8 @@
 import { colors, spacers, theme } from '@dhis2/ui-constants'
 import { IconSearch16 } from '@dhis2/ui-icons'
+import { InputField } from '@dhis2-ui/input'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { InputField } from '../../../../input/src/input-field/input-field.js'
 
 function Search({ value, onChange, placeholder }) {
     return (


### PR DESCRIPTION
Some imports were relative (`../../../../`) when they should have imported from other component packages (`@dhis2-ui/input`, for example)

I also updated the behavior of app links to open in the same window instead of a new one, maintaining the behavior of the previous app menu.  We might want to support cmd/ctl+enter to open in a new tab.