### PR TITLE
fix(select): adjust active option style

### DIFF
--- a/components/select/src/multi-select-option/multi-select-option.js
+++ b/components/select/src/multi-select-option/multi-select-option.js
@@ -20,7 +20,7 @@ const MultiSelectOption = ({
     value,
 }) => (
     <div
-        className={cx(className, { disabled })}
+        className={cx(className, { active, disabled })}
         data-test={dataTest}
         data-value={value}
         data-label={label}
@@ -40,6 +40,14 @@ const MultiSelectOption = ({
         <style jsx>{`
             div:hover {
                 background-color: ${colors.grey200};
+            }
+
+            div.active {
+                background-color: ${colors.teal050};
+            }
+
+            div.active:hover {
+                background-color: #e6f4f4;
             }
 
             div.disabled:hover {

--- a/components/select/src/single-select-option/single-select-option.js
+++ b/components/select/src/single-select-option/single-select-option.js
@@ -22,16 +22,18 @@ const SingleSelectOption = ({
         data-value={value}
         data-label={label}
     >
-        {label}
-
+        <span className="checkmark" aria-hidden="true"></span>
+        <span className="content">{label}</span>
         <style jsx>{`
             div {
+                display: flex;
+                align-items: center;
                 cursor: pointer;
                 font-size: 14px;
                 text-decoration: none;
                 color: ${colors.grey900};
                 padding-block: ${spacers.dp8};
-                padding-inline: ${spacers.dp12};
+                padding-inline: 6px ${spacers.dp12};
             }
 
             div:hover {
@@ -40,8 +42,7 @@ const SingleSelectOption = ({
 
             div:active,
             div.active {
-                background-color: ${colors.teal700};
-                color: ${colors.white};
+                background-color: ${colors.teal050};
                 cursor: auto;
             }
 
@@ -53,6 +54,18 @@ const SingleSelectOption = ({
 
             div.disabled:hover {
                 background-color: initial;
+            }
+
+            div .checkmark {
+                width: 16px;
+                height: 16px;
+                margin-inline-end: 6px;
+                flex-shrink: 0;
+                background-size: contain;
+                background-repeat: no-repeat;
+                background-image: ${active
+                    ? `url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTMuNjMyMDkgNy44MzIxNEMzLjI3MjA5IDcuNDcyMTQgMi43MjAwOSA3LjQ3MjE0IDIuMzYwMDkgNy44MzIxNEMyLjAwMDA5IDguMTkyMTQgMi4wMDAwOSA4Ljc0NDE0IDIuMzYwMDkgOS4xMDQxNEw1LjYyNDA5IDEyLjM2ODFDNS45ODQwOSAxMi43MjgxIDYuNTM2MDkgMTIuNzI4MSA2Ljg5NjA5IDEyLjM2ODFMMTQuNjQ4MSA0LjY0MDE0QzE1LjAwODEgNC4yODAxNCAxNS4wMDgxIDMuNzI4MTQgMTQuNjQ4MSAzLjM2ODE0QzE0LjI4ODEgMy4wMDgxNCAxMy43MzYxIDMuMDA4MTQgMTMuMzUyMSAzLjM2ODE0TDYuMjcyMDkgMTAuNDcyMUwzLjYzMjA5IDcuODMyMTRaIiBmaWxsPSIjMDA2OTVDIi8+Cjwvc3ZnPgo=')`
+                    : 'none'};
             }
         `}</style>
     </div>


### PR DESCRIPTION
Implements [UX-178](https://dhis2.atlassian.net/browse/UX-178)

---

### Description

This PR adjusts the `active` style for `SingleSelect` options to improve readability and better align with native browser `select` styles. Minor cosmetic changes to the `MultiSelect` `active` option are included for consistency.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Before (`SingleSelect`): 

![image](https://github.com/user-attachments/assets/857f1fd2-79d0-4785-ad44-ab282bcd41dc)

After (`SingleSelect`):

![image](https://github.com/user-attachments/assets/94953485-abac-44b9-a813-4feeca7fdc75)

Before (`MultiSelect`):

![image](https://github.com/user-attachments/assets/833bf49f-2936-4025-a417-be6f430412c7)

After (`MultiSelect`):

![image](https://github.com/user-attachments/assets/e592df5f-4b54-44cc-b48c-8ab9119b4ab1)

`SingleSelect` option handling multiline content:

![image](https://github.com/user-attachments/assets/e4f57b7c-d102-47c7-8272-bc25c6b596a3)


[UX-178]: https://dhis2.atlassian.net/browse/UX-178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ