### PR TITLE
fix(command palette): consistent highlighting of first item in home view

### DIFF
--- a/components/header-bar/src/command-palette/hooks/use-navigation.js
+++ b/components/header-bar/src/command-palette/hooks/use-navigation.js
@@ -24,12 +24,20 @@ export const useNavigation = ({
         setActiveSection,
     } = useCommandPaletteContext()
 
+    const defaultSection = showGrid ? 'grid' : 'actions'
+
     // highlight first item in filtered results
     useEffect(() => {
         setHighlightedIndex(0)
     }, [filter, setHighlightedIndex])
 
-    const defaultSection = showGrid ? 'grid' : 'actions'
+    // highlight first item in home view
+    useEffect(() => {
+        if (currentView === 'home' && !activeSection) {
+            setActiveSection(defaultSection)
+            setHighlightedIndex(0)
+        }
+    }, [])
 
     const goToDefaultView = useCallback(() => {
         setFilter('')
@@ -256,7 +264,5 @@ export const useNavigation = ({
         handleKeyDown,
         goToDefaultView,
         modalRef,
-        activeSection,
-        setActiveSection,
     }
 }


### PR DESCRIPTION
Fixes [BETA-272](https://dhis2.atlassian.net/browse/BETA-272)

---

### Description
- This PR ensures to always highlight the first item in the default/home view whenever the command palette is opened.  
- The command palette can be opened by:
  - the keyboard shortcut (`Ctrl/Meta` + `/`),
  - clicking on the apps menu icon,
  -  or tabbing to the apps menu icon and pressing the `Enter` key. 
- The default/home view has a `grid` section containing 8 apps, and an `actions` sections with a list of actions for the user to take. 
- The fix in this PR sets the active section on component render and highlights the first item in that section. 
  - If the header bar has apps to render, then the highlighted item will be the first app in the grid. 
  - If the header bar does not have any apps to render, i.e. only the actions are available, then the highlighted item will be the first action in the actions section. 
 - Once the first item is highlighted, then a user can move through the items in the command palette with the arrow keys.

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

https://github.com/user-attachments/assets/727a645d-d15b-45f6-9eae-07611fdb9d93


[BETA-272]: https://dhis2.atlassian.net/browse/BETA-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ