### PR TITLE
fix(command palette): remove dual focus functionality

### DIFF
--- a/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
+++ b/components/header-bar/src/command-palette/__tests__/browse-apps-view.test.js
@@ -122,13 +122,10 @@ describe('Command Palette - List View - Browse Apps View', () => {
             'Test App 1'
         )
 
-        // simulate hover
+        // simulate hover - no highlight
         await user.hover(listItems[8])
-        expect(listItems[1]).not.toHaveClass('highlighted')
-        expect(listItems[8]).toHaveClass('highlighted')
-        expect(listItems[8].querySelector('span')).toHaveTextContent(
-            'Test App 9'
-        )
+        expect(listItems[0]).toHaveClass('highlighted')
+        expect(listItems[8]).not.toHaveClass('highlighted')
 
         const clearButton = getAllByRole('button')[1]
         await user.click(clearButton)

--- a/components/header-bar/src/command-palette/sections/app-item.js
+++ b/components/header-bar/src/command-palette/sections/app-item.js
@@ -3,14 +3,9 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-function AppItem({ name, path, img, highlighted, handleMouseEnter }) {
+function AppItem({ name, path, img, highlighted }) {
     return (
-        <a
-            href={path}
-            className={cx('item', { highlighted })}
-            onMouseEnter={handleMouseEnter}
-            tabIndex={-1}
-        >
+        <a href={path} className={cx('item', { highlighted })} tabIndex={-1}>
             <img src={img} alt="app" className="app-icon" />
             <span className="app-name">{name}</span>
             <style jsx>{`
@@ -51,7 +46,6 @@ function AppItem({ name, path, img, highlighted, handleMouseEnter }) {
 }
 
 AppItem.propTypes = {
-    handleMouseEnter: PropTypes.func,
     highlighted: PropTypes.bool,
     img: PropTypes.string,
     name: PropTypes.string,

--- a/components/header-bar/src/command-palette/sections/list-item.js
+++ b/components/header-bar/src/command-palette/sections/list-item.js
@@ -13,7 +13,6 @@ function ListItem({
     onClickHandler,
     highlighted,
     dataTest = 'headerbar-list-item',
-    handleMouseEnter,
 }) {
     const showDescription = type === 'commands'
     return (
@@ -22,7 +21,6 @@ function ListItem({
             onClick={onClickHandler}
             className={cx('item', { highlighted })}
             data-test={dataTest}
-            onMouseEnter={handleMouseEnter}
             tabIndex={-1}
         >
             <div className="icon">
@@ -100,7 +98,6 @@ function ListItem({
 ListItem.propTypes = {
     dataTest: PropTypes.string,
     description: PropTypes.string,
-    handleMouseEnter: PropTypes.func,
     highlighted: PropTypes.bool,
     icon: PropTypes.node,
     image: PropTypes.string,

--- a/components/header-bar/src/command-palette/sections/list.js
+++ b/components/header-bar/src/command-palette/sections/list.js
@@ -4,7 +4,7 @@ import { useCommandPaletteContext } from '../context/command-palette-context.js'
 import ListItem from './list-item.js'
 
 function List({ filteredItems, type }) {
-    const { highlightedIndex, setHighlightedIndex } = useCommandPaletteContext()
+    const { highlightedIndex } = useCommandPaletteContext()
     return (
         <div data-test="headerbar-list">
             {filteredItems.map(
@@ -20,7 +20,6 @@ function List({ filteredItems, type }) {
                         image={icon}
                         description={description}
                         highlighted={highlightedIndex === idx}
-                        handleMouseEnter={() => setHighlightedIndex(idx)}
                     />
                 )
             )}

--- a/components/header-bar/src/command-palette/views/home-view.js
+++ b/components/header-bar/src/command-palette/views/home-view.js
@@ -18,7 +18,6 @@ function HomeView({ apps, commands, shortcuts, actions }) {
         highlightedIndex,
         setHighlightedIndex,
         activeSection,
-        setActiveSection,
     } = useCommandPaletteContext()
     const filteredItems = apps.concat(commands, shortcuts)
     const topApps = apps?.slice(0, 8)
@@ -54,10 +53,6 @@ function HomeView({ apps, commands, shortcuts, actions }) {
                                                 activeSection === 'grid' &&
                                                 highlightedIndex === idx
                                             }
-                                            handleMouseEnter={() => {
-                                                setActiveSection('grid')
-                                                setHighlightedIndex(idx)
-                                            }}
                                         />
                                     )
                                 )}
@@ -118,10 +113,6 @@ function HomeView({ apps, commands, shortcuts, actions }) {
                                             activeSection === 'actions' &&
                                             highlightedIndex === index
                                         }
-                                        handleMouseEnter={() => {
-                                            setActiveSection('actions')
-                                            setHighlightedIndex(index)
-                                        }}
                                     />
                                 )
                             }


### PR DESCRIPTION
Fixes [BETA-222](https://dhis2.atlassian.net/browse/BETA-222)

---

### Description

- This PR removes the dual focus caused by highlighting items in the command palette either by: 
  - use of the arrow keys, or
  - hovering over them. 

- Focus on an item can now only be done through arrow key navigation. 

---

### Checklist

-   [ ] API docs are generated
-   [x] Tests were added
-   [ ] Storybook demos were added

---


[BETA-222]: https://dhis2.atlassian.net/browse/BETA-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ