### PR TITLE
fix: app redirects on command palette launch

### DIFF
--- a/components/header-bar/src/command-palette/command-palette.js
+++ b/components/header-bar/src/command-palette/command-palette.js
@@ -88,15 +88,14 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
                 <IconApps24 color={colors.white} />
             </button>
             {openModal ? (
-                <ModalContainer setShow={setOpenModal} show={openModal}>
-                    <div
-                        data-test="headerbar-menu"
-                        className="headerbar-menu"
-                        ref={modalRef}
-                        tabIndex={0}
-                        onFocus={handleFocus}
-                        onKeyDown={handleKeyDown}
-                    >
+                <ModalContainer
+                    setShow={setOpenModal}
+                    show={openModal}
+                    modalRef={modalRef}
+                    onFocus={handleFocus}
+                    onKeyDown={handleKeyDown}
+                >
+                    <div data-test="headerbar-menu" className="headerbar-menu">
                         <Search
                             value={filter}
                             onChange={handleFilterChange}

--- a/components/header-bar/src/command-palette/command-palette.js
+++ b/components/header-bar/src/command-palette/command-palette.js
@@ -19,10 +19,13 @@ import {
 
 const CommandPalette = ({ apps, commands, shortcuts }) => {
     const containerEl = useRef(null)
-    const [show, setShow] = useState(false)
+    const [openModal, setOpenModal] = useState(false)
     const { currentView, filter, setFilter } = useCommandPaletteContext()
 
-    const handleVisibilityToggle = useCallback(() => setShow(!show), [show])
+    const handleVisibilityToggle = useCallback(
+        () => setOpenModal(!openModal),
+        [openModal]
+    )
     const handleFilterChange = useCallback(
         ({ value }) => setFilter(value),
         [setFilter]
@@ -38,9 +41,8 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
     } = useFilter({ apps, commands, shortcuts })
 
     const { handleKeyDown, goToDefaultView, modalRef } = useNavigation({
-        setShow,
+        setOpenModal,
         itemsArray: currentViewItemsArray,
-        show,
         showGrid: apps?.length > 0,
         actionsLength: actionsArray?.length,
     })
@@ -65,11 +67,17 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
     }
 
     useEffect(() => {
+        const handleKeyDown = (event) => {
+            if ((event.metaKey || event.ctrlKey) && event.key === '/') {
+                setOpenModal((open) => !open)
+                goToDefaultView()
+            }
+        }
         document.addEventListener('keydown', handleKeyDown)
         return () => {
             document.removeEventListener('keydown', handleKeyDown)
         }
-    }, [handleKeyDown])
+    }, [goToDefaultView])
 
     return (
         <div ref={containerEl} data-test="headerbar" className="headerbar">
@@ -79,14 +87,15 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
             >
                 <IconApps24 color={colors.white} />
             </button>
-            {show ? (
-                <ModalContainer setShow={setShow} show={show}>
+            {openModal ? (
+                <ModalContainer setShow={setOpenModal} show={openModal}>
                     <div
                         data-test="headerbar-menu"
                         className="headerbar-menu"
                         ref={modalRef}
                         tabIndex={0}
                         onFocus={handleFocus}
+                        onKeyDown={handleKeyDown}
                     >
                         <Search
                             value={filter}

--- a/components/header-bar/src/command-palette/hooks/use-navigation.js
+++ b/components/header-bar/src/command-palette/hooks/use-navigation.js
@@ -5,9 +5,8 @@ export const GRID_ITEMS_LENGTH = 8
 export const MIN_APPS_NUM = GRID_ITEMS_LENGTH
 
 export const useNavigation = ({
-    setShow,
+    setOpenModal,
     itemsArray,
-    show,
     showGrid,
     actionsLength,
 }) => {
@@ -180,7 +179,7 @@ export const useNavigation = ({
 
             if (event.key === 'Escape') {
                 event.preventDefault()
-                setShow(false)
+                setOpenModal(false)
                 setActiveSection(defaultSection)
                 setHighlightedIndex(0)
             }
@@ -193,7 +192,7 @@ export const useNavigation = ({
             highlightedIndex,
             setActiveSection,
             setHighlightedIndex,
-            setShow,
+            setOpenModal,
         ]
     )
 
@@ -219,11 +218,6 @@ export const useNavigation = ({
                 })
             }
 
-            if ((event.metaKey || event.ctrlKey) && event.key === '/') {
-                setShow((show) => !show)
-                goToDefaultView()
-            }
-
             if (event.key === 'Enter') {
                 if (activeSection === 'actions') {
                     modal
@@ -246,8 +240,7 @@ export const useNavigation = ({
             highlightedIndex,
             itemsArray,
             setActiveSection,
-            setShow,
-            show,
+            setOpenModal,
             showGrid,
         ]
     )

--- a/components/header-bar/src/command-palette/sections/container.js
+++ b/components/header-bar/src/command-palette/sections/container.js
@@ -3,10 +3,24 @@ import { Layer } from '@dhis2-ui/layer'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const ModalContainer = ({ children, setShow, show }) => {
+const ModalContainer = ({
+    children,
+    setShow,
+    show,
+    modalRef,
+    onFocus,
+    onKeyDown,
+}) => {
     return (
         <Layer onBackdropClick={() => setShow(false)} translucent={show}>
-            <div role="dialog" aria-modal="true">
+            <div
+                role="dialog"
+                aria-modal="true"
+                ref={modalRef}
+                tabIndex={0}
+                onFocus={onFocus}
+                onKeyDown={onKeyDown}
+            >
                 {children}
             </div>
             <style jsx>{`
@@ -30,8 +44,11 @@ const ModalContainer = ({ children, setShow, show }) => {
 
 ModalContainer.propTypes = {
     children: PropTypes.node,
+    modalRef: PropTypes.object,
     setShow: PropTypes.func,
     show: PropTypes.bool,
+    onFocus: PropTypes.func,
+    onKeyDown: PropTypes.func,
 }
 
 export default ModalContainer


### PR DESCRIPTION
Implements [DHIS2-18943](https://dhis2.atlassian.net/browse/DHIS2-18943)

---

### Description

This PR separates the keydown logic specific to the command palette component from that attached to the document.

**Previous Behaviour**:
-  Previously, when a user pressed the `Enter` key on the apps menu icon, an app would open immediately. 
- This was due to the command palette launching and the document `Enter` key logic triggering the selection of the first highlighted item, hence redirecting to the app. 

**Fixed Behaviour**: 
- Only the key down logic for the keyboard shortcuts (`Ctrl/Meta` + `/`) used to open the command palette is attached to the document since it can be triggered anywhere within the app. 
- All other keydown functionality specific for use within the command palette is attached to its parent component. 
- Now, pressing the `Enter` key on the apps menu icon opens the command palette without a problem

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

---

### Screenshots
**Before**

https://github.com/user-attachments/assets/f5c96123-acca-4da6-9300-0917d55151a1

**After**

https://github.com/user-attachments/assets/b429a555-4951-4898-8f73-37398bb1dcdf



[DHIS2-18943]: https://dhis2.atlassian.net/browse/DHIS2-18943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ