### PR TITLE
feat: add commands support and make logout searchable

### DIFF
--- a/components/header-bar/src/command-palette/command-palette.js
+++ b/components/header-bar/src/command-palette/command-palette.js
@@ -44,7 +44,7 @@ const CommandPalette = ({ apps, commands, shortcuts }) => {
         setOpenModal,
         itemsArray: currentViewItemsArray,
         showGrid: apps?.length > 0,
-        actionsLength: actionsArray?.length,
+        actionsArray,
     })
 
     useEffect(() => {

--- a/components/header-bar/src/command-palette/commands/index.js
+++ b/components/header-bar/src/command-palette/commands/index.js
@@ -1,0 +1,9 @@
+import useLogout from './useLogout.js'
+
+const useCommands = () => {
+    const { logout } = useLogout()
+
+    return [logout]
+}
+
+export default useCommands

--- a/components/header-bar/src/command-palette/commands/useLogout.js
+++ b/components/header-bar/src/command-palette/commands/useLogout.js
@@ -1,0 +1,29 @@
+import { clearSensitiveCaches, useConfig } from '@dhis2/app-runtime'
+import { colors } from '@dhis2/ui-constants'
+import { IconLogOut16 } from '@dhis2/ui-icons'
+import React from 'react'
+import { joinPath } from '../../join-path.js'
+
+const useLogout = () => {
+    const { baseUrl } = useConfig()
+
+    const href = joinPath(baseUrl, 'dhis-web-commons-security/logout.action')
+    const logoutAction = async () => {
+        await clearSensitiveCaches()
+        window.location.assign(href)
+    }
+
+    return {
+        logout: {
+            name: 'Logout',
+            icon: <IconLogOut16 color={colors.grey700} />,
+            description: 'Logout of the application',
+            action: logoutAction,
+            url: href,
+        },
+        logoutURL: href,
+        logoutAction,
+    }
+}
+
+export default useLogout

--- a/components/header-bar/src/command-palette/hooks/use-actions.js
+++ b/components/header-bar/src/command-palette/hooks/use-actions.js
@@ -7,9 +7,20 @@ import {
 } from '@dhis2/ui-icons'
 import React, { useMemo } from 'react'
 import i18n from '../../locales/index.js'
+import useLogout from '../commands/useLogout.js'
+import { useCommandPaletteContext } from '../context/command-palette-context.js'
 import { MIN_APPS_NUM } from './use-navigation.js'
 
 export const useAvailableActions = ({ apps, shortcuts, commands }) => {
+    const { setCurrentView, setHighlightedIndex } = useCommandPaletteContext()
+
+    const switchViewAction = (type) => {
+        setCurrentView(type)
+        setHighlightedIndex(0)
+    }
+
+    const { logoutAction, logoutURL } = useLogout()
+
     const actions = useMemo(() => {
         const actionsArray = []
         if (apps?.length > MIN_APPS_NUM) {
@@ -18,6 +29,7 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
                 title: i18n.t('Browse apps'),
                 icon: <IconApps16 color={colors.grey700} />,
                 dataTest: 'headerbar-browse-apps',
+                action: () => switchViewAction('apps'),
             })
         }
         if (commands?.length > 0) {
@@ -26,6 +38,7 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
                 title: i18n.t('Browse commands'),
                 icon: <IconTerminalWindow16 color={colors.grey700} />,
                 dataTest: 'headerbar-browse-commands',
+                action: () => switchViewAction('commands'),
             })
         }
         if (shortcuts?.length > 0) {
@@ -34,6 +47,7 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
                 title: i18n.t('Browse shortcuts'),
                 icon: <IconRedo16 color={colors.grey700} />,
                 dataTest: 'headerbar-browse-shortcuts',
+                action: () => switchViewAction('shortcuts'),
             })
         }
         // default logout action
@@ -42,6 +56,8 @@ export const useAvailableActions = ({ apps, shortcuts, commands }) => {
             title: i18n.t('Logout'),
             icon: <IconLogOut16 color={colors.grey700} />,
             dataTest: 'headerbar-logout',
+            action: logoutAction,
+            href: logoutURL,
         })
         return actionsArray
     }, [apps, shortcuts, commands])

--- a/components/header-bar/src/command-palette/sections/list.js
+++ b/components/header-bar/src/command-palette/sections/list.js
@@ -9,20 +9,32 @@ function List({ filteredItems, type }) {
         <div data-test="headerbar-list">
             {filteredItems.map(
                 (
-                    { displayName, name, defaultAction, icon, description },
+                    {
+                        displayName,
+                        name,
+                        defaultAction,
+                        icon,
+                        description,
+                        url,
+                    },
                     idx
-                ) => (
-                    <ListItem
-                        type={type}
-                        key={`app-${name}-${idx}`}
-                        title={displayName || name}
-                        path={defaultAction}
-                        image={icon}
-                        description={description}
-                        highlighted={highlightedIndex === idx}
-                        handleMouseEnter={() => setHighlightedIndex(idx)}
-                    />
-                )
+                ) => {
+                    const isImage = typeof icon === 'string'
+                    const isIcon = React.isValidElement(icon)
+                    return (
+                        <ListItem
+                            type={type}
+                            key={`app-${name}-${idx}`}
+                            title={displayName || name}
+                            path={defaultAction || url}
+                            image={isImage ? icon : undefined}
+                            icon={isIcon ? icon : undefined}
+                            description={description}
+                            highlighted={highlightedIndex === idx}
+                            handleMouseEnter={() => setHighlightedIndex(idx)}
+                        />
+                    )
+                }
             )}
         </div>
     )

--- a/components/header-bar/src/command-palette/views/home-view.js
+++ b/components/header-bar/src/command-palette/views/home-view.js
@@ -1,8 +1,6 @@
-import { clearSensitiveCaches, useConfig } from '@dhis2/app-runtime'
 import { spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { joinPath } from '../../join-path.js'
 import i18n from '../../locales/index.js'
 import { useCommandPaletteContext } from '../context/command-palette-context.js'
 import AppItem from '../sections/app-item.js'
@@ -11,10 +9,8 @@ import ListItem from '../sections/list-item.js'
 import ListView from './list-view.js'
 
 function HomeView({ apps, commands, shortcuts, actions }) {
-    const { baseUrl } = useConfig()
     const {
         filter,
-        setCurrentView,
         highlightedIndex,
         setHighlightedIndex,
         activeSection,
@@ -79,41 +75,18 @@ function HomeView({ apps, commands, shortcuts, actions }) {
                         data-test="headerbar-actions-menu"
                     >
                         {actions.map(
-                            ({ dataTest, icon, title, type }, index) => {
-                                const logoutActionHandler = async () => {
-                                    await clearSensitiveCaches()
-                                    window.location.assign(
-                                        joinPath(
-                                            baseUrl,
-                                            'dhis-web-commons-security/logout.action'
-                                        )
-                                    )
-                                }
-
-                                const viewActionHandler = () => {
-                                    setCurrentView(type)
-                                    setHighlightedIndex(0)
-                                }
-
+                            (
+                                { dataTest, icon, title, type, href, action },
+                                index
+                            ) => {
                                 return (
                                     <ListItem
                                         key={`action-${type}-${index}`}
                                         title={title}
                                         icon={icon}
                                         dataTest={dataTest}
-                                        href={
-                                            type === 'logout'
-                                                ? joinPath(
-                                                      baseUrl,
-                                                      'dhis-web-commons-security/logout.action'
-                                                  )
-                                                : undefined
-                                        }
-                                        onClickHandler={
-                                            type === 'logout'
-                                                ? logoutActionHandler
-                                                : viewActionHandler
-                                        }
+                                        href={href}
+                                        onClickHandler={action}
                                         highlighted={
                                             activeSection === 'actions' &&
                                             highlightedIndex === index

--- a/components/header-bar/src/header-bar.js
+++ b/components/header-bar/src/header-bar.js
@@ -3,6 +3,7 @@ import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import CommandPalette from './command-palette/command-palette.js'
+import useCommands from './command-palette/commands/index.js'
 import { CommandPaletteContextProvider } from './command-palette/context/command-palette-context.js'
 import { HeaderBarContextProvider } from './header-bar-context.js'
 import { joinPath } from './join-path.js'
@@ -57,7 +58,7 @@ export const HeaderBar = ({
     }, [data, baseUrl])
 
     // fetch commands
-    const commands = []
+    const commands = useCommands()
 
     // fetch shortcuts
     const shortcuts = []


### PR DESCRIPTION
Implements [LIBS-735](https://dhis2.atlassian.net/browse/LIBS-735)

---

### Description

- This PR is an attempt to start the work on adding commands to the command palette, which means users can search for them too. 

The current implementation:
- adds a hook for the `logout` command functionality. 
- retrieves all commands created through a `useCommands` hook, which are then passed to the `headerbar` component making them available and searchable. (In this case, only the `logout` command has been added)

(**_TBD_**: whether commands are fetched from the backend or defined in the UI here)

This PR also handles:

- updating the action handlers in the `useActions` hook to have an action attribute with its associated action handler, for example, for `Browse Apps`, its action is a function to switch views to the `all apps list view`. 
- passing the actions array to the `useNavigation` hook to simplify the `Enter` key logic. 
- refactoring the `Enter` key down logic by utilising the app's `defaultAction(url)` attribute to open it in a new window, and the commands/actions `action` attribute to trigger its attached handler. 
- differentiating between an icon and image

**Conclusion**:  Users can search for the logout command across the command palette. 

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

**Logout Search Results**
<img width="1675" alt="logout results" src="https://github.com/user-attachments/assets/941d0c46-887a-4af0-b7e1-f5056450cdb4" />

**All Commands View**
<img width="1672" alt="browse cmds" src="https://github.com/user-attachments/assets/8942e9e5-cb43-4f0f-9778-09e64340b364" />
