### PR TITLE
feat: add dataStore to SharingDialog types

### DIFF
--- a/components/sharing-dialog/src/constants.js
+++ b/components/sharing-dialog/src/constants.js
@@ -36,6 +36,7 @@ export const DIALOG_TYPES = {
     DATA_ELEMENT_GROUP: 'dataElementGroup',
     DATA_ELEMENT_GROUP_SET: 'dataElementGroupSet',
     DATA_SET: 'dataSet',
+    DATASTORE: 'dataStore',
     DOCUMENT: 'document',
     EVENT_CHART: 'eventChart',
     EVENT_FILTER: 'eventFilter',


### PR DESCRIPTION
Implements [DHIS2-19007](https://dhis2.atlassian.net/browse/DHIS2-19007)

---

### Description

This PR adds the `dataStore` resource to the list of accepted types for the Sharing Dialog component. This is to support the [sharing feature](https://github.com/dhis2/datastore-app/pull/145) in the new DataStore app. 

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

----


[DHIS2-19007]: https://dhis2.atlassian.net/browse/DHIS2-19007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ