### PR TITLE
fix: calendar select styles

### DIFF
--- a/components/calendar/src/calendar/calendar-table.js
+++ b/components/calendar/src/calendar/calendar-table.js
@@ -35,7 +35,7 @@ export const CalendarTable = ({
                 border: none;
                 border-collapse: collapse;
                 width: 100%;
-                margin-block: ${spacers.dp4};
+                margin-block: 0 ${spacers.dp4};
             }
             .calendar-table tr,
             .calendar-table td {

--- a/components/calendar/src/calendar/navigation-container.js
+++ b/components/calendar/src/calendar/navigation-container.js
@@ -5,7 +5,7 @@ import React, { useMemo } from 'react'
 import i18n from '../locales/index.js'
 
 const wrapperBorderColor = colors.grey300
-const headerBackground = colors.grey050
+const headerBackground = colors.grey100
 
 export const NavigationContainer = ({
     languageDirection,
@@ -91,6 +91,18 @@ export const NavigationContainer = ({
                                 </option>
                             ))}
                         </select>
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M10.1465 6.85363L10.8536 6.14652L8.00004 3.29297L5.14648 6.14652L5.85359 6.85363L8.00004 4.70718L10.1465 6.85363ZM5.85367 9.1466L5.14656 9.8537L8.00011 12.7073L10.8537 9.8537L10.1466 9.1466L8.00011 11.293L5.85367 9.1466Z"
+                                fill={colors.grey700}
+                            />
+                        </svg>
                     </div>
                     <div className="next">
                         <button
@@ -128,6 +140,18 @@ export const NavigationContainer = ({
                                 </option>
                             ))}
                         </select>
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M10.1465 6.85363L10.8536 6.14652L8.00004 3.29297L5.14648 6.14652L5.85359 6.85363L8.00004 4.70718L10.1465 6.85363ZM5.85367 9.1466L5.14656 9.8537L8.00011 12.7073L10.8537 9.8537L10.1466 9.1466L8.00011 11.293L5.85367 9.1466Z"
+                                fill={colors.grey700}
+                            />
+                        </svg>
                     </div>
                     <div className="next">
                         <button
@@ -145,17 +169,30 @@ export const NavigationContainer = ({
                 .navigation-container {
                     display: flex;
                     justify-content: space-between;
+                    gap: ${spacers.dp4};
                     padding: ${spacers.dp4};
                     border-bottom: 1px solid ${wrapperBorderColor};
                     background-color: ${headerBackground};
-                    font-size: 1.08em;
+                    font-size: 1em;
+                    width: 100%;
                 }
                 .month,
                 .year {
                     display: flex;
                     align-items: center;
                     justify-content: space-between;
-                    width: 50%;
+                    border: 1px solid ${colors.grey300};
+                    border-radius: 3px;
+                    background: ${colors.white};
+                }
+                .month {
+                    flex-grow: 1;
+                }
+                .prev {
+                    border-inline-end: 1px solid ${colors.grey300};
+                }
+                .next {
+                    border-inline-start: 1px solid ${colors.grey300};
                 }
                 .prev,
                 .next,
@@ -167,22 +204,32 @@ export const NavigationContainer = ({
                 }
                 .prev,
                 .next {
-                    width: 24px;
+                    width: 20px;
                     flex-shrink: 0;
                 }
                 .monthList,
                 .yearList {
                     flex: 0 1 auto;
                     overflow: hidden;
+                    position: relative;
+                }
+                .monthList {
+                    flex-grow: 1;
+                    width: 100%;
+                }
+                .monthList svg,
+                .yearList svg {
+                    position: absolute;
+                    inset-inline-end: 0px;
+                    pointer-events: none;
                 }
                 button {
                     background: none;
                     border: 0;
-                    padding: ${spacers.dp4};
+                    padding: ${spacers.dp4} 2px;
                     height: 24px;
-                    width: 24px;
-                    color: ${colors.grey600};
-                    border-radius: 3px;
+                    width: 20px;
+                    color: ${colors.grey700};
                     display: flex;
                     align-items: center;
                     justify-content: center;
@@ -192,16 +239,33 @@ export const NavigationContainer = ({
                     color: ${colors.grey900};
                     cursor: pointer;
                 }
-                button:active {
-                    background-color: ${colors.grey300};
-                }
                 .month-select,
                 .year-select {
-                    padding: ${spacers.dp4} ${spacers.dp8};
+                    padding-inline-start: 4px;
+                    padding-inline-end: 16px;
+                    height: 24px;
                     white-space: nowrap;
                     overflow: hidden;
-                    text-align: center;
+                    text-align: start;
+                    width: 100%;
                     max-width: 100%;
+                    border-radius: 0px;
+                    border: 0;
+                    color: ${colors.grey800};
+                    background: none;
+                    appearance: none;
+                }
+                .month-select:hover,
+                .year-select:hover {
+                    background: ${colors.grey200};
+                    cursor: pointer;
+                }
+                .month-select:focus,
+                .month-select-active,
+                .year-select:focus,
+                .year-select-active {
+                    background: ${colors.grey200};
+                    outline-color: ${colors.grey700};
                 }
             `}</style>
         </>


### PR DESCRIPTION
### Description

This PR adjusts the styling of the `select` components used for month and year dropdown. Custom styles are applied to ensure cross-platform consistency.

### Screenshots

![image](https://github.com/user-attachments/assets/85abf173-5516-4a0b-8c6a-c67f78e24649)

![image](https://github.com/user-attachments/assets/cfe50cb1-187d-49d3-9368-793a0e6e11f3)

![image](https://github.com/user-attachments/assets/30d54060-fd35-4334-9512-c31f47ba9603)

