### PR TITLE
fix(select): adjust spacing, padding, clear icon

### DIFF
--- a/components/select/src/select/input-clear-button.js
+++ b/components/select/src/select/input-clear-button.js
@@ -28,12 +28,16 @@ const InputClearButton = ({ onClear, clearText, className, dataTest }) => (
                     background: none;
                     border: none;
                     display: flex;
+                    flex-shrink: 0;
                     align-items: center;
                     justify-content: center;
                     cursor: pointer;
                     height: 24px;
                     width: 24px;
                     border-radius: 3px;
+                }
+                button svg {
+                    flex-shrink: 0;
                 }
                 button svg path {
                     fill: ${colors.grey500};

--- a/components/select/src/select/input-wrapper.js
+++ b/components/select/src/select/input-wrapper.js
@@ -48,7 +48,7 @@ const InputWrapper = ({
                     display: flex;
                     min-height: 40px;
                     padding-block: 6px;
-                    padding-inline: 12px;
+                    padding-inline: 12px 6px;
                     box-shadow: inset 0 0 1px 0 rgba(48, 54, 60, 0.1);
                 }
 
@@ -80,7 +80,7 @@ const InputWrapper = ({
 
                 .root.dense {
                     padding-block: 2px;
-                    padding-inline: 8px;
+                    padding-inline: 8px 4px;
                     min-height: 32px;
                 }
 
@@ -90,7 +90,7 @@ const InputWrapper = ({
 
                 .root-right {
                     margin-block-start: 4px;
-                    margin-inline-start: 8px;
+                    margin-inline-start: 2px;
                 }
             `}</style>
         </div>


### PR DESCRIPTION
This PR makes minor changes to the `select` component:
- Adjusts padding and spacing of the end-aligned components (down-arrow and clear action)
- Prevents clear button icon shrinking

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Before:

![image](https://github.com/user-attachments/assets/44efec64-86f1-4c9c-bde1-edf3f24bfff0)

After:

![image](https://github.com/user-attachments/assets/0d39e18d-97a0-4d48-b895-0465994c7df4)

