### PR TITLE
fix(button): adjust dropdown arrow spacing for small buttons

### DIFF
--- a/components/button/src/dropdown-button/dropdown-button.js
+++ b/components/button/src/dropdown-button/dropdown-button.js
@@ -4,7 +4,6 @@ import { Layer } from '@dhis2-ui/layer'
 import { Popper } from '@dhis2-ui/popper'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { resolve } from 'styled-jsx/css'
 import { Button } from '../button/index.js'
 
 function ArrowDown({ className }) {
@@ -57,10 +56,6 @@ function ArrowUp({ className }) {
 ArrowUp.propTypes = {
     className: PropTypes.string,
 }
-
-const arrow = resolve`
-    margin-inline-start: ${spacers.dp12};
-`
 
 class DropdownButton extends Component {
     state = {
@@ -156,7 +151,9 @@ class DropdownButton extends Component {
                     data-test="dhis2-uicore-dropdownbutton-toggle"
                 >
                     {children}
-                    <ArrowIconComponent className={arrow.className} />
+                    <ArrowIconComponent
+                        className={`arrow ${small && 'arrow-small'}`}
+                    />
                 </Button>
 
                 {open && (
@@ -171,8 +168,15 @@ class DropdownButton extends Component {
                     </Layer>
                 )}
 
-                {arrow.styles}
                 <style jsx>{`
+                    .arrow {
+                        margin-inline-start: ${spacers.dp8};
+                    }
+
+                    .arrow-small {
+                        margin-inline-start: ${spacers.dp4};
+                    }
+
                     div {
                         display: inline-flex;
                         position: relative;


### PR DESCRIPTION
Fixes [UX-188](https://dhis2.atlassian.net/browse/UX-188)

---

### Description

This PR adjusts the spacing of the `DropdownButton` arrow icon.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Before:

![image](https://github.com/user-attachments/assets/293ab101-fb65-4a5a-bd4a-67b458994784)

![image](https://github.com/user-attachments/assets/fb2efdb2-bfac-4afb-a1e7-c0ce5e10cb45)


After:

![image](https://github.com/user-attachments/assets/8e977198-0d2e-412d-8e6f-41e68d533ff0)

![image](https://github.com/user-attachments/assets/2c76256b-dfa8-4883-af64-71cf67ddb1b9)




[UX-188]: https://dhis2.atlassian.net/browse/UX-188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ