### PR TITLE
ci: update yarn cache method

### DIFF
--- a/.github/workflows/dhis2-preview-pr.yml
+++ b/.github/workflows/dhis2-preview-pr.yml
@@ -22,11 +22,11 @@ jobs:
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - run: yarn build

--- a/.github/workflows/dhis2-verify-commits.yml
+++ b/.github/workflows/dhis2-verify-commits.yml
@@ -13,7 +13,7 @@ jobs:
               with:
                   node-version: 20.x
                   cache: 'yarn'
-                  
+
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -31,7 +31,7 @@ jobs:
               with:
                   node-version: 20.x
                   cache: 'yarn'
-                  
+
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")

--- a/.github/workflows/dhis2-verify-commits.yml
+++ b/.github/workflows/dhis2-verify-commits.yml
@@ -9,10 +9,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
                   node-version: 20.x
-            - uses: c-hive/gha-yarn-cache@v1
+                  cache: 'yarn'
+                  
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -26,10 +27,11 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
                   node-version: 20.x
-            - uses: c-hive/gha-yarn-cache@v1
+                  cache: 'yarn'
+                  
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")

--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -37,8 +37,8 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: |
                   yarn install --frozen-lockfile
                   yarn setup
@@ -62,6 +62,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
             - uses: actions/download-artifact@v4
               with:
@@ -69,7 +70,6 @@ jobs:
 
             - run: ./scripts/extract-artifact.sh
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Lint
@@ -83,6 +83,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
             - uses: actions/download-artifact@v4
               with:
@@ -90,7 +91,6 @@ jobs:
 
             - run: ./scripts/extract-artifact.sh
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Test
@@ -174,6 +174,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 20.x
+                  cache: 'yarn'
 
             - uses: actions/download-artifact@v4
               with:
@@ -182,7 +183,6 @@ jobs:
             - run: ./scripts/extract-artifact.sh
 
             # ensure that d2-app-scripts is available
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - uses: dhis2/action-semantic-release@node20


### PR DESCRIPTION
Replaces the [deprecated gha-yarn-cache](https://github.com/c-hive/gha-yarn-cache?tab=readme-ov-file#deprecated):

> This functionality is now part of [actions/setup-node](https://github.com/actions/setup-node):
```
- name: Setup Node.js
  uses: actions/setup-node@v3
  with:
    node-version: '16'
    cache: 'yarn'
```