### PR TITLE
refactor: remove dynamic syles from transfer

### DIFF
--- a/components/transfer/src/common/index.js
+++ b/components/transfer/src/common/index.js
@@ -1,5 +1,4 @@
 export { ADD_MODE, RANGE_MODE, REPLACE_MODE } from './modes.js'
-export { backgroundColor, borderColor, borderRadius } from './styles.js'
 export { findOptionIndex } from './find-option-index.js'
 export { getModeByModifierKey } from './get-mode-by-modifier-key.js'
 export { isOption } from './is-option.js'

--- a/components/transfer/src/common/styles.js
+++ b/components/transfer/src/common/styles.js
@@ -1,5 +1,0 @@
-import { colors } from '@dhis2/ui-constants'
-
-export const backgroundColor = colors.white
-export const borderColor = colors.grey400
-export const borderRadius = '3px'

--- a/components/transfer/src/left-footer.js
+++ b/components/transfer/src/left-footer.js
@@ -1,7 +1,6 @@
-import { spacers } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { borderColor } from './common/index.js'
 
 export const LeftFooter = ({ children, dataTest }) => (
     <div data-test={dataTest}>
@@ -10,7 +9,7 @@ export const LeftFooter = ({ children, dataTest }) => (
         <style jsx>{`
             div {
                 flex-grow: 0;
-                border-top: 1px solid ${borderColor};
+                border-top: 1px solid ${colors.grey400};
                 padding: 0 ${spacers.dp8};
             }
         `}</style>

--- a/components/transfer/src/left-header.js
+++ b/components/transfer/src/left-header.js
@@ -1,7 +1,6 @@
-import { spacers } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { borderColor } from './common/index.js'
 
 export const LeftHeader = ({ children, dataTest }) => (
     <div data-test={dataTest}>
@@ -9,7 +8,7 @@ export const LeftHeader = ({ children, dataTest }) => (
 
         <style jsx>{`
             div {
-                border-bottom: 1px solid ${borderColor};
+                border-bottom: 1px solid ${colors.grey400};
                 flex-grow: 0;
                 padding: 0 ${spacers.dp8};
             }

--- a/components/transfer/src/left-side.js
+++ b/components/transfer/src/left-side.js
@@ -1,6 +1,6 @@
+import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { backgroundColor, borderColor, borderRadius } from './common/index.js'
 
 export const LeftSide = ({ children, dataTest, width }) => (
     <div data-test={dataTest}>
@@ -16,9 +16,9 @@ export const LeftSide = ({ children, dataTest, width }) => (
             div {
                 display: flex;
                 flex-direction: column;
-                background-color: ${backgroundColor};
-                border-radius: ${borderRadius};
-                border: 1px solid ${borderColor};
+                background-color: ${colors.white};
+                border-radius: 3px;
+                border: 1px solid ${colors.grey400};
                 min-height: 240px;
                 max-width: 100%;
                 width: ${width};

--- a/components/transfer/src/right-footer.js
+++ b/components/transfer/src/right-footer.js
@@ -1,7 +1,6 @@
-import { spacers } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { borderColor } from './common/index.js'
 
 export const RightFooter = ({ children, dataTest }) => (
     <div data-test={dataTest}>
@@ -10,7 +9,7 @@ export const RightFooter = ({ children, dataTest }) => (
         <style jsx>{`
             div {
                 flex-grow: 0;
-                border-top: 1px solid ${borderColor};
+                border-top: 1px solid ${colors.grey400};
                 padding: 0 ${spacers.dp8};
             }
         `}</style>

--- a/components/transfer/src/right-header.js
+++ b/components/transfer/src/right-header.js
@@ -1,7 +1,6 @@
-import { spacers } from '@dhis2/ui-constants'
+import { colors, spacers } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { borderColor } from './common/index.js'
 
 export const RightHeader = ({ children, dataTest }) => (
     <div data-test={dataTest}>
@@ -9,7 +8,7 @@ export const RightHeader = ({ children, dataTest }) => (
 
         <style jsx>{`
             div {
-                border-bottom: 1px solid ${borderColor};
+                border-bottom: 1px solid ${colors.grey400};
                 flex-grow: 0;
                 padding: 0 ${spacers.dp8};
             }

--- a/components/transfer/src/right-side.js
+++ b/components/transfer/src/right-side.js
@@ -1,6 +1,6 @@
+import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { backgroundColor, borderColor, borderRadius } from './common/index.js'
 
 export const RightSide = ({ children, dataTest, width }) => (
     <div data-test={dataTest}>
@@ -14,9 +14,9 @@ export const RightSide = ({ children, dataTest, width }) => (
         }
         <style jsx>{`
             div {
-                background-color: ${backgroundColor};
-                border: 1px solid ${borderColor};
-                border-radius: ${borderRadius};
+                background-color: ${colors.white};
+                border: 1px solid ${colors.grey400};
+                border-radius: 3px;
                 display: flex;
                 flex-direction: column;
                 max-width: 100%;

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -142,7 +142,6 @@ const [components, collections, icons, constants] = uiPackages({
 
 const ignore = [
     '**/index.js',
-    '**/*.styles.js',
     '**/*.test.js',
     '**/*.stories.*',
     '**/features',


### PR DESCRIPTION
This refactor removes dynamic styles usage from the transfer component. The reason is that these dynamic styles break the rendering of the component in tests if project using it. I think this solving problem, and hence not having to mock teh component, is more beneficial that a the repetitions. 

This refactor removes the use of styled-jsx dynamic styles from the Transfer component. The motivation behind this change is to prevent rendering issues that occur in projects that use this component during testing —  dynamic style variables were not properly resolved.

While this results in some repetition in the style definitions, I think avoiding the need to mock the component in tests outweighs the downside.

