### PR TITLE
fix: bump multi-calendar-dates

### DIFF
--- a/components/calendar/package.json
+++ b/components/calendar/package.json
@@ -38,7 +38,7 @@
         "@dhis2-ui/input": "10.7.2",
         "@dhis2-ui/layer": "10.7.2",
         "@dhis2-ui/popper": "10.7.2",
-        "@dhis2/multi-calendar-dates": "2.1.0",
+        "@dhis2/multi-calendar-dates": "2.1.2",
         "@dhis2/prop-types": "^3.1.2",
         "@dhis2/ui-constants": "10.7.2",
         "@dhis2/ui-icons": "10.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2729,10 +2729,10 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/multi-calendar-dates@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-2.1.0.tgz#81ac31304294195c9f18d1269adbcc69ad63de01"
-  integrity sha512-1CKQJTuN4e1+at1bRQL8991BhwxTtn74x6JcM7/Tr43DGwjjUIlNLYCFxHhsEuAW7smLKBk03+ueyo16ur2egw==
+"@dhis2/multi-calendar-dates@2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-2.1.2.tgz#c3dd01e358c3dda4354c6722bb72e077b3ddd9b8"
+  integrity sha512-7/EuYZFi266QwyRpK+s79iEiwdOUVBwM+QjKwNUHN3zdYMDmQcWLTo5TujJFg1XnnQ8UhdiRqESq5rgoJkM2fQ==
   dependencies:
     "@dhis2/d2-i18n" "^1.1.3"
     "@js-temporal/polyfill" "0.4.3"


### PR DESCRIPTION
bumps to the latest version of multi-calendar-dates (mainly for the [fix](https://github.com/dhis2/multi-calendar-dates/commit/6f896c6296e23710f744d1a392540df70875bb4b#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R75) the declared peer dependency)