### PR TITLE
fix: ensure publishing docs

### DIFF
--- a/.github/workflows/dhis2-deploy-netlify.yml
+++ b/.github/workflows/dhis2-deploy-netlify.yml
@@ -13,8 +13,6 @@ on:
     push:
         branches:
             - master
-        paths:
-            - '_redirects' # only rebuild and deploy when redirects file changes
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}

--- a/.github/workflows/dhis2-verify-lib.yml
+++ b/.github/workflows/dhis2-verify-lib.yml
@@ -191,3 +191,15 @@ jobs:
                   publish-github: true
                   github-token: ${{ env.GH_TOKEN }}
                   npm-token: ${{ env.NPM_TOKEN }}
+
+    send-slack-message:
+        runs-on: ubuntu-latest
+        if: ${{ always() && github.ref == 'refs/heads/master' }}
+        needs: [build, lint, test, e2e, publish]
+        steps:
+            - uses: rtCamp/action-slack-notify@v2
+              env:
+                  SLACK_WEBHOOK: ${{ secrets.SLACK_BACKEND_WEBHOOK }}
+                  SLACK_CHANNEL: 'team-extensibility-notifications'
+                  SLACK_MESSAGE_ON_FAILURE: 'Master branch failed to build or publish the UI library.'
+                  SLACK_COLOR: ${{ job.status }}


### PR DESCRIPTION
This PR:
- ensures that the updated docs are published
- sends a slack notification when master branch publishes (or fails to publish) a new version