### PR TITLE
fix: do not block event propagation unless needed

### DIFF
--- a/components/select/src/select/select.js
+++ b/components/select/src/select/select.js
@@ -128,8 +128,6 @@ export class Select extends Component {
             return
         }
 
-        e.stopPropagation()
-
         const { open } = this.state
         const { keyCode } = e
         const shouldOpen =
@@ -138,6 +136,13 @@ export class Select extends Component {
                 keyCode === UP_KEY ||
                 keyCode === DOWN_KEY)
         const shouldClose = open && keyCode === ESCAPE_KEY
+
+        /* Do not block event propagation when the Select is closed unless
+         * the key to open it is pressed, so that other components like
+         * the Modal can still respond to keypresses (i.e. ESC to close) */
+        if (open || shouldOpen) {
+            e.stopPropagation()
+        }
 
         if (shouldClose) {
             return this.handleClose()


### PR DESCRIPTION
We encountered a failing Cypress test after upgrading to React 18 in the Maps App. The failure was that the `Modal` was not being closed by the `ESC` keypress. The root cause turned out to be the `Select` which had focus during the test. Because the `keyDown` listener in the select was unconditionally blocking event propagation, the keypress even never reached the modal and this is why it remained in view instead of closing.

This fix addresses the issue, but I am not 100% confident that it does not introduce any unwanted side effect. Or if it is completely in line with best practices.

For what it's worth I share the basic reasoning behind it:
- When the `Select` is open is OK to capture all events, because we can assume the user is interacting with it.
- When it's closed we should not make that assumption and we should allow event propagation as normal
- The exception is when the `Select` is closed and being opened by keypress. This is a valid keyboard interaction with the Select so event propagation should be blocked.

While I am actually relatively confident that the behaviour I outline above is probably correct, I am not 100% sure about this change because it can actually cause subtle issues for consuming components that have attached an `onKeyDown` prop. If blocking event propagation is relevant for them, they will now find they have to do so in the callback, while before it was not required.

The `Select` itself is an internal component, but the `SingleSelect` and `MultiSelect` expose an `onKeyDown` prop which they simply forward to the `Select`, so the problem above is still relevant.

To avoid introducing this problem, which I guess it could technically be classified as a breaking change (?), we could change the condition slightly to `if (open || shouldOpen || onKeyDown)`. However, this now introduces very unpredictable behaviour. Suppose you have a `SingleSelect` in a `Modal` and closing the `Modal` by hitting `ESC` works fine. And now you add a `onKeyDown` to the `SingleSelect` and all of a sudden the "close by ESC" functionality breaks. Not only is this extremely confusing, it's also quite tricky to solve. You will probably end up having to programatically close the modal from the `onKeyDown` handler you attached to the select 🤯 .

Personally I think that maybe we should just say: the previous behaviour was wrong, this is a bug-fix and tough luck for cases that may have been relying on the buggy behaviour. Just start propagation in your `onKeyDown` handler.