### PR TITLE
fix: [LIBS-718] calendar input onBlur in Safari

### DIFF
--- a/components/calendar/src/calendar-input/calendar-input.js
+++ b/components/calendar/src/calendar-input/calendar-input.js
@@ -42,6 +42,7 @@ export const CalendarInput = ({
 } = {}) => {
     const ref = useRef()
     const calendarRef = useRef()
+    const popperRef = useRef()
     const [open, setOpen] = useState(false)
     const [partialDate, setPartialDate] = useState(date)
 
@@ -101,7 +102,11 @@ export const CalendarInput = ({
     }
 
     const handleBlur = (_, e) => {
-        if (e.relatedTarget && calendarRef.current?.contains(e.relatedTarget)) {
+        if (
+            e.relatedTarget &&
+            (calendarRef.current?.contains(e.relatedTarget) ||
+                popperRef.current === e.relatedTarget)
+        ) {
             return
         }
 
@@ -182,6 +187,9 @@ export const CalendarInput = ({
                         reference={ref}
                         placement="bottom-start"
                         modifiers={[offsetModifier]}
+                        onFirstUpdate={(component) => {
+                            popperRef.current = component?.elements?.popper
+                        }}
                     >
                         <CalendarContainer
                             {...calendarProps}

--- a/components/calendar/src/calendar/calendar-container.js
+++ b/components/calendar/src/calendar/calendar-container.js
@@ -1,4 +1,4 @@
-import { elevations } from '@dhis2/ui-constants'
+import { colors, elevations } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import { CalendarTable, CalendarTableProps } from './calendar-table.js'
@@ -7,7 +7,7 @@ import {
     NavigationContainerProps,
 } from './navigation-container.js'
 
-const backgroundColor = 'none'
+const backgroundColor = colors.white
 
 export const CalendarContainer = React.memo(function CalendarContainer({
     date,


### PR DESCRIPTION
Implements [LIBS-718](https://dhis2.atlassian.net/browse/LIBS-718)

---

### Description

In Safari, the [relatedTarget](https://github.com/dhis2/ui/blob/master/components/calendar/src/calendar-input/calendar-input.js#L104) of the blur event resolves to the popper element, whereas in other browsers it points to the clicked element within the calendar. As a result, this [if](https://github.com/dhis2/ui/blob/master/components/calendar/src/calendar-input/calendar-input.js#L104) resolves to false in Safari, causing the calendar to close before the onClick event can be triggered. 

The proposed solution involves storing a reference to the popper in the calendar-input and comparing it with the `relatedTarget`. Since I’m not very familiar with the UI library, any feedback or suggestions for a better approach would be greatly appreciated.

I also took advantages of this ticket to set the background to `white` to fixed a minor CSS issue introduced by https://github.com/dhis2/ui/commit/14595510ad8c5130029c81b8817db6192f4eb45b.


---

### Known issues

-   [ ] _issue_

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Issue with the calendar background being set to none 
<img width="917" alt="background" src="https://github.com/user-attachments/assets/9c92650f-6180-4662-9fbc-5845b4cf1ed0" />



[LIBS-718]: https://dhis2.atlassian.net/browse/LIBS-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ