### PR TITLE
fix: small fix in transfer proptype

### DIFF
--- a/components/transfer/src/transfer.js
+++ b/components/transfer/src/transfer.js
@@ -411,7 +411,7 @@ Transfer.propTypes = {
     leftHeader: PropTypes.node,
     loading: PropTypes.bool,
     loadingPicked: PropTypes.bool,
-    maxSelections: PropTypes.oneOf([1, Infinity]),
+    maxSelections: PropTypes.number,
     optionsWidth: PropTypes.string,
     removeAllText: PropTypes.string,
     removeIndividualText: PropTypes.string,


### PR DESCRIPTION

The component accepts every number for maxSelections, so changing the prototype accordingly to avoid false warnings
