### PR TITLE
fix: add preventUsersFromRemovingMetadataWriteAccess to type def

### DIFF
--- a/components/sharing-dialog/types/index.d.ts
+++ b/components/sharing-dialog/types/index.d.ts
@@ -95,6 +95,7 @@ export interface SharingDialogProps {
     initialSharingSettings?: SharingDialogInitialSharingSettings
     dataSharing?: boolean
     cascadeDashboardSharing?: boolean
+    preventUsersFromRemovingMetadataWriteAccess?: boolean
     onClose?: ModalOnCloseEventHandler
     onError?: (error: any) => void
     onSave?: () => void


### PR DESCRIPTION
This is a fix for recent PR (https://github.com/dhis2/ui/pull/1694) and adds the newly introduced `preventUsersFromRemovingMetadataWriteAccess` prop for the SharingDialog into the exported type definition