### PR TITLE
fix: add overflow hidden

### DIFF
--- a/components/header-bar/src/profile.js
+++ b/components/header-bar/src/profile.js
@@ -65,6 +65,7 @@ const Profile = ({ name, email, avatarId, helpUrl }) => {
                 .headerbar-profile {
                     position: relative;
                     height: 100%;
+                    overflow: hidden;
                 }
 
                 .headerbar-profile-btn {


### PR DESCRIPTION
Implements [DHIS2-19621](https://dhis2.atlassian.net/browse/DHIS2-19621)

---

### Description
When uploading a custom avatar with height greater than width as profile picture. After in hover state of profile picture, the background is set to blue and now appears to overflow the header bar area. 
---

### Known issues

-   [ ] _issue_

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

