### PR TITLE
fix(icons): add missing exports for icon types

### DIFF
--- a/icons/types/index.d.ts
+++ b/icons/types/index.d.ts
@@ -130,6 +130,8 @@ export const IconLegend16: React.FC<IconProps>
 export const IconLegend24: React.FC<IconProps>
 export const IconLink16: React.FC<IconProps>
 export const IconLink24: React.FC<IconProps>
+export const IconLinkOff16: React.FC<IconProps>
+export const IconLinkOff24: React.FC<IconProps>
 export const IconList16: React.FC<IconProps>
 export const IconList24: React.FC<IconProps>
 export const IconLocation16: React.FC<IconProps>
@@ -244,8 +246,14 @@ export const IconVisualizationLine16: React.FC<IconProps>
 export const IconVisualizationLine24: React.FC<IconProps>
 export const IconVisualizationLineMulti16: React.FC<IconProps>
 export const IconVisualizationLineMulti24: React.FC<IconProps>
+export const IconVisualizationLinelist16: React.FC<IconProps>
+export const IconVisualizationLinelist24: React.FC<IconProps>
+export const IconVisualizationOutlierTable16: React.FC<IconProps>
+export const IconVisualizationOutlierTable24: React.FC<IconProps>
 export const IconVisualizationPie16: React.FC<IconProps>
 export const IconVisualizationPie24: React.FC<IconProps>
+export const IconVisualizationPivotTable16: React.FC<IconProps>
+export const IconVisualizationPivotTable24: React.FC<IconProps>
 export const IconVisualizationRadar16: React.FC<IconProps>
 export const IconVisualizationRadar24: React.FC<IconProps>
 export const IconVisualizationScatter16: React.FC<IconProps>


### PR DESCRIPTION
Implements [JIRA_ISSUE_ID](https://dhis2.atlassian.net/browse/JIRA_ISSUE_ID)

---

### Description

This PR adds missing exports for a bunch of icons which prevented them from being used in typescript projects.

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

Error about missing export shown in the editor:
<img width="1015" height="103" alt="Screenshot 2025-07-29 at 16 26 31" src="https://github.com/user-attachments/assets/50946b7e-0f2b-435e-a022-829a99700f03" />


