### PR TITLE
feat: add program attribute icon size 16

### DIFF
--- a/icons/API.md
+++ b/icons/API.md
@@ -1338,6 +1338,26 @@ import { IconDimensionOrgUnitGroupset16 } from '@dhis2/ui'
 |dataTest|string||||
 |ariaLabel|string||||
 
+### SvgDimensionProgramAttribute16
+
+#### Usage
+
+To use `IconDimensionProgramAttribute16`, you can import the component from the `@dhis2/ui` library  
+
+
+```js
+import { IconDimensionProgramAttribute16 } from '@dhis2/ui'
+```
+
+
+#### Props
+
+|Name|Type|Default|Required|Description|
+|---|---|---|---|---|
+|color|string||||
+|dataTest|string||||
+|ariaLabel|string||||
+
 ### SvgDimensionProgramIndicator16
 
 #### Usage

--- a/icons/src/svg/dimension-program-attribute-16.svg
+++ b/icons/src/svg/dimension-program-attribute-16.svg
@@ -1,0 +1,1 @@
+ <svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><path d="m15 3 v10h-7v-10z m-1 1 v2h-5v-2z m0 3 v2h-5v-2z m0 3 v2h-5v-2z m-7 -6 h-5v7h5v1h-6v-10h6z" fill="#010101" fill-rule="evenodd" /></svg>

--- a/icons/types/index.d.ts
+++ b/icons/types/index.d.ts
@@ -72,6 +72,7 @@ export const IconDimensionEventDataItem16: React.FC<IconProps>
 export const IconDimensionIndicator16: React.FC<IconProps>
 export const IconDimensionOrgUnit16: React.FC<IconProps>
 export const IconDimensionOrgUnitGroupset16: React.FC<IconProps>
+export const IconDimensionProgramAttribute16: React.FC<IconProps>
 export const IconDimensionProgramIndicator16: React.FC<IconProps>
 export const IconDimensionValidationRule16: React.FC<IconProps>
 export const IconDirectionNorth16: React.FC<IconProps>


### PR DESCRIPTION
Implements [JIRA_ISSUE_ID](https://dhis2.atlassian.net/browse/JIRA_ISSUE_ID)

---

### Description

Adding the programattribute icon size 16, which has been located in the Line-listing app. It should be co-located with the other dimension icons in the ui library.

---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

_supporting text_
