### PR TITLE
fix: adjust type definitions to align with prop-types

### DIFF
--- a/components/pagination/types/index.d.ts
+++ b/components/pagination/types/index.d.ts
@@ -14,7 +14,7 @@ export interface PaginationProps {
     isLastPage?: boolean
     nextPageText?: TranslateableProp
     pageCount?: number
-    pageLength?: boolean
+    pageLength?: number
     pageSelectText?: TranslateableProp
     pageSizeSelectText?: TranslateableProp
     pageSizes?: string[]

--- a/components/table/types/index.d.ts
+++ b/components/table/types/index.d.ts
@@ -319,7 +319,7 @@ export interface DataTableColumnHeaderProps {
     /**
      * Left or top required when fixed
      */
-    left?: boolean
+    left?: string
     /**
      * Can be used to match a column with a property name
      */
@@ -333,7 +333,7 @@ export interface DataTableColumnHeaderProps {
     /**
      * Left or top required when fixed
      */
-    top?: boolean
+    top?: string
     width?: string
     onFilterIconClick?: (
         payload: { name?: string; active: boolean },


### PR DESCRIPTION
I encountered some type mismatches between the prop-types and the type definitions. Quite likely this was to do with the usage of the `requiredIf` prop-type helper.

I've added a comment to each type-definition change with a reference to the prop-type it belongs to.