### PR TITLE
docs: install command in README (use 'yarn add' instead of 'yarn install) #1705 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 To install `@dhis2/ui` run:
 
 ```bash
-yarn install @dhis2/ui
+yarn add @dhis2/ui
 ```
 
 All components can be imported directly from `@dhis2/ui` like so:


### PR DESCRIPTION
Implements [#1705 ]

---

### Description

This pull request updates the installation instructions in the README.md file to use the correct Yarn command.
The old command yarn install @dhis2/ui has been replaced with yarn add @dhis2/ui, which is the proper method to add a new dependency with Yarn.
A command for npm users is also provided (npm install @dhis2/ui) to ensure clarity for all users.

---

### Known issues

-   [ ] No Known Issue

---

### Checklist

-   [ ] API docs are generated (Not applicable)
-   [ ] Tests were added (Not applicable; documentation change only)
-   [ ] Storybook demos were added (Not applicable; documentation change only)


---

### Screenshots

<img width="1645" height="390" alt="image" src="https://github.com/user-attachments/assets/02d5dc19-a3e1-42a4-a12c-e2d0dda52e0e" />

