### PR TITLE
feat(headerbar): fix locale handling

### DIFF
--- a/components/header-bar/src/header-bar.js
+++ b/components/header-bar/src/header-bar.js
@@ -55,11 +55,30 @@ export const HeaderBar = ({
         }))
     }, [data, baseUrl])
 
+    // sources
+    // 1. App Platform: /adapter/src/utils/localeUtils.js#L15
+    // 2. https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag
+    const parseLocale = (locale) => {
+        const [language, region, script] = locale.split('_')
+
+        let languageTag = language
+        if (script) {
+            languageTag += `-${script}`
+        }
+        if (region) {
+            languageTag += `-${region}`
+        }
+        return new Intl.Locale(languageTag)
+    }
+
     // See https://jira.dhis2.org/browse/LIBS-180
     if (!loading && !error) {
         // TODO: This will run every render which is probably wrong!
         // Also, setting the global locale shouldn't be done in the headerbar
-        const locale = data.user.settings.keyUiLocale || 'en'
+
+        // ensures the locale/variant is separated by hyphens before being passed to changeLanguage
+        const locale =
+            parseLocale(data.user.settings.keyUiLocale)?.baseName || 'en'
         i18n.setDefaultNamespace('default')
         i18n.changeLanguage(locale)
     }


### PR DESCRIPTION
Implements [LIBS-798](https://dhis2.atlassian.net/browse/LIBS-798)

---

### Description
The previous implementation does not parse the locales with variants well enough to trigger the relevant change in language in the UI. When we pass a `keyUILocale` that is a language variant, say `pt_BR` directly to `i18n.changeLanguage`, it will not be picked up and the UI defaults to `English`.

In this implementation, we parse locales using the same functionality in the [app platform's adapter](https://github.com/dhis2/app-platform/blob/8e2f83c3b70ea2a66a566e1bae3d8326724d0cf8/adapter/src/utils/localeUtils.js#L15). It reformats the locale to follow the [BCP 47 syntax](https://developer.mozilla.org/en-US/docs/Glossary/BCP_47_language_tag#bcp_47_syntax). For example, `pt_Br` becomes `pt-Br` which triggers the translation. 


---

### Checklist

-   [ ] API docs are generated
-   [ ] Tests were added
-   [ ] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots
**For 'pt_Br'**
<img width="400" height="452" alt="pt_Br" src="https://github.com/user-attachments/assets/a1ee2517-8080-4849-9142-7e4924728341" />



[LIBS-798]: https://dhis2.atlassian.net/browse/LIBS-798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ