### PR TITLE
fix(header-bar): allow bypassing i18n logic

### DIFF
--- a/collections/ui/API.md
+++ b/collections/ui/API.md
@@ -729,6 +729,7 @@ import { HeaderBar } from '@dhis2/ui'
 |---|---|---|---|---|
 |appName|string||||
 |className|string||||
+|skipI18n|boolean|||`skipI18n` skips initalising internationalisation in the UI component<br/>This is useful for app-platform apps, as the platform already sets i18n, so it can skip i18n (and avoid race conditions).<br/>For non-platform apps, they can continue relying on this logic running for backwards compatibility.|
 |updateAvailable|boolean||||
 |onApplyAvailableUpdate|function||||
 

--- a/components/header-bar/API.md
+++ b/components/header-bar/API.md
@@ -16,5 +16,6 @@ import { HeaderBar } from '@dhis2/ui'
 |---|---|---|---|---|
 |appName|string||||
 |className|string||||
+|skipI18n|boolean|||`skipI18n` skips initalising internationalisation in the UI component<br/>This is useful for app-platform apps, as the platform already sets i18n, so it can skip i18n (and avoid race conditions).<br/>For non-platform apps, they can continue relying on this logic running for backwards compatibility.|
 |updateAvailable|boolean||||
 |onApplyAvailableUpdate|function||||

--- a/components/header-bar/src/header-bar.prod.stories.js
+++ b/components/header-bar/src/header-bar.prod.stories.js
@@ -1,5 +1,5 @@
 import { CustomDataProvider } from '@dhis2/app-runtime'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
     createDecoratorProvider,
     mockOfflineInterface,
@@ -7,6 +7,7 @@ import {
 } from './__e2e__/stories/common.js'
 import { OnlineStatusMessageUpdate } from './__e2e__/stories/online-status-message.js'
 import { HeaderBar } from './header-bar.js'
+import i18n from './locales/index.js'
 
 const subtitle = 'The common navigation bar used in all DHIS2 apps'
 
@@ -196,6 +197,25 @@ export const NonEnglishUserLocale = () => (
     </CustomDataProvider>
 )
 NonEnglishUserLocale.storyName = 'Non-english user locale'
+
+export const NonEnglishUserLocaleIgnoringI18n = () => {
+    const [language, setLanguage] = useState()
+    useEffect(() => {
+        console.log('custom effect to set language from consumer')
+
+        i18n.setDefaultNamespace('default')
+        i18n.changeLanguage('es')
+        setLanguage('es')
+    }, [])
+
+    return language ? (
+        <CustomDataProvider data={customLocaleData}>
+            <HeaderBar appName="Exemple!" skipI18n />
+        </CustomDataProvider>
+    ) : null
+}
+NonEnglishUserLocaleIgnoringI18n.storyName =
+    'Custom locale initialisation (spanish) from the consumer'
 
 export const NoAuthorityForInterpretationsApp = () => (
     <CustomDataProvider data={customAuthoritiesData}>

--- a/components/header-bar/types/index.d.ts
+++ b/components/header-bar/types/index.d.ts
@@ -5,6 +5,7 @@ export interface HeaderBarProps {
     className?: string
     updateAvailable?: boolean
     onApplyAvailableUpdate?: () => void
+    skipI18n?: boolean
 }
 
 export const HeaderBar: React.FC<HeaderBarProps>


### PR DESCRIPTION
relates to https://dhis2.atlassian.net/browse/LIBS-798 and https://github.com/dhis2/app-platform/pull/942 

---

### Description

This makes it possible to bypass the default i18n initialisation logic that was part of the header-bar component, so it doesn't run twice in app-shell for example.

---

### Checklist

-   [x] API docs are generated
-   [ ] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

