### PR TITLE
feat(input): character count indicator

### DIFF
--- a/components/input/src/input-field/input-field.js
+++ b/components/input/src/input-field/input-field.js
@@ -41,6 +41,7 @@ class InputField extends React.Component {
             autoComplete,
             clearable,
             prefixIcon,
+            characterCountLimit,
             dataTest = 'dhis2-uiwidgets-inputfield',
         } = this.props
 
@@ -84,6 +85,7 @@ class InputField extends React.Component {
                         clearable={clearable}
                         prefixIcon={prefixIcon}
                         width={inputWidth}
+                        characterCountLimit={characterCountLimit}
                     />
                 </Box>
             </Field>
@@ -94,6 +96,8 @@ class InputField extends React.Component {
 const InputFieldProps = {
     /** The [native `autocomplete` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete) */
     autoComplete: PropTypes.string,
+    /** Soft maximum character length. Displays a counter showing current/max characters. Counter turns red when exceeded but typing is not prevented */
+    characterCountLimit: PropTypes.number,
     className: PropTypes.string,
     /** Makes the input field clearable */
     clearable: PropTypes.bool,

--- a/components/input/src/input-field/input-field.prod.stories.js
+++ b/components/input/src/input-field/input-field.prod.stories.js
@@ -193,3 +193,102 @@ export const ClearableInput = (args) => {
         />
     )
 }
+
+export const WithcharacterCountLimit = (args) => {
+    const [value, setValue] = useState('')
+    return (
+        <InputField
+            {...args}
+            name="characterCountLimit-input"
+            label="Description"
+            helpText="Maximum of 50 characters"
+            placeholder="Enter a description"
+            value={value}
+            onChange={(e) => setValue(e.value)}
+            characterCountLimit={50}
+        />
+    )
+}
+WithcharacterCountLimit.storyName = 'With characterCountLimit counter'
+
+export const WithcharacterCountLimitExceeded = () => (
+    <InputField
+        name="characterCountLimit-exceeded"
+        label="Short title"
+        value="This text exceeds the maximum character limit set on this field"
+        characterCountLimit={20}
+        onChange={() => {}}
+    />
+)
+WithcharacterCountLimitExceeded.storyName = 'With characterCountLimit exceeded'
+
+export const CharacterCountLimitDense = (args) => {
+    const [value, setValue] = useState('')
+    return (
+        <InputField
+            {...args}
+            name="characterCountLimit-dense"
+            label="Dense with counter"
+            dense
+            characterCountLimit={30}
+            placeholder="Dense input"
+            value={value}
+            onChange={(e) => setValue(e.value)}
+        />
+    )
+}
+CharacterCountLimitDense.storyName = 'characterCountLimit + dense'
+
+export const CharacterCountLimitClearable = (args) => {
+    const [value, setValue] = useState('Some text')
+    return (
+        <InputField
+            {...args}
+            name="characterCountLimit-clearable"
+            label="Clearable with counter"
+            characterCountLimit={40}
+            clearable
+            value={value}
+            onChange={(e) => setValue(e.value)}
+        />
+    )
+}
+CharacterCountLimitClearable.storyName = 'characterCountLimit + clearable'
+
+export const CharacterCountLimitWithValidation = (args) => {
+    const [value, setValue] = useState('Invalid value')
+    return (
+        <InputField
+            {...args}
+            name="characterCountLimit-validation"
+            label="With error status"
+            characterCountLimit={50}
+            error
+            validationText="This field has a validation error"
+            value={value}
+            onChange={(e) => setValue(e.value)}
+        />
+    )
+}
+CharacterCountLimitWithValidation.storyName =
+    'characterCountLimit + error + validationText'
+
+export const CharacterCountLimitClearableError = (args) => {
+    const [value, setValue] = useState('Text with all options')
+    return (
+        <InputField
+            {...args}
+            name="characterCountLimit-all"
+            label="All options combined"
+            characterCountLimit={30}
+            clearable
+            error
+            validationText="Too many characters"
+            helpText="Keep it short"
+            value={value}
+            onChange={(e) => setValue(e.value)}
+        />
+    )
+}
+CharacterCountLimitClearableError.storyName =
+    'characterCountLimit + clearable + error'

--- a/components/input/src/input/__tests__/input.test.js
+++ b/components/input/src/input/__tests__/input.test.js
@@ -26,4 +26,102 @@ describe('<Input>', () => {
 
         expect(onKeyDown).toHaveBeenCalledTimes(1)
     })
+
+    describe('character counter (characterCountLimit)', () => {
+        it('renders a counter when characterCountLimit is provided', () => {
+            const { getByTestId } = render(
+                <Input value="hello" characterCountLimit={10} />
+            )
+            expect(getByTestId('dhis2-uicore-input-counter')).toBeTruthy()
+        })
+
+        it('shows the correct current/max text', () => {
+            const { getByTestId } = render(
+                <Input value="hello" characterCountLimit={10} />
+            )
+            expect(getByTestId('dhis2-uicore-input-counter').textContent).toBe(
+                '5/10'
+            )
+        })
+
+        it('shows 0/max when value is empty', () => {
+            const { getByTestId } = render(
+                <Input value="" characterCountLimit={50} />
+            )
+            expect(getByTestId('dhis2-uicore-input-counter').textContent).toBe(
+                '0/50'
+            )
+        })
+
+        it('applies exceeds-maximum class when value exceeds characterCountLimit', () => {
+            const { getByTestId } = render(
+                <Input value="this exceeds" characterCountLimit={5} />
+            )
+            const counter = getByTestId('dhis2-uicore-input-counter')
+            expect(counter.className).toMatch(/exceeds-maximum/)
+        })
+
+        it('does not apply exceeds-maximum class when within limit', () => {
+            const { getByTestId } = render(
+                <Input value="hi" characterCountLimit={10} />
+            )
+            const counter = getByTestId('dhis2-uicore-input-counter')
+            expect(counter.className).not.toMatch(/exceeds-maximum/)
+        })
+
+        it('does not render the counter when disabled', () => {
+            const { queryByTestId } = render(
+                <Input value="hello" characterCountLimit={10} disabled />
+            )
+            expect(queryByTestId('dhis2-uicore-input-counter')).toBeNull()
+        })
+
+        it('does not render the counter when readOnly', () => {
+            const { queryByTestId } = render(
+                <Input value="hello" characterCountLimit={10} readOnly />
+            )
+            expect(queryByTestId('dhis2-uicore-input-counter')).toBeNull()
+        })
+
+        it('does not set the native maxLength attribute (soft limit)', () => {
+            render(<Input name="test" value="hello" characterCountLimit={10} />)
+            const input = screen.getByRole('textbox')
+            expect(input).not.toHaveAttribute('maxlength')
+        })
+
+        it('does not render a counter when characterCountLimit is not provided', () => {
+            const { queryByTestId } = render(<Input value="hello" />)
+            expect(queryByTestId('dhis2-uicore-input-counter')).toBeNull()
+        })
+
+        it('does not render a counter when characterCountLimit is 0', () => {
+            const { queryByTestId } = render(
+                <Input value="hello" characterCountLimit={0} />
+            )
+            expect(queryByTestId('dhis2-uicore-input-counter')).toBeNull()
+        })
+
+        it('sets aria-describedby on the input when name is provided', () => {
+            render(
+                <Input name="myfield" value="hello" characterCountLimit={10} />
+            )
+            const input = screen.getByRole('textbox')
+            expect(input).toHaveAttribute('aria-describedby', 'myfield-counter')
+        })
+
+        it('gives the counter span a matching id for aria-describedby', () => {
+            const { getByTestId } = render(
+                <Input name="myfield" value="hello" characterCountLimit={10} />
+            )
+            const counter = getByTestId('dhis2-uicore-input-counter')
+            expect(counter.id).toBe('myfield-counter')
+        })
+
+        it('renders counter alongside the clear button when clearable', () => {
+            const { getByTestId } = render(
+                <Input value="hello" characterCountLimit={10} clearable />
+            )
+            expect(getByTestId('dhis2-uicore-input-counter')).toBeTruthy()
+        })
+    })
 })

--- a/components/input/src/input/input.js
+++ b/components/input/src/input/input.js
@@ -89,6 +89,41 @@ const styles = css`
         color: ${theme.disabled};
         cursor: not-allowed;
     }
+
+    .input-end-items {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        pointer-events: none;
+    }
+
+    .input-end-items .clear-button {
+        position: static;
+        inset-inline-end: unset;
+        pointer-events: auto;
+    }
+
+    .character-counter {
+        font-size: 12px;
+        line-height: 14px;
+        font-variant-numeric: tabular-nums;
+        color: ${colors.grey700};
+        white-space: nowrap;
+    }
+
+    .character-counter.exceeds-maximum {
+        color: ${theme.error};
+        font-weight: 500;
+    }
+
+    .input-has-counter input {
+        padding-inline-end: 60px;
+    }
+
+    .input-has-counter.input-clearable input {
+        padding-inline-end: 82px;
+    }
 `
 
 export class Input extends Component {
@@ -172,10 +207,24 @@ export class Input extends Component {
             clearable,
             prefixIcon,
             width,
+            characterCountLimit,
         } = this.props
 
         const statusIcon = error || loading || valid || warning
         const clearButtonPadding = statusIcon ? '40px' : '10px'
+
+        const showCounter =
+            characterCountLimit != null &&
+            characterCountLimit > 0 &&
+            !disabled &&
+            !readOnly
+        const valueLength = value?.length || 0
+        const exceedsMaximum = showCounter && valueLength > characterCountLimit
+        const counterId = showCounter && name ? `${name}-counter` : undefined
+
+        const showClearButton = clearable && value?.length > 0
+
+        const endItemsEnd = statusIcon ? '38px' : '8px'
 
         return (
             <div
@@ -183,7 +232,8 @@ export class Input extends Component {
                     'input',
                     className,
                     { 'input-prefix-icon': prefixIcon },
-                    { 'input-clearable': clearable }
+                    { 'input-clearable': clearable },
+                    { 'input-has-counter': showCounter }
                 )}
                 data-test={dataTest}
             >
@@ -192,6 +242,7 @@ export class Input extends Component {
                     aria-label={ariaLabel}
                     aria-controls={ariaControls}
                     aria-haspopup={ariaHaspopup}
+                    aria-describedby={counterId}
                     role={role}
                     id={name}
                     name={name}
@@ -219,7 +270,29 @@ export class Input extends Component {
                         'read-only': readOnly,
                     })}
                 />
-                {clearable && value?.length ? (
+                {showCounter && (
+                    <span className="input-end-items">
+                        {showClearButton && (
+                            <button
+                                type="button"
+                                onClick={this.handleClear}
+                                className="clear-button"
+                            >
+                                <IconCross16 color={colors.white} />
+                            </button>
+                        )}
+                        <span
+                            id={counterId}
+                            className={cx('character-counter', {
+                                'exceeds-maximum': exceedsMaximum,
+                            })}
+                            data-test={`${dataTest}-counter`}
+                        >
+                            {valueLength}/{characterCountLimit}
+                        </span>
+                    </span>
+                )}
+                {!showCounter && showClearButton && (
                     <button
                         type="button"
                         onClick={this.handleClear}
@@ -227,7 +300,7 @@ export class Input extends Component {
                     >
                         <IconCross16 color={colors.white} />
                     </button>
-                ) : null}
+                )}
                 <StatusIcon
                     error={error}
                     valid={valid}
@@ -277,6 +350,10 @@ export class Input extends Component {
                         background: ${colors.grey500};
                         padding: 1px;
                     }
+
+                    .input-end-items {
+                        inset-inline-end: ${endItemsEnd};
+                    }
                 `}</style>
             </div>
         )
@@ -292,6 +369,8 @@ Input.propTypes = {
     ariaLabel: PropTypes.string,
     /** The [native `autocomplete` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete) */
     autoComplete: PropTypes.string,
+    /** Soft maximum character length. Displays a counter showing current/max characters. Counter turns red when exceeded but typing is not prevented */
+    characterCountLimit: PropTypes.number,
     className: PropTypes.string,
     /** Makes the input field clearable */
     clearable: PropTypes.bool,

--- a/components/input/src/input/input.prod.stories.js
+++ b/components/input/src/input/input.prod.stories.js
@@ -123,6 +123,71 @@ ValueTextOverflow.args = {
     warning: true,
 }
 
+export const WithMaxLength = (args) => {
+    const [value, setValue] = React.useState('')
+    return <Input {...args} value={value} onChange={(e) => setValue(e.value)} />
+}
+WithMaxLength.args = {
+    name: 'characterCountLimit',
+    characterCountLimit: 50,
+    placeholder: 'Max 50 characters',
+}
+WithMaxLength.storyName = 'With characterCountLimit counter'
+
+export const WithMaxLengthExceeded = Template.bind({})
+WithMaxLengthExceeded.args = {
+    characterCountLimit: 20,
+    value: 'This text exceeds the character limit',
+}
+WithMaxLengthExceeded.storyName = 'With characterCountLimit exceeded'
+
+export const MaxLengthDense = (args) => {
+    const [value, setValue] = React.useState('')
+    return <Input {...args} value={value} onChange={(e) => setValue(e.value)} />
+}
+MaxLengthDense.args = {
+    name: 'characterCountLimit-dense',
+    characterCountLimit: 30,
+    dense: true,
+    placeholder: 'Dense with counter',
+}
+MaxLengthDense.storyName = 'characterCountLimit + dense'
+
+export const MaxLengthClearable = (args) => {
+    const [value, setValue] = React.useState('Some text')
+    return <Input {...args} value={value} onChange={(e) => setValue(e.value)} />
+}
+MaxLengthClearable.args = {
+    name: 'characterCountLimit-clearable',
+    characterCountLimit: 40,
+    clearable: true,
+}
+MaxLengthClearable.storyName = 'characterCountLimit + clearable'
+
+export const MaxLengthWithError = (args) => {
+    const [value, setValue] = React.useState('Invalid value')
+    return <Input {...args} value={value} onChange={(e) => setValue(e.value)} />
+}
+MaxLengthWithError.args = {
+    name: 'characterCountLimit-error',
+    characterCountLimit: 50,
+    error: true,
+}
+MaxLengthWithError.storyName = 'characterCountLimit + error status'
+
+export const MaxLengthClearableError = (args) => {
+    const [value, setValue] = React.useState('Text with all options')
+    return <Input {...args} value={value} onChange={(e) => setValue(e.value)} />
+}
+MaxLengthClearableError.args = {
+    name: 'characterCountLimit-clearable-error',
+    characterCountLimit: 30,
+    clearable: true,
+    error: true,
+}
+MaxLengthClearableError.storyName =
+    'characterCountLimit + clearable + error status'
+
 export const RTLErrorPlaceholder = (args) => (
     <div dir="rtl">
         <Input {...args} />

--- a/components/input/types/index.d.ts
+++ b/components/input/types/index.d.ts
@@ -40,6 +40,10 @@ export interface InputProps {
      * The [native `autocomplete` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete)
      */
     autoComplete?: string
+    /**
+     * Soft maximum character length. Displays a counter showing current/max characters. Counter turns red when exceeded but typing is not prevented
+     */
+    characterCountLimit?: number
     className?: string
     /**
      * Makes the input clearable
@@ -188,6 +192,10 @@ export interface InputFieldProps {
      * The [native `max` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-max), for use when `type` is `'number'`
      */
     max?: string
+    /**
+     * Soft maximum character length. Displays a counter showing current/max characters. Counter turns red when exceeded but typing is not prevented
+     */
+    characterCountLimit?: number
     /**
      * The [native `min` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-min), for use when `type` is `'number'`
      */


### PR DESCRIPTION
Implements [LIBS-531](https://dhis2.atlassian.net/browse/LIBS-531)

---

### Description

This PR adds a character count indicator to the `Input` component. The counter is information only so the prop is named `characterCountLimit` rather than the native `<input>`'s `maxLength`, which is actually enforced.

There is some complexity to the way an `Input` with both `characterCountLimit` and `clearable` display the end-aligned items. To avoid changing the existing implementation, the additional flex layout element is only used when both `characterCountLimit` and `clearable` are present (which is not an expected common use case).

I considered linking the character limit to the input's `error` prop, but for now validation remains the responsibility of the consumer.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

<img width="541" height="108" alt="image" src="https://github.com/user-attachments/assets/e360bc6d-f648-4b86-bd22-8c71e5be192b" />

<img width="537" height="101" alt="image" src="https://github.com/user-attachments/assets/8470f9f3-51e2-4cbc-b0c1-c11c934573c6" />

<img width="432" height="145" alt="image" src="https://github.com/user-attachments/assets/a23e3c66-03ef-4352-b3bc-dd858d38ed3c" />



[LIBS-531]: https://dhis2.atlassian.net/browse/LIBS-531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ