### PR TITLE
feat(notice-box): dense variant, allow custom icon

### DIFF
--- a/components/notice-box/src/__tests__/notice-box-icon.test.js
+++ b/components/notice-box/src/__tests__/notice-box-icon.test.js
@@ -11,6 +11,45 @@ describe('NoticeBoxIcon', () => {
         expect(wrapper.find('SvgInfoFilled24')).toHaveLength(1)
     })
 
+    it('should render 16px info icon when dense', () => {
+        const wrapper = shallow(<NoticeBoxIcon dense dataTest="test" />)
+
+        expect(wrapper.find('SvgInfoFilled16')).toHaveLength(1)
+        expect(wrapper.find('SvgInfoFilled24')).toHaveLength(0)
+    })
+
+    it('should render 16px error icon when dense and error', () => {
+        const wrapper = shallow(<NoticeBoxIcon dense error dataTest="test" />)
+
+        expect(wrapper.find('SvgErrorFilled16')).toHaveLength(1)
+        expect(wrapper.find('SvgErrorFilled24')).toHaveLength(0)
+    })
+
+    it('should render custom icon when icon is set', () => {
+        const wrapper = shallow(
+            <NoticeBoxIcon
+                icon={<span className="custom">x</span>}
+                dataTest="test"
+            />
+        )
+
+        expect(wrapper.find('.custom')).toHaveLength(1)
+        expect(wrapper.find('SvgInfoFilled24')).toHaveLength(0)
+    })
+
+    it('should ignore status props when custom icon is set', () => {
+        const wrapper = shallow(
+            <NoticeBoxIcon
+                error
+                icon={<span className="custom">x</span>}
+                dataTest="test"
+            />
+        )
+
+        expect(wrapper.find('.custom')).toHaveLength(1)
+        expect(wrapper.find('SvgErrorFilled24')).toHaveLength(0)
+    })
+
     it('should log errors when both warning and error flag are set', () => {
         const spy = jest
             .spyOn(global.console, 'error')

--- a/components/notice-box/src/notice-box-content.js
+++ b/components/notice-box/src/notice-box-content.js
@@ -8,19 +8,24 @@ export const NoticeBoxContent = ({
     children,
     dataTest = 'dhis2-uicore-noticebox-content',
     title,
+    dense = false,
 }) => {
     return (
         <div data-test={dataTest}>
-            <NoticeBoxTitle title={title} dataTest={`${dataTest}-title`} />
-            <NoticeBoxMessage dataTest={`${dataTest}-message`}>
+            <NoticeBoxTitle
+                title={title}
+                dense={dense}
+                dataTest={`${dataTest}-title`}
+            />
+            <NoticeBoxMessage dense={dense} dataTest={`${dataTest}-message`}>
                 {children}
             </NoticeBoxMessage>
             <style jsx>{`
                 div {
                     display: flex;
                     flex-direction: column;
-                    gap: ${spacers.dp8};
-                    padding-block-start: 3px;
+                    gap: ${dense ? '2px' : spacers.dp8};
+                    padding-block-start: ${dense ? '0' : '3px'};
                 }
             `}</style>
         </div>
@@ -30,5 +35,6 @@ export const NoticeBoxContent = ({
 NoticeBoxContent.propTypes = {
     children: PropTypes.node,
     dataTest: PropTypes.string,
+    dense: PropTypes.bool,
     title: PropTypes.string,
 }

--- a/components/notice-box/src/notice-box-icon.js
+++ b/components/notice-box/src/notice-box-icon.js
@@ -1,32 +1,61 @@
 import { mutuallyExclusive } from '@dhis2/prop-types'
 import { colors, spacers } from '@dhis2/ui-constants'
 import {
-    IconErrorFilled24,
-    IconWarningFilled24,
-    IconInfoFilled24,
+    IconCheckmarkCircle16,
     IconCheckmarkCircle24,
+    IconErrorFilled16,
+    IconErrorFilled24,
+    IconInfoFilled16,
+    IconInfoFilled24,
+    IconWarningFilled16,
+    IconWarningFilled24,
 } from '@dhis2/ui-icons'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-export const NoticeBoxIcon = ({ valid, warning, error, dataTest }) => {
-    // Info is the default icon
+export const NoticeBoxIcon = ({
+    valid,
+    warning,
+    error,
+    dataTest,
+    dense = false,
+    icon,
+}) => {
+    const marginInlineEnd = dense ? spacers.dp8 : spacers.dp12
+
+    if (icon != null) {
+        return (
+            <div data-test={dataTest}>
+                {icon}
+                <style jsx>{`
+                    div {
+                        display: flex;
+                        flex-shrink: 0;
+                        align-items: flex-start;
+                        line-height: 0;
+                        margin-inline-end: ${marginInlineEnd};
+                    }
+                `}</style>
+            </div>
+        )
+    }
+
     let color = colors.blue900
-    let Icon = IconInfoFilled24
+    let Icon = dense ? IconInfoFilled16 : IconInfoFilled24
 
     if (valid) {
         color = colors.green700
-        Icon = IconCheckmarkCircle24
+        Icon = dense ? IconCheckmarkCircle16 : IconCheckmarkCircle24
     }
 
     if (warning) {
         color = colors.yellow700
-        Icon = IconWarningFilled24
+        Icon = dense ? IconWarningFilled16 : IconWarningFilled24
     }
 
     if (error) {
         color = colors.red700
-        Icon = IconErrorFilled24
+        Icon = dense ? IconErrorFilled16 : IconErrorFilled24
     }
 
     return (
@@ -34,8 +63,9 @@ export const NoticeBoxIcon = ({ valid, warning, error, dataTest }) => {
             <Icon color={color} />
 
             <style jsx>{`
-                margin-inline-end: ${spacers.dp12};
-                height: ${spacers.dp24};
+                margin-inline-end: ${marginInlineEnd};
+                margin-block-start: ${dense ? '1px' : '0'};
+                height: ${dense ? spacers.dp16 : spacers.dp24};
             `}</style>
         </div>
     )
@@ -43,7 +73,11 @@ export const NoticeBoxIcon = ({ valid, warning, error, dataTest }) => {
 
 NoticeBoxIcon.propTypes = {
     dataTest: PropTypes.string.isRequired,
+    /** Uses 16px icons and tighter spacing between icon and content */
+    dense: PropTypes.bool,
     error: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
+    /** Replaces the default status icon (error/warning/valid still affect box styling) */
+    icon: PropTypes.node,
     valid: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
     warning: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
 }

--- a/components/notice-box/src/notice-box-message.js
+++ b/components/notice-box/src/notice-box-message.js
@@ -2,7 +2,7 @@ import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-export const NoticeBoxMessage = ({ children, dataTest }) => {
+export const NoticeBoxMessage = ({ children, dataTest, dense = false }) => {
     if (!children) {
         return null
     }
@@ -14,8 +14,8 @@ export const NoticeBoxMessage = ({ children, dataTest }) => {
             <style jsx>{`
                 div {
                     color: ${colors.grey900};
-                    font-size: 14px;
-                    line-height: 19px;
+                    font-size: ${dense ? '13px' : '14px'};
+                    line-height: ${dense ? '18px' : '19px'};
                 }
             `}</style>
         </div>
@@ -25,4 +25,5 @@ export const NoticeBoxMessage = ({ children, dataTest }) => {
 NoticeBoxMessage.propTypes = {
     dataTest: PropTypes.string.isRequired,
     children: PropTypes.node,
+    dense: PropTypes.bool,
 }

--- a/components/notice-box/src/notice-box-title.js
+++ b/components/notice-box/src/notice-box-title.js
@@ -2,7 +2,7 @@ import { colors } from '@dhis2/ui-constants'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-export const NoticeBoxTitle = ({ title, dataTest }) => {
+export const NoticeBoxTitle = ({ title, dataTest, dense = false }) => {
     if (!title) {
         return null
     }
@@ -13,9 +13,9 @@ export const NoticeBoxTitle = ({ title, dataTest }) => {
             <style jsx>{`
                 h6 {
                     color: ${colors.grey900};
-                    font-size: 14px;
+                    font-size: ${dense ? '13px' : '14px'};
                     font-weight: 500;
-                    line-height: 19px;
+                    line-height: ${dense ? '18px' : '19px'};
                     margin: 0;
                 }
             `}</style>
@@ -25,5 +25,6 @@ export const NoticeBoxTitle = ({ title, dataTest }) => {
 
 NoticeBoxTitle.propTypes = {
     dataTest: PropTypes.string.isRequired,
+    dense: PropTypes.bool,
     title: PropTypes.string,
 }

--- a/components/notice-box/src/notice-box.js
+++ b/components/notice-box/src/notice-box.js
@@ -14,8 +14,10 @@ export const NoticeBox = ({
     warning,
     error,
     valid,
+    dense = false,
+    icon,
 }) => {
-    const classnames = cx(className, 'root', { warning, error, valid })
+    const classnames = cx(className, 'root', { warning, error, valid, dense })
 
     return (
         <div className={classnames} data-test={dataTest}>
@@ -23,11 +25,14 @@ export const NoticeBox = ({
                 error={error}
                 warning={warning}
                 valid={valid}
+                dense={dense}
+                icon={icon}
                 dataTest={`${dataTest}-icon`}
             />
             <div>
                 <NoticeBoxContent
                     title={title}
+                    dense={dense}
                     dataTest={`${dataTest}-content`}
                 >
                     {children}
@@ -42,6 +47,11 @@ export const NoticeBox = ({
                     display: flex;
                     padding-block: ${spacers.dp12};
                     padding-inline: ${spacers.dp16};
+                }
+
+                .root.dense {
+                    padding-block: ${spacers.dp8};
+                    padding-inline: ${spacers.dp8};
                 }
 
                 .root.warning {
@@ -67,8 +77,12 @@ NoticeBox.propTypes = {
     children: PropTypes.node,
     className: PropTypes.string,
     dataTest: PropTypes.string,
+    /** Uses 16px icons and tighter padding and internal spacing */
+    dense: PropTypes.bool,
     /** Applies 'error' message styles. Mutually exclusive with the `valid` and `warning` props */
     error: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),
+    /** Replaces the default status icon; `error`, `warning`, and `valid` still set box colors */
+    icon: PropTypes.node,
     title: PropTypes.string,
     /** Applies 'valid' message styles. Mutually exclusive with the `error` and `warning` props */
     valid: mutuallyExclusive(['error', 'valid', 'warning'], PropTypes.bool),

--- a/components/notice-box/src/notice-box.prod.stories.js
+++ b/components/notice-box/src/notice-box.prod.stories.js
@@ -1,4 +1,5 @@
-import { sharedPropTypes } from '@dhis2/ui-constants'
+import { colors, sharedPropTypes } from '@dhis2/ui-constants'
+import { IconCalendar24 } from '@dhis2/ui-icons'
 import React from 'react'
 import { NoticeBox } from './notice-box.js'
 
@@ -25,6 +26,12 @@ import { NoticeBox } from '@dhis2/ui'
 \`\`\`
 `
 
+const text =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' +
+    'Ut semper interdum scelerisque. Suspendisse ut velit sed ' +
+    'lacus pretium convallis vitae sit amet purus. Nam ut ' +
+    'libero rhoncus, consectetur sem a, sollicitudin lectus.'
+
 export default {
     title: 'Notice Box',
     component: NoticeBox,
@@ -33,19 +40,32 @@ export default {
         docs: { description: { component: description } },
     },
     argTypes: {
+        dense: { control: 'boolean' },
         error: { ...sharedPropTypes.statusArgType },
         warning: { ...sharedPropTypes.statusArgType },
         valid: { ...sharedPropTypes.statusArgType },
     },
 }
 
-export const Default = (args) => (
+const dashboardUpdateNotice = (args) => (
     <NoticeBox {...args}>
         Data shown in this dashboard may take a few hours to update. Scheduled
         dashboard updates can be managed in the scheduler app.
     </NoticeBox>
 )
+
+export const Default = dashboardUpdateNotice
 Default.args = { title: 'Your database was updated in the last 24 hours' }
+
+export const WithCustomIcon = (args) => (
+    <NoticeBox {...args}>
+        Dashboard updates can be managed in the scheduler app.
+    </NoticeBox>
+)
+WithCustomIcon.args = {
+    title: 'Scheduled maintenance',
+    icon: <IconCalendar24 color={colors.grey900} />,
+}
 
 export const Valid = (args) => (
     <NoticeBox {...args}>
@@ -79,12 +99,6 @@ Error.args = {
     title: "Access rules for this instance are set to 'Public'",
 }
 
-const text =
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
-    'Ut semper interdum scelerisque. Suspendisse ut velit sed' +
-    'lacus pretium convallis vitae sit amet purus. Nam ut' +
-    'libero rhoncus, consectetur sem a, sollicitudin lectus.'
-
 export const WithALongTitle = (args) => (
     <NoticeBox {...args}>The title text will wrap</NoticeBox>
 )
@@ -98,10 +112,35 @@ export const TitleOnly = () => (
     <NoticeBox title="This noticebox has only a title"></NoticeBox>
 )
 
-export const RTL = (args) => (
+const rtlNotice = (args) => (
     <div dir="rtl">
         <NoticeBox {...args}>هذه رسالة باللغة العربية.</NoticeBox>
     </div>
 )
+
+export const RTL = rtlNotice
 RTL.args = { title: 'مثال على العنوان' }
 RTL.storyName = 'RTL Text'
+
+export const Dense = dashboardUpdateNotice
+Dense.args = {
+    dense: true,
+    title: 'Your database was updated in the last 24 hours',
+}
+
+export const DenseWithALongTitle = (args) => (
+    <NoticeBox {...args}>The title text will wrap</NoticeBox>
+)
+DenseWithALongTitle.args = { dense: true, error: true, title: text }
+
+export const DenseWithoutTitle = (args) => (
+    <NoticeBox {...args}>This noticebox does not have a title.</NoticeBox>
+)
+DenseWithoutTitle.args = { dense: true }
+
+export const DenseTitleOnly = (args) => <NoticeBox {...args}></NoticeBox>
+DenseTitleOnly.args = { dense: true, title: 'This noticebox has only a title' }
+
+export const DenseRTL = rtlNotice
+DenseRTL.args = { dense: true, title: 'مثال على العنوان' }
+DenseRTL.storyName = 'Dense RTL Text'

--- a/components/notice-box/src/notice-box.prod.stories.js
+++ b/components/notice-box/src/notice-box.prod.stories.js
@@ -1,4 +1,5 @@
-import { sharedPropTypes } from '@dhis2/ui-constants'
+import { colors, sharedPropTypes } from '@dhis2/ui-constants'
+import { IconCalendar24 } from '@dhis2/ui-icons'
 import React from 'react'
 import { NoticeBox } from './notice-box.js'
 
@@ -25,6 +26,12 @@ import { NoticeBox } from '@dhis2/ui'
 \`\`\`
 `
 
+const text =
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ' +
+    'Ut semper interdum scelerisque. Suspendisse ut velit sed ' +
+    'lacus pretium convallis vitae sit amet purus. Nam ut ' +
+    'libero rhoncus, consectetur sem a, sollicitudin lectus.'
+
 export default {
     title: 'Notice Box',
     component: NoticeBox,
@@ -33,19 +40,32 @@ export default {
         docs: { description: { component: description } },
     },
     argTypes: {
+        dense: { control: 'boolean' },
         error: { ...sharedPropTypes.statusArgType },
         warning: { ...sharedPropTypes.statusArgType },
         valid: { ...sharedPropTypes.statusArgType },
     },
 }
 
-export const Default = (args) => (
+const DashboardUpdateTemplate = (args) => (
     <NoticeBox {...args}>
         Data shown in this dashboard may take a few hours to update. Scheduled
         dashboard updates can be managed in the scheduler app.
     </NoticeBox>
 )
+
+export const Default = DashboardUpdateTemplate.bind({})
 Default.args = { title: 'Your database was updated in the last 24 hours' }
+
+export const WithCustomIcon = (args) => (
+    <NoticeBox {...args}>
+        Dashboard updates can be managed in the scheduler app.
+    </NoticeBox>
+)
+WithCustomIcon.args = {
+    title: 'Scheduled maintenance',
+    icon: <IconCalendar24 color={colors.grey900} />,
+}
 
 export const Valid = (args) => (
     <NoticeBox {...args}>
@@ -79,12 +99,6 @@ Error.args = {
     title: "Access rules for this instance are set to 'Public'",
 }
 
-const text =
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.' +
-    'Ut semper interdum scelerisque. Suspendisse ut velit sed' +
-    'lacus pretium convallis vitae sit amet purus. Nam ut' +
-    'libero rhoncus, consectetur sem a, sollicitudin lectus.'
-
 export const WithALongTitle = (args) => (
     <NoticeBox {...args}>The title text will wrap</NoticeBox>
 )
@@ -98,10 +112,35 @@ export const TitleOnly = () => (
     <NoticeBox title="This noticebox has only a title"></NoticeBox>
 )
 
-export const RTL = (args) => (
+const RtlNoticeTemplate = (args) => (
     <div dir="rtl">
         <NoticeBox {...args}>هذه رسالة باللغة العربية.</NoticeBox>
     </div>
 )
+
+export const RTL = RtlNoticeTemplate.bind({})
 RTL.args = { title: 'مثال على العنوان' }
 RTL.storyName = 'RTL Text'
+
+export const Dense = DashboardUpdateTemplate.bind({})
+Dense.args = {
+    dense: true,
+    title: 'Your database was updated in the last 24 hours',
+}
+
+export const DenseWithALongTitle = (args) => (
+    <NoticeBox {...args}>The title text will wrap</NoticeBox>
+)
+DenseWithALongTitle.args = { dense: true, error: true, title: text }
+
+export const DenseWithoutTitle = (args) => (
+    <NoticeBox {...args}>This noticebox does not have a title.</NoticeBox>
+)
+DenseWithoutTitle.args = { dense: true }
+
+export const DenseTitleOnly = (args) => <NoticeBox {...args}></NoticeBox>
+DenseTitleOnly.args = { dense: true, title: 'This noticebox has only a title' }
+
+export const DenseRTL = RtlNoticeTemplate.bind({})
+DenseRTL.args = { dense: true, title: 'مثال على العنوان' }
+DenseRTL.storyName = 'Dense RTL Text'

--- a/components/notice-box/types/index.d.ts
+++ b/components/notice-box/types/index.d.ts
@@ -5,6 +5,14 @@ export interface NoticeBoxProps {
     className?: string
     dataTest?: string
     /**
+     * Uses 16px icons and tighter padding and internal spacing
+     */
+    dense?: boolean
+    /**
+     * Replaces the default status icon; `error`, `warning`, and `valid` still set box colors
+     */
+    icon?: React.ReactNode
+    /**
      * Applies 'error' message styles. Mutually exclusive with the `valid` and `warning` props
      */
     error?: boolean


### PR DESCRIPTION
Implements [UX-197](https://dhis2.atlassian.net/browse/UX-197)

---

### Description

- Adds a dense variant
- Allows a custom icon

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

_All points above should be relevant for feature PRs. For bugfixes, some points might not be relevant. In that case, just check them anyway to signal the work is done._

---

### Screenshots

<img width="718" height="119" alt="image" src="https://github.com/user-attachments/assets/e53d2016-cccc-4d35-b7ca-198229bdc854" />

<img width="727" height="90" alt="image" src="https://github.com/user-attachments/assets/c4ab9c8e-98ad-437a-a1bc-cf9716657997" />

<img width="721" height="112" alt="image" src="https://github.com/user-attachments/assets/614d7016-1cab-4ec7-a08e-7b1b5a603e6f" />



[UX-197]: https://dhis2.atlassian.net/browse/UX-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ