### PR TITLE
fix: add overflow to sharing dialog menu popup

### DIFF
--- a/components/sharing-dialog/src/autocomplete/menu-popup.js
+++ b/components/sharing-dialog/src/autocomplete/menu-popup.js
@@ -27,6 +27,7 @@ export const MenuPopup = ({
                 .card {
                     width: ${menuWidth};
                     max-height: ${maxHeight};
+                    overflow-y: auto;
                 }
             `}</style>
         </Layer>


### PR DESCRIPTION
Implements [LIBS-615](https://dhis2.atlassian.net/browse/LIBS-615)

---

### Description
 Add overflow to sharing dialog user and user-group search so that it is scrollable

---



### Screenshots

#### Before:
https://github.com/user-attachments/assets/a4ae94af-0b16-45df-9753-8a1047fb9cca

#### After:
https://github.com/user-attachments/assets/e9bbbd92-23b1-48f5-a738-82a614971b89





[LIBS-615]: https://dhis2.atlassian.net/browse/LIBS-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ