### PR TITLE
feat(multi-select): add collapseSelectionAfter prop

### DIFF
--- a/components/select/src/multi-select/input.js
+++ b/components/select/src/multi-select/input.js
@@ -3,6 +3,7 @@ import { colors } from '@dhis2/ui-constants'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
+import i18n from '../locales/index.js'
 import {
     InputClearButton,
     InputPlaceholder,
@@ -22,8 +23,13 @@ const Input = ({
     className,
     disabled,
     inputMaxHeight = '100px',
+    collapseSelectionAfter,
 }) => {
     const hasSelection = selected.length > 0
+    const shouldCollapse =
+        hasSelection &&
+        typeof collapseSelectionAfter === 'number' &&
+        selected.length > collapseSelectionAfter
     const onClear = (e) => {
         const data = { selected: [] }
 
@@ -40,7 +46,15 @@ const Input = ({
                     dataTest={`${dataTest}-placeholder`}
                 />
             )}
-            {hasSelection && (
+            {hasSelection && shouldCollapse && (
+                <span
+                    className="collapsed-selection-text"
+                    data-test={`${dataTest}-selection-count`}
+                >
+                    {i18n.t('{{count}} selected', { count: selected.length })}
+                </span>
+            )}
+            {hasSelection && !shouldCollapse && (
                 <div className="root-input">
                     {/* the wrapper div above is necessary to enforce wrapping on overflow */}
                     <SelectionList
@@ -81,6 +95,11 @@ const Input = ({
                 .root-right {
                     margin-inline-start: auto;
                 }
+
+                .collapsed-selection-text {
+                    flex: 1;
+                    user-select: none;
+                }
             `}</style>
 
             <style jsx>{`
@@ -97,6 +116,7 @@ Input.propTypes = {
     className: PropTypes.string,
     clearText: requiredIf((props) => props.clearable, PropTypes.string),
     clearable: PropTypes.bool,
+    collapseSelectionAfter: PropTypes.number,
     disabled: PropTypes.bool,
     inputMaxHeight: PropTypes.string,
     options: PropTypes.node,

--- a/components/select/src/multi-select/multi-select.js
+++ b/components/select/src/multi-select/multi-select.js
@@ -37,6 +37,7 @@ const MultiSelect = ({
     noMatchText,
     initialFocus,
     dense,
+    collapseSelectionAfter,
     dataTest = 'dhis2-uicore-multiselect',
 }) => {
     // If the select is filterable, use a filterable menu
@@ -65,6 +66,7 @@ const MultiSelect = ({
                             placeholder={placeholder}
                             prefix={prefix}
                             inputMaxHeight={inputMaxHeight}
+                            collapseSelectionAfter={collapseSelectionAfter}
                         />
                     }
                     menu={menu}
@@ -114,6 +116,8 @@ MultiSelect.propTypes = {
     clearText: requiredIf((props) => props.clearable, PropTypes.string),
     /** Adds a 'clear' option to the menu */
     clearable: PropTypes.bool,
+    /** When the number of selected items exceeds this threshold, chips are replaced with "X selected" text */
+    collapseSelectionAfter: PropTypes.number,
     dataTest: PropTypes.string,
     dense: PropTypes.bool,
     disabled: PropTypes.bool,

--- a/components/select/src/multi-select/multi-select.prod.stories.js
+++ b/components/select/src/multi-select/multi-select.prod.stories.js
@@ -367,6 +367,31 @@ export const ShiftedIntoView = (args) => (
     </>
 )
 
+export const CollapseSelectionAfterThreshold = () => {
+    const [selected, setSelected] = React.useState(['1', '3', '5'])
+    return (
+        <div style={{ maxWidth: 400 }}>
+            <MultiSelect
+                className="select"
+                selected={selected}
+                onChange={({ selected }) => setSelected(selected)}
+                collapseSelectionAfter={2}
+                prefix="Prefix text"
+                clearable
+                clearText="Clear all"
+            >
+                <MultiSelectOption value="1" label="option one" />
+                <MultiSelectOption value="2" label="option two" />
+                <MultiSelectOption value="3" label="option three" />
+                <MultiSelectOption value="4" label="option four" />
+                <MultiSelectOption value="5" label="option five" />
+                <MultiSelectOption value="6" label="option six" />
+            </MultiSelect>
+        </div>
+    )
+}
+CollapseSelectionAfterThreshold.storyName = 'Collapse selection after threshold'
+
 export const RTL = (args) => {
     useEffect(() => {
         document.body.dir = 'rtl'

--- a/components/select/types/index.d.ts
+++ b/components/select/types/index.d.ts
@@ -51,6 +51,10 @@ export interface MultiSelectProps {
      * Adds a 'clear' option to the menu
      */
     clearable?: boolean
+    /**
+     * When the number of selected items exceeds this threshold, chips are replaced with "X selected" text
+     */
+    collapseSelectionAfter?: number
     dataTest?: string
     dense?: boolean
     disabled?: boolean


### PR DESCRIPTION
## Summary
- Add a `collapseSelectionAfter` prop to `MultiSelect` that replaces individual chips with "X selected" text once the selection count exceeds the given threshold


https://github.com/user-attachments/assets/fb835e66-6303-4000-9112-c862711c1fd4

