### PR TITLE
fix: handle incomplete regular expressions [DHIS2-19573]

### DIFF
--- a/components/transfer/src/__tests__/helper/default-filter-callback.test.js
+++ b/components/transfer/src/__tests__/helper/default-filter-callback.test.js
@@ -34,4 +34,12 @@ describe('Transfer - defaultFilterCallback', () => {
 
         expect(actual).toEqual(expected)
     })
+
+    it('should return all options when the filter is invalid regexp', () => {
+        const filter = '('
+        const expected = options
+        const actual = defaultFilterCallback(options, filter)
+
+        expect(actual).toEqual(expected)
+    })
 })

--- a/components/transfer/src/transfer/default-filter-callback.js
+++ b/components/transfer/src/transfer/default-filter-callback.js
@@ -3,7 +3,15 @@
  * @param {string} filter
  * @returns {Object[]}
  */
-export const defaultFilterCallback = (options, filter) =>
-    filter === ''
-        ? options
-        : options.filter(({ label }) => label.match(new RegExp(filter, 'i')))
+export const defaultFilterCallback = (options, filter) => {
+    if (filter === '') {
+        return options
+    }
+    try {
+        const regex = new RegExp(filter, 'i')
+        return options.filter(({ label }) => label.match(regex))
+    } catch {
+        console.warn('Invalid regex filter:', filter)
+        return options
+    }
+}


### PR DESCRIPTION
Implements [DHIS2-19573](https://dhis2.atlassian.net/browse/DHIS2-19573)

---

### Description

The transfer filter uses regular expressions for filtering. This is honestly bit weird, but there might be a reason for that as the token-based filter accepts regular expressions (see thread here: https://dhis2.slack.com/archives/C0BP0RABF/p1761812319940729)

While we still may want to update this logic to not use regular expressions, the update here at least fixes things so that invalid regular expressions return all options (e.g. they are treated as there is no filter). This is better than the current error, which will result in app crash.

---

### Known issues

-   [ ] we probably should decide if we want to use regular expression filters here.

---

### Checklist

-   [ ] API docs are generated
-   [X] Tests were added
-   [ ] Storybook demos were added

We could add this to the documentation if we think it's something we definitely want to keep? I don't think there's a need for highlighting this in a storybook demo.


[DHIS2-19573]: https://dhis2.atlassian.net/browse/DHIS2-19573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ