### PR TITLE
fix: add missing fields to CalendarInputProps type [DHIS2-21530]

### DIFF
--- a/components/calendar/types/index.d.ts
+++ b/components/calendar/types/index.d.ts
@@ -42,6 +42,10 @@ export interface CalendarProps {
      */
     numberingSystem?: CalendarPickerOptions['numberingSystem']
     /**
+     * When true, only shows years in the past (current year and earlier)
+     */
+    pastOnly?: boolean
+    /**
      * the timeZone to use
      */
     timeZone?: CalendarPickerOptions['timeZone']
@@ -64,6 +68,18 @@ export type CalendarInputProps = Omit<InputFieldProps, 'type' | 'value'> &
          * or processed. If not provided it supports both formats
          */
         format?: 'YYYY-MM-DD' | 'DD-MM-YYYY'
+        /**
+         * The maximum selectable date
+         */
+        maxDate?: string
+        /**
+         * The minimum selectable date
+         */
+        minDate?: string
+        /**
+         * Whether to use strict validation by showing errors for out-of-range dates when enabled (default), and warnings when disabled
+         */
+        strictValidation?: boolean
     }
 
 export const CalendarInput: React.FC<CalendarInputProps>


### PR DESCRIPTION
Some props were missing from the type definitions, see [21530](https://dhis2.atlassian.net/browse/DHIS2-21530)