### PR TITLE
feat: organisation-unit-tree to support shortname (DHIS2-21561)

### DIFF
--- a/components/organisation-unit-tree/src/organisation-unit-node/organisation-unit-node-children.js
+++ b/components/organisation-unit-tree/src/organisation-unit-node/organisation-unit-node-children.js
@@ -21,6 +21,7 @@ export const OrganisationUnitNodeChildren = ({
     autoExpandLoadingError,
     dataTest,
     disableSelection,
+    displayProperty,
     expanded,
     filter,
     highlighted,
@@ -42,6 +43,7 @@ export const OrganisationUnitNodeChildren = ({
         isUserDataViewFallback,
         suppressAlphabeticalSorting,
         onComplete: onChildrenLoaded,
+        displayProperty,
     })
 
     const displayChildren =
@@ -68,6 +70,7 @@ export const OrganisationUnitNodeChildren = ({
                             dataTest={dataTest}
                             disableSelection={disableSelection}
                             displayName={child.displayName}
+                            displayProperty={displayProperty}
                             expanded={expanded}
                             filter={filter}
                             highlighted={highlighted}
@@ -105,6 +108,7 @@ OrganisationUnitNodeChildren.propTypes = {
 
     autoExpandLoadingError: PropTypes.bool,
     disableSelection: PropTypes.bool,
+    displayProperty: PropTypes.oneOf(['displayName', 'displayShortName']),
     expanded: PropTypes.arrayOf(orgUnitPathPropType),
     filter: PropTypes.arrayOf(orgUnitPathPropType),
     highlighted: PropTypes.arrayOf(orgUnitPathPropType),

--- a/components/organisation-unit-tree/src/organisation-unit-node/organisation-unit-node.js
+++ b/components/organisation-unit-tree/src/organisation-unit-node/organisation-unit-node.js
@@ -17,6 +17,7 @@ export const OrganisationUnitNode = ({
     dataTest,
     disableSelection,
     displayName,
+    displayProperty,
     expanded,
     highlighted,
     id,
@@ -142,6 +143,7 @@ export const OrganisationUnitNode = ({
                     autoExpandLoadingError={autoExpandLoadingError}
                     dataTest={dataTest}
                     disableSelection={disableSelection}
+                    displayProperty={displayProperty}
                     expanded={expanded}
                     filter={filter}
                     highlighted={highlighted}
@@ -172,6 +174,7 @@ OrganisationUnitNode.propTypes = {
     autoExpandLoadingError: PropTypes.bool,
     disableSelection: PropTypes.bool,
     displayName: PropTypes.string,
+    displayProperty: PropTypes.oneOf(['displayName', 'displayShortName']),
     expanded: PropTypes.arrayOf(orgUnitPathPropType),
     filter: PropTypes.arrayOf(orgUnitPathPropType),
     highlighted: PropTypes.arrayOf(orgUnitPathPropType),

--- a/components/organisation-unit-tree/src/organisation-unit-node/use-org-children.js
+++ b/components/organisation-unit-tree/src/organisation-unit-node/use-org-children.js
@@ -7,7 +7,10 @@ const ORG_DATA_QUERY = {
         resource: `organisationUnits`,
         id: ({ id }) => id,
         params: ({ displayProperty }) => ({
-            fields: `children[id,path,${displayProperty}~rename(displayName)]`,
+            fields:
+                displayProperty === 'displayName'
+                    ? 'children[id,path,displayName]'
+                    : `children[id,path,${displayProperty}~rename(displayName)]`,
         }),
     },
 }
@@ -46,7 +49,7 @@ export const useOrgChildren = ({
         return suppressAlphabeticalSorting
             ? orgUnit.children
             : sortNodeChildrenAlphabetically(orgUnit.children)
-    }, [data, suppressAlphabeticalSorting])
+    }, [data, node.children, suppressAlphabeticalSorting])
 
     useEffect(() => {
         if (onComplete && orgChildren && !onCompleteCalledRef.current) {
@@ -54,7 +57,7 @@ export const useOrgChildren = ({
             onComplete({ ...node, children: orgChildren })
             onCompleteCalledRef.current = true
         }
-    }, [onComplete, orgChildren, onCompleteCalledRef])
+    }, [node, onComplete, orgChildren, onCompleteCalledRef])
 
     return { called, loading, error: error || null, data: orgChildren }
 }

--- a/components/organisation-unit-tree/src/organisation-unit-node/use-org-children.js
+++ b/components/organisation-unit-tree/src/organisation-unit-node/use-org-children.js
@@ -6,9 +6,9 @@ const ORG_DATA_QUERY = {
     orgUnit: {
         resource: `organisationUnits`,
         id: ({ id }) => id,
-        params: {
-            fields: 'children[id,path,displayName]',
-        },
+        params: ({ displayProperty }) => ({
+            fields: `children[id,path,${displayProperty}~rename(displayName)]`,
+        }),
     },
 }
 
@@ -17,16 +17,18 @@ const ORG_DATA_QUERY = {
  * @param {Object} options
  * @param {string} options.displayName
  * @param {boolean} [options.withChildren]
+ * @param {'displayName'|'displayShortName'} [options.displayProperty]
  * @returns {Object}
  */
 export const useOrgChildren = ({
     node,
     suppressAlphabeticalSorting,
     onComplete,
+    displayProperty = 'displayName',
 }) => {
     const onCompleteCalledRef = useRef(false)
     const { called, loading, error, data } = useDataQuery(ORG_DATA_QUERY, {
-        variables: { id: node.id },
+        variables: { id: node.id, displayProperty },
     })
 
     const orgChildren = useMemo(() => {

--- a/components/organisation-unit-tree/src/organisation-unit-tree/organisation-unit-tree.js
+++ b/components/organisation-unit-tree/src/organisation-unit-tree/organisation-unit-tree.js
@@ -20,6 +20,7 @@ const OrganisationUnitTree = ({
     autoExpandLoadingError,
     dataTest = 'dhis2-uiwidgets-orgunittree',
     disableSelection,
+    displayProperty = 'displayName',
     forceReload,
     highlighted = staticArray,
     isUserDataViewFallback,
@@ -47,6 +48,7 @@ const OrganisationUnitTree = ({
     const { called, loading, error, data, refetch } = useRootOrgData(rootIds, {
         isUserDataViewFallback,
         suppressAlphabeticalSorting,
+        displayProperty,
     })
 
     const { expanded, handleExpand, handleCollapse } = useExpanded({
@@ -90,6 +92,7 @@ const OrganisationUnitTree = ({
                             dataTest={dataTest}
                             disableSelection={disableSelection}
                             displayName={rootNode.displayName}
+                            displayProperty={displayProperty}
                             expanded={expanded}
                             highlighted={highlighted}
                             id={rootId}
@@ -131,6 +134,14 @@ OrganisationUnitTree.propTypes = {
 
     /** When set to true, no unit can be selected */
     disableSelection: PropTypes.bool,
+
+    /**
+     * Which field to render as the org unit label. Defaults to `'displayName'`.
+     * Set to `'displayShortName'` to honour the `keyAnalysisDisplayProperty`
+     * system/user setting. The query renames the chosen field back to
+     * `displayName` internally, so consumer-facing data shape is unchanged.
+     */
+    displayProperty: PropTypes.oneOf(['displayName', 'displayShortName']),
 
     expanded: requiredIf(
         (props) => !!props.handleExpand || !!props.handleCollapse,

--- a/components/organisation-unit-tree/src/organisation-unit-tree/use-root-org-data/use-root-org-data.js
+++ b/components/organisation-unit-tree/src/organisation-unit-tree/use-root-org-data/use-root-org-data.js
@@ -2,7 +2,7 @@ import { useDataQuery } from '@dhis2/app-runtime'
 import { useMemo } from 'react'
 import { patchMissingDisplayName } from './patch-missing-display-name.js'
 
-export const createRootQuery = (ids) =>
+export const createRootQuery = (ids, displayProperty) =>
     ids.reduce(
         (query, id) => ({
             ...query,
@@ -11,7 +11,11 @@ export const createRootQuery = (ids) =>
                 resource: `organisationUnits`,
                 params: ({ isUserDataViewFallback }) => ({
                     isUserDataViewFallback,
-                    fields: ['displayName', 'path', 'id'],
+                    fields: [
+                        `${displayProperty}~rename(displayName)`,
+                        'path',
+                        'id',
+                    ],
                 }),
             },
         }),
@@ -23,10 +27,17 @@ export const createRootQuery = (ids) =>
  * @param {Object} [options]
  * @param {boolean} [options.withChildren]
  * @param {boolean} [options.isUserDataViewFallback]
+ * @param {'displayName'|'displayShortName'} [options.displayProperty]
  * @returns {Object}
  */
-export const useRootOrgData = (ids, { isUserDataViewFallback } = {}) => {
-    const query = useMemo(() => createRootQuery(ids), [ids])
+export const useRootOrgData = (
+    ids,
+    { isUserDataViewFallback, displayProperty = 'displayName' } = {}
+) => {
+    const query = useMemo(
+        () => createRootQuery(ids, displayProperty),
+        [ids, displayProperty]
+    )
     const variables = { isUserDataViewFallback }
     const rootOrgUnits = useDataQuery(query, {
         variables,

--- a/components/organisation-unit-tree/src/organisation-unit-tree/use-root-org-data/use-root-org-data.js
+++ b/components/organisation-unit-tree/src/organisation-unit-tree/use-root-org-data/use-root-org-data.js
@@ -12,7 +12,9 @@ export const createRootQuery = (ids, displayProperty) =>
                 params: ({ isUserDataViewFallback }) => ({
                     isUserDataViewFallback,
                     fields: [
-                        `${displayProperty}~rename(displayName)`,
+                        displayProperty === 'displayName'
+                            ? 'displayName'
+                            : `${displayProperty}~rename(displayName)`,
                         'path',
                         'id',
                     ],

--- a/components/organisation-unit-tree/types/index.d.ts
+++ b/components/organisation-unit-tree/types/index.d.ts
@@ -52,6 +52,13 @@ export interface OrganisationUnitTreeProps {
      * When set to true, no unit can be selected
      */
     disableSelection?: boolean
+    /**
+     * Which field to render as the org unit label. Defaults to 'displayName'.
+     * Set to 'displayShortName' to honour the keyAnalysisDisplayProperty
+     * system/user setting. The query renames the chosen field back to
+     * `displayName` internally, so the consumer-facing data shape is unchanged.
+     */
+    displayProperty?: 'displayName' | 'displayShortName'
     expanded?: boolean
     /**
      * All organisation units with a path that includes the provided paths will be shown.


### PR DESCRIPTION
Ref this subtask: https://dhis2.atlassian.net/browse/DHIS2-21561

Adds a `displayProperty` prop to `OrganisationUnitTree` so consumers can render labels with `displayShortName` instead of `displayName`.

Context: DHIS2 has a `keyAnalysisDisplayProperty` system/user setting that the analytics apps (data-visualizer, line-listing, dashboards) already plumb through `@dhis2/analytics`'s `OrgUnitDimension` as `displayNameProp`. That dead-ended at the tree though, since there was no matching prop on this side. This PR is the missing piece.

Both `useDataQuery` calls use the field-rename trick when a non-default `displayProperty` is passed:
- root: `${displayProperty}~rename(displayName)`
- children: `children[id,path,${displayProperty}~rename(displayName)]`

When `displayProperty` is the default `'displayName'`, the field strings stay byte-identical to before, so the wire format and existing mocks are unchanged. The internal node shape always exposes `.displayName`, so no render-side code moves and existing callers see no difference. Fully backwards compatible.

`@dhis2/analytics` still needs a small change to actually forward `displayProperty` through `OrgUnitDimension`, but that's a separate PR.

Also fixed two pre-existing react-hooks/exhaustive-deps warnings in `use-org-children.js` that CI surfaced once the file was in the diff (`node.children` missing from `useMemo`, `node` missing from `useEffect`). Both effects already guard against unwanted re-runs, so behavior is unchanged.

### Checklist

- [x] API docs are generated (auto-generated from propTypes)
- Tests were added. _N/A_ Existing assertions are ok.
- Storybook demos were added. _N/A_ Not needed.