### PR TITLE
feat(select): add menuMinWidth and menuMaxWidth to SimpleSingleSelect

### DIFF
--- a/components/select/src/simple-single-select-field/simple-single-select-field.js
+++ b/components/select/src/simple-single-select-field/simple-single-select-field.js
@@ -137,6 +137,12 @@ SimpleSingleSelectField.propTypes = {
     /** Allows to modify the max height of the menu **/
     menuMaxHeight: PropTypes.string,
 
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMaxWidth: PropTypes.string,
+
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMinWidth: PropTypes.string,
+
     /** String that will be displayed when the select is being filtered but the options array is empty **/
     noMatchText: requiredIf((props) => props.filterable, PropTypes.string),
 

--- a/components/select/src/simple-single-select-field/simple-single-select-field.prod.stories.js
+++ b/components/select/src/simple-single-select-field/simple-single-select-field.prod.stories.js
@@ -26,6 +26,13 @@ const options = [
     { value: '10', label: 'ten' },
 ]
 
+const longOptions = [
+    { value: '1', label: 'option one' },
+    { value: '2', label: 'option two' },
+    { value: '3', label: 'option three' },
+    { value: '4', label: 'A longer option that exceeds the minimum' },
+]
+
 export default {
     title: 'SimpleSingleSelectField',
     component: SimpleSingleSelectField,
@@ -182,6 +189,48 @@ export const InputWidth = () => {
                 valueLabel={valueLabel}
                 onChange={(nextValue) => setValue(nextValue)}
                 options={options}
+            />
+        </div>
+    )
+}
+
+export const WithMenuMinWidth = () => {
+    const [value, setValue] = useState('')
+    const valueLabel = value
+        ? longOptions.find((option) => option.value === value)?.label
+        : ''
+
+    return (
+        <div style={{ width: 120 }}>
+            <SimpleSingleSelectField
+                name="simple"
+                label="This is the label"
+                value={value}
+                valueLabel={valueLabel}
+                onChange={(nextValue) => setValue(nextValue)}
+                options={longOptions}
+                menuMinWidth="240px"
+            />
+        </div>
+    )
+}
+
+export const WithMenuMaxWidth = () => {
+    const [value, setValue] = useState('')
+    const valueLabel = value
+        ? longOptions.find((option) => option.value === value)?.label
+        : ''
+
+    return (
+        <div style={{ width: 120 }}>
+            <SimpleSingleSelectField
+                name="simple"
+                label="This is the label"
+                value={value}
+                valueLabel={valueLabel}
+                onChange={(nextValue) => setValue(nextValue)}
+                options={longOptions}
+                menuMaxWidth="200px"
             />
         </div>
     )

--- a/components/select/src/simple-single-select-field/simple-single-select-field.test.js
+++ b/components/select/src/simple-single-select-field/simple-single-select-field.test.js
@@ -52,6 +52,8 @@ describe('<SimpleSingleSelectField />', () => {
                 loading={false}
                 menuLoadingText=""
                 menuMaxHeight=""
+                menuMaxWidth="400px"
+                menuMinWidth="240px"
                 noMatchText=""
                 optionUpdateStrategy="off"
                 placeholder=""
@@ -91,6 +93,8 @@ describe('<SimpleSingleSelectField />', () => {
         expect(SimpleSingleSelect.mock.calls[0][0].loading).toBe(false)
         expect(SimpleSingleSelect.mock.calls[0][0].menuLoadingText).toBe('')
         expect(SimpleSingleSelect.mock.calls[0][0].menuMaxHeight).toBe('')
+        expect(SimpleSingleSelect.mock.calls[0][0].menuMaxWidth).toBe('400px')
+        expect(SimpleSingleSelect.mock.calls[0][0].menuMinWidth).toBe('240px')
         expect(SimpleSingleSelect.mock.calls[0][0].noMatchText).toBe('')
         expect(SimpleSingleSelect.mock.calls[0][0].optionUpdateStrategy).toBe(
             'off'

--- a/components/select/src/simple-single-select/__stories__/WithMenuMaxWidth.js
+++ b/components/select/src/simple-single-select/__stories__/WithMenuMaxWidth.js
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import { SimpleSingleSelect } from '../simple-single-select.js'
+
+const options = [
+    { value: '1', label: 'option one' },
+    { value: '2', label: 'option two' },
+    { value: '3', label: 'A much longer option label that gets clamped' },
+]
+
+export const WithMenuMaxWidth = () => {
+    const [selected, setSelected] = useState(null)
+
+    return (
+        <div style={{ width: 120 }}>
+            <SimpleSingleSelect
+                name="simple"
+                selected={selected}
+                onChange={setSelected}
+                options={options}
+                menuMaxWidth="200px"
+            />
+        </div>
+    )
+}

--- a/components/select/src/simple-single-select/__stories__/WithMenuMinWidth.js
+++ b/components/select/src/simple-single-select/__stories__/WithMenuMinWidth.js
@@ -1,0 +1,25 @@
+import React, { useState } from 'react'
+import { SimpleSingleSelect } from '../simple-single-select.js'
+
+const options = [
+    { value: '1', label: 'option one' },
+    { value: '2', label: 'option two' },
+    { value: '3', label: 'option three' },
+    { value: '4', label: 'A longer option that exceeds the minimum' },
+]
+
+export const WithMenuMinWidth = () => {
+    const [selected, setSelected] = useState(null)
+
+    return (
+        <div style={{ width: 120 }}>
+            <SimpleSingleSelect
+                name="simple"
+                selected={selected}
+                onChange={setSelected}
+                options={options}
+                menuMinWidth="240px"
+            />
+        </div>
+    )
+}

--- a/components/select/src/simple-single-select/menu/menu.js
+++ b/components/select/src/simple-single-select/menu/menu.js
@@ -26,6 +26,8 @@ export function Menu({
     loading,
     loadingText,
     maxHeight,
+    maxWidth,
+    minWidth,
     noMatchText,
     optionUpdateStrategy,
     selectRef,
@@ -34,18 +36,16 @@ export function Menu({
     onClose,
     onEndReached,
 }) {
-    const [menuWidth, setWidth] = useState('auto')
+    const [selectWidth, setSelectWidth] = useState()
     const dataTestPrefix = `${dataTest}-menu`
 
+    // Re-measuring whenever `hidden` changes keeps the width current when the
+    // select's container has been resized since the menu was last opened
     useEffect(() => {
         if (selectRef) {
-            const callback = () => setWidth(`${selectRef.offsetWidth}px`)
-            callback() // We want to know the width as soon as the
-
-            selectRef.addEventListener('resize', callback)
-            return () => selectRef.removeEventListener('resize', callback)
+            setSelectWidth(`${selectRef.offsetWidth}px`)
         }
-    }, [selectRef])
+    }, [selectRef, hidden])
 
     if (hidden) {
         return null
@@ -60,6 +60,14 @@ export function Menu({
 
     const isEmpty = !options.length && !filterValue
 
+    const flexible = Boolean(minWidth || maxWidth)
+    // We never want the menu narrower than the select, so a maxWidth below
+    // the select's width intentionally has no effect
+    const flexibleMinWidth =
+        minWidth && selectWidth
+            ? `max(${selectWidth}, ${minWidth})`
+            : minWidth || selectWidth
+
     return (
         <Layer onBackdropClick={onClose} transparent>
             <Popper
@@ -67,7 +75,15 @@ export function Menu({
                 placement="bottom-start"
                 observeReferenceResize
             >
-                <div className="menu" style={{ width: menuWidth, maxHeight }}>
+                <div
+                    className="menu"
+                    style={{
+                        width: flexible ? 'fit-content' : selectWidth,
+                        minWidth: flexible ? flexibleMinWidth : undefined,
+                        maxWidth,
+                        maxHeight,
+                    }}
+                >
                     {isEmpty && <Empty>{empty}</Empty>}
 
                     {hasNoFilterMatch && <NoMatch>{noMatchText}</NoMatch>}
@@ -160,6 +176,8 @@ Menu.propTypes = {
     loading: PropTypes.bool,
     loadingText: PropTypes.string,
     maxHeight: PropTypes.string,
+    maxWidth: PropTypes.string,
+    minWidth: PropTypes.string,
     noMatchText: PropTypes.string,
     optionComponent: PropTypes.elementType,
     optionUpdateStrategy: PropTypes.oneOf(['off', 'polite', 'assertive']),

--- a/components/select/src/simple-single-select/simple-single-select.js
+++ b/components/select/src/simple-single-select/simple-single-select.js
@@ -75,6 +75,8 @@ export function SimpleSingleSelect({
     loading = false,
     menuLoadingText: _menuLoadingText = '',
     menuMaxHeight = '288px',
+    menuMaxWidth,
+    menuMinWidth,
     noMatchText: _noMatchText = '',
     optionUpdateStrategy = 'polite',
     placeholder = '',
@@ -261,6 +263,8 @@ export function SimpleSingleSelect({
                 loading={loading}
                 loadingText={menuLoadingText}
                 maxHeight={menuMaxHeight}
+                maxWidth={menuMaxWidth}
+                minWidth={menuMinWidth}
                 noMatchText={noMatchText}
                 optionUpdateStrategy={optionUpdateStrategy}
                 options={options}
@@ -341,6 +345,12 @@ SimpleSingleSelect.propTypes = {
 
     /** Allows to modify the max height of the menu **/
     menuMaxHeight: PropTypes.string,
+
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMaxWidth: PropTypes.string,
+
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMinWidth: PropTypes.string,
 
     /** String that will be displayed when the select is being filtered but the options array is empty **/
     noMatchText: requiredIf((props) => props.filterable, PropTypes.string),

--- a/components/select/src/simple-single-select/simple-single-select.prod.stories.js
+++ b/components/select/src/simple-single-select/simple-single-select.prod.stories.js
@@ -22,6 +22,8 @@ export { WithOptionsAndLoadingText } from './__stories__/WithOptionsAndLoadingTe
 export { WithoutOptionsAndLoading } from './__stories__/WithoutOptionsAndLoading.js'
 export { WithManyOptions } from './__stories__/WithManyOptions.js'
 export { WithCustomLowMaxHeight } from './__stories__/WithCustomLowMaxHeight.js'
+export { WithMenuMinWidth } from './__stories__/WithMenuMinWidth.js'
+export { WithMenuMaxWidth } from './__stories__/WithMenuMaxWidth.js'
 export { WithOptionsAndDisabled } from './__stories__/WithOptionsAndDisabled.js'
 export { WithSelectionAndDisabled } from './__stories__/WithSelectionAndDisabled.js'
 export { WithPrefix } from './__stories__/WithPrefix.js'

--- a/components/select/src/simple-single-select/simple-single-select.test.js
+++ b/components/select/src/simple-single-select/simple-single-select.test.js
@@ -150,6 +150,74 @@ describe('<SimpleSingleSelect />', () => {
         expect(menu.style.maxHeight).toBe('100px')
     })
 
+    describe('dropdown menu width', () => {
+        let offsetWidth
+
+        beforeEach(() => {
+            // The menu's width is derived from the select's measured width,
+            // which is always 0 in jsdom
+            offsetWidth = jest
+                .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+                .mockReturnValue(120)
+        })
+
+        afterEach(() => {
+            offsetWidth.mockRestore()
+        })
+
+        const renderAndOpen = (props) => {
+            render(
+                <SimpleSingleSelect
+                    name="simple"
+                    selected={{ value: 'foo', label: 'Foo' }}
+                    onChange={() => null}
+                    options={[{ value: 'foo', label: 'Foo' }]}
+                    {...props}
+                />
+            )
+
+            fireEvent.click(screen.getByRole('combobox'))
+
+            const listbox = screen.getByRole('listbox')
+            return listbox.parentNode.parentNode.parentNode
+        }
+
+        it('should match the width of the select by default', () => {
+            const menu = renderAndOpen()
+
+            expect(menu.style.width).toBe('120px')
+        })
+
+        it('should not be narrower than menuMinWidth or the select', () => {
+            const menu = renderAndOpen({ menuMinWidth: '240px' })
+
+            expect(menu.style.minWidth).toBe('max(120px, 240px)')
+        })
+
+        it('should not be wider than menuMaxWidth', () => {
+            const menu = renderAndOpen({ menuMaxWidth: '200px' })
+
+            expect(menu.style.maxWidth).toBe('200px')
+            expect(menu.style.minWidth).toBe('120px')
+        })
+
+        it('should re-measure the select when the menu is reopened', () => {
+            renderAndOpen({ menuMinWidth: '240px' })
+            const comboBox = screen.getByRole('combobox')
+
+            // close the menu
+            fireEvent.click(comboBox)
+
+            // widen the select while the menu is closed, then reopen it
+            offsetWidth.mockReturnValue(300)
+            fireEvent.click(comboBox)
+
+            const listbox = screen.getByRole('listbox')
+            const menu = listbox.parentNode.parentNode.parentNode
+            expect(menu.style.minWidth).toBe('max(300px, 240px)')
+        })
+    })
+
     it('should accept a placeholder', () => {
         render(
             <SimpleSingleSelect

--- a/components/select/types/index.d.ts
+++ b/components/select/types/index.d.ts
@@ -71,6 +71,14 @@ export interface MultiSelectProps {
     loadingText?: string
     maxHeight?: string
     /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMaxWidth?: string
+    /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMinWidth?: string
+    /**
      * Required if `filterable` prop is `true`
      */
     noMatchText?: string
@@ -167,6 +175,14 @@ export interface MultiSelectFieldProps {
      * Constrains height of the MultiSelect
      */
     maxHeight?: string
+    /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMaxWidth?: string
+    /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMinWidth?: string
     /**
      * Text to display when there are no filter results
      */
@@ -286,6 +302,14 @@ export interface SingleSelectProps {
     loadingText?: string
     maxHeight?: string
     /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMaxWidth?: string
+    /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMinWidth?: string
+    /**
      * Text to show when filter returns no results. Required if `filterable` prop is true
      */
     noMatchText?: string
@@ -402,6 +426,12 @@ export interface SimpleSingleSelectProps {
 
     /** Allows to modify the max height of the menu - Default is 288px **/
     menuMaxHeight?: string
+
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMaxWidth?: string
+
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMinWidth?: string
 
     /** String that will be displayed when the select is being filtered but the options array is empty **/
     noMatchText?: string
@@ -520,6 +550,12 @@ export interface SimpleSingleSelectFieldProps {
 
     /** Allows to modify the max height of the menu **/
     menuMaxHeight?: string
+
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMaxWidth?: string
+
+    /** See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width) **/
+    menuMinWidth?: string
 
     /** String that will be displayed when the select is being filtered but the options array is empty **/
     noMatchText?: string
@@ -655,6 +691,14 @@ export interface SingleSelectFieldProps {
      * Constrains height of the SingleSelect
      */
     maxHeight?: string
+    /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMaxWidth?: string
+    /**
+     * See [dropdown menu width](https://developers.dhis2.org/docs/ui/components/select#dropdown-menu-width)
+     */
+    menuMinWidth?: string
     /**
      * Text to display when there are no filter results
      */

--- a/docs/docs/components/select.md
+++ b/docs/docs/components/select.md
@@ -164,33 +164,18 @@ Use a multi select if the user can choose one or more options.
 </SingleSelectField>
 ```
 
-By default the dropdown menu matches the input's width. When the input is
-sized to its content, this can make the menu too narrow to read longer options
-comfortably. `menuMinWidth` and `menuMaxWidth`, available on
-`SingleSelectField`/`SingleSelect`, `MultiSelectField`/`MultiSelect` and
-`SimpleSingleSelectField`/`SimpleSingleSelect`, let you decouple the menu
-width from the input:
+By default the dropdown menu matches the input's width. When the input is sized to its content, this can make the menu too narrow to read longer options comfortably. `menuMinWidth` and `menuMaxWidth`, available on `SingleSelectField`/`SingleSelect`, `MultiSelectField`/`MultiSelect` and `SimpleSingleSelectField`/`SimpleSingleSelect`, let you decouple the menu width from the input:
 
--   `menuMinWidth` — the menu grows to fit its content (`fit-content`) but is
-    never narrower than the greater of the input width and this value.
--   `menuMaxWidth` — caps how wide the menu may grow. Useful together with
-    `menuMinWidth` to stop very long option labels from making the menu
-    excessively wide. It never shrinks the menu below the input width, so a
-    `menuMaxWidth` smaller than the input has no visible effect.
+-   `menuMinWidth` — the menu grows to fit its content (`fit-content`) but is never narrower than the greater of the input width and this value.
+-   `menuMaxWidth` — caps how wide the menu may grow. Useful together with `menuMinWidth` to stop very long option labels from making the menu excessively wide. It never shrinks the menu below the input width, so a `menuMaxWidth` smaller than the input has no visible effect.
 
-Setting either prop switches the menu to `fit-content` sizing; setting neither
-keeps the original behavior (menu width equals input width).
+Setting either prop switches the menu to `fit-content` sizing; setting neither keeps the original behavior (menu width equals input width).
 
 :::note
-These props accept any absolute or font-relative CSS length, e.g. `'200px'` or
-`'20rem'`. **Percentages are not supported**: the menu is rendered in a portal,
-so a percentage would resolve against the viewport rather than the input.
+These props accept any absolute or font-relative CSS length, e.g. `'200px'` or `'20rem'`. **Percentages are not supported**: the menu is rendered in a portal, so a percentage would resolve against the viewport rather than the input.
 :::
 
-`SimpleSingleSelect` and `SimpleSingleSelectField` have no `inputWidth` prop —
-the select is sized by its container, and the menu uses that measured width:
-as its own width by default, and as the lower bound `menuMinWidth` is compared
-against.
+`SimpleSingleSelect` and `SimpleSingleSelectField` have no `inputWidth` prop — the select is sized by its container, and the menu uses that measured width: as its own width by default, and as the lower bound `menuMinWidth` is compared against.
 
 <Demo
     path="simple-single-select--with-menu-min-width"

--- a/docs/docs/components/select.md
+++ b/docs/docs/components/select.md
@@ -167,13 +167,16 @@ Use a multi select if the user can choose one or more options.
 By default the dropdown menu matches the input's width. When the input is
 sized to its content, this can make the menu too narrow to read longer options
 comfortably. `menuMinWidth` and `menuMaxWidth`, available on
-`SingleSelectField`/`SingleSelect` and `MultiSelectField`/`MultiSelect`, let you decouple the menu width from the input:
+`SingleSelectField`/`SingleSelect`, `MultiSelectField`/`MultiSelect` and
+`SimpleSingleSelectField`/`SimpleSingleSelect`, let you decouple the menu
+width from the input:
 
 -   `menuMinWidth` — the menu grows to fit its content (`fit-content`) but is
     never narrower than the greater of the input width and this value.
 -   `menuMaxWidth` — caps how wide the menu may grow. Useful together with
     `menuMinWidth` to stop very long option labels from making the menu
-    excessively wide.
+    excessively wide. It never shrinks the menu below the input width, so a
+    `menuMaxWidth` smaller than the input has no visible effect.
 
 Setting either prop switches the menu to `fit-content` sizing; setting neither
 keeps the original behavior (menu width equals input width).
@@ -183,6 +186,28 @@ These props accept any absolute or font-relative CSS length, e.g. `'200px'` or
 `'20rem'`. **Percentages are not supported**: the menu is rendered in a portal,
 so a percentage would resolve against the viewport rather than the input.
 :::
+
+`SimpleSingleSelect` and `SimpleSingleSelectField` have no `inputWidth` prop —
+the select is sized by its container, and the menu uses that measured width:
+as its own width by default, and as the lower bound `menuMinWidth` is compared
+against.
+
+<Demo
+    path="simple-single-select--with-menu-min-width"
+    height="200px"
+/>
+
+```jsx
+<div style={{ width: 120 }}>
+    <SimpleSingleSelect
+        name="visit-type"
+        options={options}
+        selected={selected}
+        onChange={setSelected}
+        menuMinWidth="240px"
+    />
+</div>
+```
 
 ## Options
 


### PR DESCRIPTION
Implements [LIBS-869](https://dhis2.atlassian.net/browse/LIBS-869)

---

### Description

[#1744](https://github.com/dhis2/ui/pull/1744) added `menuMinWidth`/`menuMaxWidth` to `SingleSelect` and `MultiSelect` for flexible, fit-content menu sizing. 

This PR adds the same props to `SimpleSingleSelect` and `SimpleSingleSelectField` for consistent behavior across all select variants.

---

### Known issues

With only menuMinWidth (no menuMaxWidth), the menu can grow without an upper bound for very long option labels; menuMinWidth and menuMaxWidth should be used together when labels can vary significantly in length.

---

### Checklist

-   [x] API docs are generated
-   [x] Tests were added
-   [x] Storybook demos were added

---

### Screenshots

`menuMaxWidth` is slightly greater than the width of the input, but less than the width of the options:
<img width="260" height="170" alt="Screenshot 2026-07-29 at 12 50 40" src="https://github.com/user-attachments/assets/49c7ddb3-bf54-4a8b-a1df-0945f7e6691a" />

with `menuMinWidth`:
<img width="346" height="188" alt="Screenshot 2026-07-29 at 12 51 06" src="https://github.com/user-attachments/assets/1eae9b6d-330b-4e4a-a3ab-37466469dddf" />


[LIBS-869]: https://dhis2.atlassian.net/browse/LIBS-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ