### PR TITLE
feat(switch): add aria-checked attribute

### DIFF
--- a/components/switch/src/switch/__tests__/switch.test.js
+++ b/components/switch/src/switch/__tests__/switch.test.js
@@ -41,4 +41,20 @@ describe('<Switch />', () => {
         )
         expect(screen.getAllByLabelText(ariaLabel)).toHaveLength(1)
     })
+
+    it('reflects the checked state through aria-checked', () => {
+        const { rerender } = render(
+            <Switch name="foo" value="bar" checked={false} />
+        )
+        expect(screen.getByRole('switch')).toHaveAttribute(
+            'aria-checked',
+            'false'
+        )
+
+        rerender(<Switch name="foo" value="bar" checked={true} />)
+        expect(screen.getByRole('switch')).toHaveAttribute(
+            'aria-checked',
+            'true'
+        )
+    })
 })

--- a/components/switch/src/switch/switch.js
+++ b/components/switch/src/switch/switch.js
@@ -88,6 +88,7 @@ class Switch extends Component {
             >
                 <input
                     aria-label={ariaLabel}
+                    aria-checked={checked}
                     type="checkbox"
                     role={role}
                     ref={this.ref}


### PR DESCRIPTION
Implements [LIBS-572](https://dhis2.atlassian.net/browse/LIBS-572), part of the library-wide accessibility effort tracked in #1447.

---

### Description

`Switch` renders `role="switch"` on its input but never sets `aria-checked`, which the [WAI-ARIA switch pattern](https://www.w3.org/WAI/ARIA/apg/patterns/switch/) requires to communicate toggle state to assistive technology. This mirrors the `aria-valuenow` fix already shipped for `Loader`'s `role="progressbar"` in the same effort (#1449).

No prop changes — `aria-checked` is derived from the existing `checked` prop, the same pattern `Loader` used for `aria-valuenow`/`amount`.

Was this change primarily generated using an AI tool? Yes — Claude Code, Claude Sonnet 5. 🤖 Used to identify the gap (cross-referencing the WAI-ARIA switch pattern and the merged Loader accessibility PR for precedent), and to draft/verify the fix and test below; I reviewed and understand the change.

---

### Known issues

- [x] None

---

### Checklist

- [x] API docs are generated (no prop change, `aria-checked` is derived from existing `checked`)
- [x] Tests were added
- [x] Storybook demos were added (no new prop/variant to demo — internal a11y attribute only)

---

### Screenshots

No visual change — `aria-checked` is a non-visual accessibility attribute.

[LIBS-572]: https://dhis2.atlassian.net/browse/LIBS-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ