### PR TITLE
fix(sharing-dialog): add keyboard navigation to autocomplete

### DIFF
--- a/components/sharing-dialog/src/autocomplete/autocomplete.js
+++ b/components/sharing-dialog/src/autocomplete/autocomplete.js
@@ -20,8 +20,22 @@ export const Autocomplete = ({
     searchResults,
 }) => {
     const wrapper = useRef(null)
+    const menuWrapper = useRef(null)
     const [menuWidth] = useSize(wrapper)
     const { isDisconnected: offline } = useDhis2ConnectionStatus()
+
+    const handleInputKeyDown = (_, event) => {
+        if (event.key !== 'ArrowDown') {
+            return
+        }
+
+        const menu = menuWrapper.current?.querySelector('[role="menu"]')
+
+        if (menu) {
+            event.preventDefault()
+            menu.focus()
+        }
+    }
 
     return (
         <>
@@ -31,6 +45,7 @@ export const Autocomplete = ({
                     loading={loading}
                     placeholder={placeholder}
                     onChange={({ value }) => onSearch(value)}
+                    onKeyDown={handleInputKeyDown}
                     value={search}
                     inputWidth={inputWidth}
                     disabled={offline}
@@ -44,16 +59,18 @@ export const Autocomplete = ({
                     menuRef={wrapper}
                     dataTest={`${dataTest}-menu`}
                 >
-                    <Menu>
-                        {searchResults.map((result) => (
-                            <MenuItem
-                                key={result.id}
-                                label={result.displayName}
-                                value={result.id}
-                                onClick={({ value }) => onSelect(value)}
-                            />
-                        ))}
-                    </Menu>
+                    <div ref={menuWrapper}>
+                        <Menu>
+                            {searchResults.map((result) => (
+                                <MenuItem
+                                    key={result.id}
+                                    label={result.displayName}
+                                    value={result.id}
+                                    onClick={({ value }) => onSelect(value)}
+                                />
+                            ))}
+                        </Menu>
+                    </div>
                 </MenuPopup>
             )}
         </>

--- a/components/sharing-dialog/src/autocomplete/sharing-autocomplete.test.js
+++ b/components/sharing-dialog/src/autocomplete/sharing-autocomplete.test.js
@@ -21,6 +21,47 @@ const Wrapper = () => {
 }
 
 describe('SharingAutocomplete', () => {
+    it('supports keyboard navigation and selection from the search input', async () => {
+        const userDisplayName = 'Some User'
+        const dataProviderData = {
+            'sharing/search': jest.fn(() => ({
+                users: [
+                    {
+                        id: 'user-1',
+                        displayName: userDisplayName,
+                    },
+                    {
+                        id: 'user-2',
+                        displayName: 'Someone Else',
+                    },
+                ],
+            })),
+        }
+        render(
+            <CustomDataProvider data={dataProviderData}>
+                <Wrapper />
+            </CustomDataProvider>
+        )
+
+        await userEvent.type(screen.getByRole('textbox'), 'Som')
+        const [firstResult, secondResult] = await screen.findAllByRole(
+            'menuitem'
+        )
+
+        expect(screen.getByRole('textbox')).toHaveFocus()
+        await userEvent.keyboard('{ArrowDown}')
+        expect(firstResult.parentElement).toHaveFocus()
+
+        await userEvent.keyboard('{ArrowDown}')
+        expect(secondResult.parentElement).toHaveFocus()
+
+        await userEvent.keyboard('{ArrowUp}')
+        expect(firstResult.parentElement).toHaveFocus()
+
+        await userEvent.keyboard('{Enter}')
+        expect(screen.getByRole('textbox')).toHaveValue(userDisplayName)
+    })
+
     it('hides autocompletion results after selection', async () => {
         const userDisplayName = 'Some User'
         const dataProviderData = {


### PR DESCRIPTION
## Summary

- allow `ArrowDown` from the SharingDialog autocomplete input to move focus into the results menu
- reuse the menu's existing arrow-key navigation and Enter selection behavior
- add regression coverage for moving into the menu, navigating down/up, and selecting a result

## Why

The **User or group** autocomplete exposes matching results visually, but keyboard users cannot move focus from the search input into those results. This change provides that missing entry point without replacing the menu's existing keyboard behavior.

Keyboard sequence covered by the test: `ArrowDown` → `ArrowDown` → `ArrowUp` → `Enter`.

## Verification

- SharingDialog tests: 6 suites passed, 40 tests passed, 7 snapshots passed
- package build completed successfully
- changed files pass the repository's ESLint and Prettier checks
- `git diff --check` is clean

Jira: [LIBS-571](https://dhis2.atlassian.net/browse/LIBS-571)

Related to #1447

[LIBS-571]: https://dhis2.atlassian.net/browse/LIBS-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ